### PR TITLE
Refactoring jsh-specific fifty APIs into fifty.jsh

### DIFF
--- a/contributor/jrunscript.fifty.ts
+++ b/contributor/jrunscript.fifty.ts
@@ -14,7 +14,7 @@
 			var hasJsoup = Boolean(jsh.shell.tools.jsoup.installed);
 			var hasGit = Boolean(jsh.shell.PATH.getCommand("git"));
 			var isGitClone = (function() {
-				var SLIME = fifty.$loader.getRelativePath("..").directory;
+				var SLIME = fifty.jsh.file.object.getRelativePath("..").directory;
 				return Boolean(SLIME.getSubdirectory(".git") || SLIME.getFile(".git"));
 			})();
 			var isMkcertImplemented = (function() {

--- a/jrunscript/tools/install/module.fifty.ts
+++ b/jrunscript/tools/install/module.fifty.ts
@@ -575,7 +575,7 @@ namespace slime.jrunscript.tools.install {
 						}
 					};
 
-					var mockdownloads = fifty.jsh.file.directory();
+					var mockdownloads = fifty.jsh.file.object.temporary.directory();
 					var mockclient = new jsh.http.Client({
 						proxy: PROXY
 					});

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -208,7 +208,7 @@ namespace slime.time {
 	(
 		function(
 			fifty: slime.fifty.test.kit,
-			$loader: slime.fifty.test.$loader,
+			$loader: slime.Loader,
 			verify: slime.fifty.test.verify,
 			tests: slime.fifty.test.tests
 		) {

--- a/jsh/loader/jsh.fifty.ts
+++ b/jsh/loader/jsh.fifty.ts
@@ -48,16 +48,16 @@ namespace slime.jsh {
 				type pathsFileExports = { value: string }
 
 				tests.exports.module = function() {
-					var byFullPathname: exports = jsh.loader.module(fifty.$loader.getRelativePath("test/code/module.js"));
+					var byFullPathname: exports = jsh.loader.module(fifty.jsh.file.object.getRelativePath("test/code/module.js"));
 					verify(byFullPathname).foo.is("bar");
 
-					var byModulePathname: exports = jsh.loader.module(fifty.$loader.getRelativePath("test/code"));
+					var byModulePathname: exports = jsh.loader.module(fifty.jsh.file.object.getRelativePath("test/code"));
 					verify(byModulePathname).foo.is("bar");
 
-					var byModuleFile: exports = jsh.loader.module(fifty.$loader.getRelativePath("test/code/module.js").file);
+					var byModuleFile: exports = jsh.loader.module(fifty.jsh.file.object.getRelativePath("test/code/module.js").file);
 					verify(byModuleFile).foo.is("bar");
 
-					var byModuleDirectory: exports = jsh.loader.module(fifty.$loader.getRelativePath("test/code").directory);
+					var byModuleDirectory: exports = jsh.loader.module(fifty.jsh.file.object.getRelativePath("test/code").directory);
 					verify(byModuleDirectory).foo.is("bar");
 
 					var paths: {
@@ -78,7 +78,7 @@ namespace slime.jsh {
 					} = (function() {
 						var result = jsh.shell.jsh({
 							shell: jsh.shell.jsh.src,
-							script: fifty.$loader.getRelativePath("test/jsh-loader-code/main.jsh.js").file,
+							script: fifty.jsh.file.object.getRelativePath("test/jsh-loader-code/main.jsh.js").file,
 							stdio: {
 								output: String
 							}

--- a/jsh/script/plugin.jsh.fifty.ts
+++ b/jsh/script/plugin.jsh.fifty.ts
@@ -240,7 +240,7 @@ namespace slime.jsh.script {
 					const $api = fifty.$api;
 					var result: { status: number } = fifty.global.jsh.shell.jsh({
 						shell: fifty.global.jsh.shell.jsh.src,
-						script: fifty.$loader.getRelativePath("test/cli.jsh.js").file,
+						script: fifty.jsh.file.object.getRelativePath("test/cli.jsh.js").file,
 						arguments: ["status"],
 						evaluate: $api.Function.identity
 					});
@@ -248,7 +248,7 @@ namespace slime.jsh.script {
 
 					result = fifty.global.jsh.shell.jsh({
 						shell: fifty.global.jsh.shell.jsh.src,
-						script: fifty.$loader.getRelativePath("test/cli.jsh.js").file,
+						script: fifty.jsh.file.object.getRelativePath("test/cli.jsh.js").file,
 						arguments: ["status", "42"],
 						evaluate: $api.Function.identity
 					});
@@ -256,7 +256,7 @@ namespace slime.jsh.script {
 
 					result = fifty.global.jsh.shell.jsh({
 						shell: fifty.global.jsh.shell.jsh.src,
-						script: fifty.$loader.getRelativePath("test/cli.jsh.js").file,
+						script: fifty.jsh.file.object.getRelativePath("test/cli.jsh.js").file,
 						arguments: [],
 						evaluate: $api.Function.identity
 					});

--- a/jsh/script/plugin.jsh.fifty.ts
+++ b/jsh/script/plugin.jsh.fifty.ts
@@ -176,7 +176,7 @@ namespace slime.jsh.script {
 						subject.cli.option.string({ longname: "foo" })
 					);
 					var was = fifty.global.jsh.unit.$slime;
-					var mocked = fifty.$loader.jsh.plugin.mock({
+					var mocked = fifty.jsh.plugin.mock({
 						jsh: fifty.global.jsh,
 						$slime: Object.assign({}, was, {
 							getPackaged: function() { return null; },

--- a/jsh/unit/html.js
+++ b/jsh/unit/html.js
@@ -206,7 +206,8 @@
 			};
 
 			var Loader = function(suite) {
-				var delegate = new jsh.file.Loader({ directory: suite.getRelativePath(".").directory });
+				var directory = suite.getRelativePath(".").directory;
+				var delegate = new jsh.file.Loader({ directory: directory });
 
 				delegate.eval = function(name,scope) {
 					var code = this.get(name).read(String);
@@ -317,28 +318,14 @@
 						}
 					})(p.path);
 
-					/** @type { mockjshplugin } */
-					var mockPlugin = function(p) {
-						return jsh.$fifty.plugin.mock(
-							$api.Object.compose(
-								p,
-								{ $loader: delegate }
-							)
-						);
-					};
-
-					var toFiftyLoader = function(loader) {
-						return Object.assign(loader, {
-							jsh: {
-								plugin: {
-									mock: mockPlugin
-								}
-							}
-						})
-					};
-
 					var promise = run(
-						(path.folder) ? toFiftyLoader(delegate.Child(path.folder)) : toFiftyLoader(delegate),
+						(path.folder) ? delegate.Child(path.folder) : delegate,
+						{
+							jsh: {
+								loader: (path.folder) ? delegate.Child(path.folder) : delegate,
+								directory: (path.folder) ? directory.getSubdirectory(path.folder) : directory
+							}
+						},
 						path.file
 					);
 

--- a/loader/browser/test/api.js
+++ b/loader/browser/test/api.js
@@ -290,6 +290,7 @@
 
 						run(
 							(path.folder) ? delegate.Child(path.folder) : delegate,
+							{},
 							path.file
 						).then(function(result) {
 							p.verify(result,"Fifty " + p.path + " result").is(true);

--- a/loader/expression.fifty.ts
+++ b/loader/expression.fifty.ts
@@ -625,7 +625,7 @@ namespace slime.test {
 
 (
 	function(
-		$loader: slime.fifty.test.$loader,
+		$loader: slime.Loader,
 		verify: slime.fifty.test.verify,
 		tests: any,
 		fifty: slime.fifty.test.kit

--- a/loader/jrunscript/expression.fifty.ts
+++ b/loader/jrunscript/expression.fifty.ts
@@ -733,7 +733,7 @@ namespace slime.jrunscript {
 		fifty: slime.fifty.test.kit,
 		$slime: slime.jrunscript.runtime.Exports,
 		$api: slime.$api.Global,
-		$loader: slime.fifty.test.$loader,
+		$loader: slime.Loader,
 		verify: slime.fifty.test.verify,
 		tests: slime.fifty.test.tests,
 		run: slime.fifty.test.kit["run"]

--- a/loader/node/loader.fifty.ts
+++ b/loader/node/loader.fifty.ts
@@ -25,7 +25,7 @@ namespace slime.node {
 			fifty.tests.suite = function() {
 				fifty.global.jsh.shell.world.run(
 					fifty.global.jsh.shell.Invocation.create({
-						command: fifty.$loader.getRelativePath("test/main.bash"),
+						command: fifty.jsh.file.object.getRelativePath("test/main.bash"),
 						stdio: {
 							output: "string"
 						}

--- a/rhino/file/java.fifty.ts
+++ b/rhino/file/java.fifty.ts
@@ -117,7 +117,7 @@ namespace slime.jrunscript.file.internal.java {
 			fifty.tests.sandbox = function() {
 				var _fs = Packages.inonit.script.runtime.io.Filesystem.create();
 				var createNode = subject.test.nodeCreator(_fs);
-				var thisFile = fifty.$loader.getRelativePath("java.fifty.ts");
+				var thisFile = fifty.jsh.file.object.getRelativePath("java.fifty.ts");
 
 				var thisNode = createNode(thisFile.toString());
 				verify(thisNode).exists().is(true);

--- a/rhino/file/module-Loader.fifty.ts
+++ b/rhino/file/module-Loader.fifty.ts
@@ -38,7 +38,7 @@ namespace slime.jrunscript.file {
 
 			const { module } = fixtures;
 
-			const loader = new fixtures.module.Loader({ directory: fifty.$loader.getRelativePath("api.html").parent.directory })
+			const loader = new fixtures.module.Loader({ directory: fifty.jsh.file.object.getRelativePath("api.html").parent.directory })
 
 			fifty.tests.suite = function() {
 				run(function() {

--- a/rhino/file/module-Searchpath.fifty.ts
+++ b/rhino/file/module-Searchpath.fifty.ts
@@ -170,7 +170,7 @@ namespace slime.jrunscript.file {
 
 			fifty.tests.world = function() {
 				var searchpath = jsh.file.Searchpath([
-					fifty.$loader.getRelativePath(".")
+					fifty.jsh.file.object.getRelativePath(".")
 				]);
 				jsh.shell.console(searchpath.toString());
 				jsh.shell.console(String(searchpath.pathnames.length));

--- a/rhino/file/module.fifty.ts
+++ b/rhino/file/module.fifty.ts
@@ -178,7 +178,7 @@ namespace slime.jrunscript.file {
 			fifty.tests.state.list = function() {
 				var subject = fifty.global.jsh.file;
 
-				var prefix = fifty.$loader.getRelativePath(".").toString();
+				var prefix = fifty.jsh.file.object.getRelativePath(".").toString();
 				var lister = subject.state.list(prefix);
 				var listing = lister().sort(function(a,b) {
 					if (a.relative < b.relative) return -1;
@@ -316,7 +316,7 @@ namespace slime.jrunscript.file {
 			fifty.tests.action.delete = function() {
 				var subject = fifty.global.jsh.file;
 
-				var dir = fifty.jsh.file.directory();
+				var dir = fifty.jsh.file.object.temporary.directory();
 				dir.getRelativePath("file").write("foo", { append: false });
 				fifty.verify(dir).getFile("file").is.type("object");
 				var d2 = subject.action.delete(dir.getRelativePath("file").toString());
@@ -455,7 +455,7 @@ namespace slime.jrunscript.file {
 				const filesystem = world.filesystems.os;
 
 				fifty.tests.sandbox.filesystem.pathname.relative = function() {
-					var parent = filesystem.pathname(fifty.$loader.getRelativePath(".").toString());
+					var parent = filesystem.pathname(fifty.jsh.file.object.getRelativePath(".").toString());
 					var relative = "module.fifty.ts";
 					var result = parent.relative(relative);
 					verify(result).is.type("object");
@@ -629,7 +629,7 @@ namespace slime.jrunscript.file {
 			) {
 				const { verify } = fifty;
 				const { jsh } = fifty.global;
-				const here = jsh.file.world.filesystems.os.pathname(fifty.$loader.getRelativePath(".").toString());
+				const here = jsh.file.world.filesystems.os.pathname(fifty.jsh.file.object.getRelativePath(".").toString());
 
 				fifty.tests.sandbox.filesystem.pathname.file.read = {};
 				fifty.tests.sandbox.filesystem.pathname.file.read.string = function() {
@@ -726,14 +726,14 @@ namespace slime.jrunscript.file {
 				fifty.tests.sandbox.filesystem.Pathname = {
 					relative: function() {
 						//	TODO	the below tests may have been in the wrong place
-						var pathname = function(relative: string) { return fifty.$loader.getRelativePath(relative).toString(); };
+						var pathname = function(relative: string) { return fifty.jsh.file.object.getRelativePath(relative).toString(); };
 						var thisFile = pathname("module.fifty.ts");
 						var doesNotExist = pathname("foo");
 						verify(filesystem.File.read.string(thisFile)(), "thisFile").is.type("string");
 						verify(filesystem.File.read.string(doesNotExist)()).is.type("null");
 					},
 					isDirectory: function() {
-						var parent = fifty.$loader.getRelativePath(".").toString();
+						var parent = fifty.jsh.file.object.getRelativePath(".").toString();
 						var cases = {
 							parent: parent,
 							thisFile: filesystem.Pathname.relative(parent, "module.fifty.ts"),
@@ -751,7 +751,7 @@ namespace slime.jrunscript.file {
 					}
 				};
 
-				var here = fifty.$loader.getRelativePath(".").toString();
+				var here = fifty.jsh.file.object.getRelativePath(".").toString();
 
 				fifty.tests.sandbox.filesystem.File = {};
 
@@ -886,10 +886,10 @@ namespace slime.jrunscript.file {
 			const { world } = jsh.file;
 
 			fifty.tests.world = function() {
-				var pathname = fifty.$loader.getRelativePath("module.fifty.ts").toString();
+				var pathname = fifty.jsh.file.object.getRelativePath("module.fifty.ts").toString();
 				jsh.shell.console(world.filesystems.os.File.read.string(pathname)().substring(0,500));
 
-				var folder = fifty.$loader.getRelativePath(".").toString();
+				var folder = fifty.jsh.file.object.getRelativePath(".").toString();
 				var file = "module.fifty.ts";
 				var relative = world.filesystems.os.Pathname.relative(folder, file);
 				jsh.shell.console(relative);

--- a/rhino/http/servlet/plugin.jsh.resources.fifty.ts
+++ b/rhino/http/servlet/plugin.jsh.resources.fifty.ts
@@ -80,7 +80,7 @@ namespace slime.jsh.httpd {
 			fifty.tests.script = {
 				old: function() {
 					var one: { loader: slime.Loader } = api.script.old(
-						fifty.$loader.getRelativePath("test/resource/1.old.js").file
+						fifty.jsh.file.object.getRelativePath("test/resource/1.old.js").file
 					);
 					var indexOf = function(value: string) {
 						return function(p: (slime.loader.LoaderEntry | slime.loader.ResourceEntry)[]) {
@@ -112,7 +112,7 @@ namespace slime.jsh.httpd {
 					var code = api;
 					verify(code,"code").is.type("function");
 					var one: { loader: slime.Loader, add: any } = new code();
-					var top = fifty.$loader.getRelativePath(".").directory;
+					var top = fifty.jsh.file.object.getRelativePath(".").directory;
 					one.add({ prefix: "WEB-INF/generic/", directory: top.getSubdirectory("java") });
 					one.add({ prefix: "WEB-INF/mozilla/", directory: top.getSubdirectory("rhino") });
 					one.add({ prefix: "WEB-INF/test/", directory: top.getSubdirectory("test") });
@@ -162,7 +162,7 @@ namespace slime.jsh.httpd {
 				hg: function() {
 					var verify = fifty.verify;
 					var jsh = fifty.global.jsh;
-					var mapping: { loader: slime.Loader, build: any } = api.script(fifty.$loader.getRelativePath("test/resource/1.hg.js").file);
+					var mapping: { loader: slime.Loader, build: any } = api.script(fifty.jsh.file.object.getRelativePath("test/resource/1.hg.js").file);
 					verify(mapping).is.not(null);
 					verify(mapping).loader.is.not(null);
 					verify(mapping).loader.evaluate.property("list").is.type("function");

--- a/rhino/jrunscript/api.fifty.ts
+++ b/rhino/jrunscript/api.fifty.ts
@@ -155,7 +155,7 @@ namespace slime.internal.jrunscript.bootstrap {
 				};
 				fifty.$loader.run("api.js", {}, configuration);
 				var global: slime.internal.jrunscript.bootstrap.Global<{},{}> = configuration as slime.internal.jrunscript.bootstrap.Global<{},{}>;
-				var thisPathname = fifty.$loader.getRelativePath("api.fifty.ts");
+				var thisPathname = fifty.jsh.file.object.getRelativePath("api.fifty.ts");
 				var jshReadThisFile = thisPathname.file.read(String);
 				var bootstrapReadThisFile = (function() {
 					var javaFile = thisPathname.java.adapt();
@@ -208,7 +208,7 @@ namespace slime.internal.jrunscript.bootstrap {
 				}
 				var resource = new jsh.io.Resource(descriptor);
 				var fromZip = resource.read(String);
-				var fromFilesystem = fifty.$loader.getRelativePath("api.fifty.ts").file.read(String);
+				var fromFilesystem = fifty.jsh.file.object.getRelativePath("api.fifty.ts").file.read(String);
 				var filesAreEqual = fromZip == fromFilesystem
 				verify(filesAreEqual,"filesAreEqual").is(true);
 

--- a/rhino/shell/module.fifty.ts
+++ b/rhino/shell/module.fifty.ts
@@ -277,7 +277,7 @@ namespace slime.jrunscript.shell {
 				var to = jsh.shell.TMPDIR.createTemporary({ directory: true });
 				jsh.java.tools.javac({
 					destination: to.pathname,
-					arguments: [fifty.$loader.getRelativePath("test/java/inonit/jsh/test/" + name + ".java")]
+					arguments: [fifty.jsh.file.object.getRelativePath("test/java/inonit/jsh/test/" + name + ".java")]
 				});
 				return {
 					classpath: jsh.file.Searchpath([to.pathname]),
@@ -288,7 +288,7 @@ namespace slime.jrunscript.shell {
 			fifty.tests.run = function() {
 				var subject: Exports = fifty.global.jsh.shell;
 
-				var here: slime.jrunscript.file.Directory = fifty.$loader.getRelativePath(".").directory;
+				var here: slime.jrunscript.file.Directory = fifty.jsh.file.object.getRelativePath(".").directory;
 
 				var on = {
 					start: void(0)
@@ -378,7 +378,7 @@ namespace slime.jrunscript.shell {
 				var to = jsh.shell.TMPDIR.createTemporary({ directory: true });
 				jsh.java.tools.javac({
 					destination: to.pathname,
-					arguments: [fifty.$loader.getRelativePath("test/java/inonit/jsh/test/Echo.java")]
+					arguments: [fifty.jsh.file.object.getRelativePath("test/java/inonit/jsh/test/Echo.java")]
 				});
 				var result = module.java({
 					classpath: jsh.file.Searchpath([to.pathname]),
@@ -520,7 +520,7 @@ namespace slime.jrunscript.shell {
 				var to = jsh.shell.TMPDIR.createTemporary({ directory: true });
 				jsh.java.tools.javac({
 					destination: to.pathname,
-					arguments: [fifty.$loader.getRelativePath("test/java/inonit/jsh/test/Program.java")]
+					arguments: [fifty.jsh.file.object.getRelativePath("test/java/inonit/jsh/test/Program.java")]
 				});
 				var buffer = new jsh.io.Buffer();
 				var output = subject.java({
@@ -667,7 +667,7 @@ namespace slime.jrunscript.shell {
 			const subject = fifty.global.jsh.shell;
 
 			fifty.tests.world = function() {
-				var directory = fifty.$loader.getRelativePath(".").directory;
+				var directory = fifty.jsh.file.object.getRelativePath(".").directory;
 
 				if (fifty.global.jsh.shell.PATH.getCommand("ls")) {
 					var ls = subject.Invocation.create({
@@ -731,7 +731,7 @@ namespace slime.jrunscript.shell {
 					fifty.verify(tell).evaluate(function(f) { return f(); }).threw.name.is("JavaException");
 				})();
 
-				var directory = fifty.$loader.getRelativePath(".").directory;
+				var directory = fifty.jsh.file.object.getRelativePath(".").directory;
 
 				if (fifty.global.jsh.shell.PATH.getCommand("ls")) {
 					var ls = subject.Invocation.create({
@@ -807,7 +807,7 @@ namespace slime.jrunscript.shell {
 				}
 
 				fifty.run(function Invocation() {
-					var directory = fifty.$loader.getRelativePath(".").directory;
+					var directory = fifty.jsh.file.object.getRelativePath(".").directory;
 
 					//	TODO	test for missing command
 

--- a/rhino/shell/run.fifty.ts
+++ b/rhino/shell/run.fifty.ts
@@ -175,7 +175,7 @@ namespace slime.jrunscript.shell.internal.run {
 				var tell = subject.run({
 					context: {
 						environment: fifty.global.jsh.shell.environment,
-						directory: fifty.$loader.getRelativePath(".").directory,
+						directory: fifty.jsh.file.object.getRelativePath(".").directory,
 						stdio: {
 							input: null,
 							output: "string",

--- a/rhino/tools/db/jdbc/mysql/module.fifty.ts
+++ b/rhino/tools/db/jdbc/mysql/module.fifty.ts
@@ -109,7 +109,7 @@ namespace slime.jrunscript.db.mysql {
 			var verify = fifty.verify;
 			fifty.tests.suite = function() {
 				//	TODO	fifty.jsh.file is undocumented
-				var tmp = fifty.jsh.file.location();
+				var tmp = fifty.jsh.file.object.temporary.location();
 				var port = jsh.ip.getEphemeralPort();
 				var installed = jsh.db.jdbc.mysql.install({
 					to: tmp

--- a/rhino/tools/git/module.fifty.ts
+++ b/rhino/tools/git/module.fifty.ts
@@ -356,7 +356,7 @@ namespace slime.jrunscript.tools.git {
 				};
 
 				fifty.run(function worksWhenCreatingDirectory() {
-					var location = fifty.jsh.file.location();
+					var location = fifty.jsh.file.object.temporary.location();
 					verify(location).directory.is(null);
 					var createdLocation = internal.subject.init({
 						pathname: location
@@ -367,7 +367,7 @@ namespace slime.jrunscript.tools.git {
 
 				fifty.run(function worksWithEmptyDirectory() {
 					const $api = fifty.$api;
-					var directory = fifty.jsh.file.directory();
+					var directory = fifty.jsh.file.object.temporary.directory();
 
 					fixture.write({
 						directory: directory,
@@ -472,7 +472,7 @@ namespace slime.jrunscript.tools.git {
 				fifty.tests.types.Repository.Local.config = function() {
 					fifty.run(function old() {
 						var empty = internal.subject.init({
-							pathname: fifty.jsh.file.location()
+							pathname: fifty.jsh.file.object.temporary.location()
 						});
 						var old = empty.config({
 							arguments: ["--list", "--local"]
@@ -493,7 +493,7 @@ namespace slime.jrunscript.tools.git {
 
 					fifty.run(function list() {
 						var empty = internal.subject.init({
-							pathname: fifty.jsh.file.location()
+							pathname: fifty.jsh.file.object.temporary.location()
 						});
 						var local = empty.config({
 							list: {
@@ -523,7 +523,7 @@ namespace slime.jrunscript.tools.git {
 						}
 
 						var empty = internal.subject.init({
-							pathname: fifty.jsh.file.location()
+							pathname: fifty.jsh.file.object.temporary.location()
 						});
 						fifty.verify(empty).evaluate(getConfigObject).evaluate.property("foo.bar").is(void(0));
 
@@ -563,7 +563,7 @@ namespace slime.jrunscript.tools.git {
 				var verify = fifty.verify;
 
 				fifty.tests.types.Repository.Local.status = function() {
-					var at = fifty.jsh.file.location();
+					var at = fifty.jsh.file.object.temporary.location();
 					var repository = internal.fixtures.init({ pathname: at });
 					debugger;
 					var status = repository.status();
@@ -634,7 +634,7 @@ namespace slime.jrunscript.tools.git {
 
 		fifty.tests.submoduleTrackingBranch = function() {
 			function initialize() {
-				var tmpdir = fifty.jsh.file.directory();
+				var tmpdir = fifty.jsh.file.object.temporary.directory();
 
 				var library = internal.subject.init({ pathname: tmpdir.getRelativePath("sub") });
 				configure(library);
@@ -667,7 +667,7 @@ namespace slime.jrunscript.tools.git {
 		}
 
 		fifty.tests.submoduleWithDifferentNameAndPath = function() {
-			var tmpdir = fifty.jsh.file.directory();
+			var tmpdir = fifty.jsh.file.object.temporary.directory();
 			var sub = internal.subject.init({ pathname: tmpdir.getRelativePath("sub") });
 			configure(sub);
 			commitFile(sub, "b");
@@ -688,7 +688,7 @@ namespace slime.jrunscript.tools.git {
 		};
 
 		fifty.tests.submoduleStatusCached = function() {
-			var tmpdir = fifty.jsh.file.directory();
+			var tmpdir = fifty.jsh.file.object.temporary.directory();
 
 			var library = internal.subject.init({ pathname: tmpdir.getRelativePath("sub") });
 			configure(library);
@@ -1069,7 +1069,7 @@ namespace slime.jrunscript.tools.git {
 
 			fifty.tests.Client = {};
 			fifty.tests.Client.invocation = function() {
-				var fakeCommand = fifty.$loader.getRelativePath("git");
+				var fakeCommand = fifty.jsh.file.object.getRelativePath("git");
 				var client = {
 					command: fakeCommand
 				};
@@ -1112,13 +1112,13 @@ namespace slime.jrunscript.tools.git {
 			};
 
 			fifty.tests.sandbox = function() {
-				var SLIME = fifty.$loader.getRelativePath("../../..").directory;
+				var SLIME = fifty.jsh.file.object.getRelativePath("../../..").directory;
 				if (!SLIME.getFile(".git") || !SLIME.getSubdirectory(".git")) {
 					//	This test will not work on an export or other format without git metadata
 					return;
 				}
 				var base = fifty.global.jsh.tools.git.local({
-					start: fifty.$loader.getRelativePath(".").directory,
+					start: fifty.jsh.file.object.getRelativePath(".").directory,
 					match: api.github.isProjectUrl({ owner: "davidpcaldwell", name: "slime" })
 				});
 				fifty.verify(base.toString()).is(SLIME.toString());

--- a/tools/fifty/module.fifty.ts
+++ b/tools/fifty/module.fifty.ts
@@ -61,9 +61,6 @@ namespace slime.fifty {
 		export type verify = slime.definition.verify.Verify
 
 		export type $loader = slime.Loader & {
-			//	will return a Pathname in jsh; does not currently exist in browser
-			getRelativePath?: (p: string) => any
-
 			/**
 			 * Present if Fifty is being run in a `jsh` shell; provides the ability to load `jsh` plugins into a mock shell.
 			 */
@@ -155,8 +152,13 @@ namespace slime.fifty {
 			jsh?: {
 				$slime: jsh.plugin.$slime
 				file: {
-					location: () => slime.jrunscript.file.Pathname
-					directory: () => slime.jrunscript.file.Directory
+					object: {
+						getRelativePath: (p: string) => any
+						temporary: {
+							location: () => slime.jrunscript.file.Pathname
+							directory: () => slime.jrunscript.file.Directory
+						}
+					}
 				}
 			}
 		}

--- a/tools/fifty/module.fifty.ts
+++ b/tools/fifty/module.fifty.ts
@@ -60,28 +60,6 @@ namespace slime.fifty {
 	export namespace test {
 		export type verify = slime.definition.verify.Verify
 
-		export type $loader = slime.Loader & {
-			/**
-			 * Present if Fifty is being run in a `jsh` shell; provides the ability to load `jsh` plugins into a mock shell.
-			 */
-			jsh?: {
-				plugin: {
-					/**
-					 * Allows a test to load `jsh` plugins into a mock shell. Loads plugins from the same directory as the
-					 * shell, optionally specifying the global object, `jsh`, and the shared `plugins` object used by the jsh plugin
-					 * loader.
-					 */
-					mock: (p: {
-						global?: { [x: string]: any }
-						jsh?: { [x: string]: any }
-						plugins?: { [x: string]: any }
-						$slime?: slime.jsh.plugin.$slime
-					}) => ReturnType<slime.jsh.loader.internal.plugins.Export["mock"]>
-				},
-				$slime: jsh.plugin.$slime
-			}
-		}
-
 		export type tests = any
 
 		/**
@@ -113,7 +91,7 @@ namespace slime.fifty {
 			 * A function that can be used to create subjects and make assertions about them. See {@link slime.definition.verify.Verify}.
 			 */
 			verify: verify
-			$loader: $loader
+			$loader: slime.Loader
 			run: (f: () => void, name?: string) => void
 
 			test: {
@@ -159,6 +137,19 @@ namespace slime.fifty {
 							directory: () => slime.jrunscript.file.Directory
 						}
 					}
+				}
+				plugin: {
+					/**
+					 * Allows a test to load `jsh` plugins into a mock shell. Loads plugins from the same directory as the
+					 * shell, optionally specifying the global object, `jsh`, and the shared `plugins` object used by the jsh plugin
+					 * loader.
+					 */
+					mock: (p: {
+						global?: { [x: string]: any }
+						jsh?: { [x: string]: any }
+						plugins?: { [x: string]: any }
+						$slime?: slime.jsh.plugin.$slime
+					}) => ReturnType<slime.jsh.loader.internal.plugins.Export["mock"]>
 				}
 			}
 		}

--- a/tools/fifty/scope-jsh.ts
+++ b/tools/fifty/scope-jsh.ts
@@ -5,21 +5,37 @@
 //	END LICENSE
 
 (
-	function(jsh: slime.jsh.Global, $export: (value: slime.fifty.test.kit["jsh"]) => void) {
-		$export({
-			file: {
-				location: function() {
-					var directory = jsh.shell.TMPDIR.createTemporary({ directory: true });
-					var rv = directory.pathname;
-					directory.remove();
-					return rv;
-				},
-				directory: function() {
-					return jsh.shell.TMPDIR.createTemporary({ directory: true }) as slime.jrunscript.file.Directory;
-				}
+	function(jsh: slime.jsh.Global, $export: (value: (scope: { directory: slime.jrunscript.file.Directory }) => slime.fifty.test.kit["jsh"]) => void) {
+		var tmp = {
+			location: function() {
+				var directory = jsh.shell.TMPDIR.createTemporary({ directory: true });
+				var rv = directory.pathname;
+				directory.remove();
+				return rv;
 			},
-			$slime: jsh.unit.$slime
-		})
+			directory: function() {
+				return jsh.shell.TMPDIR.createTemporary({ directory: true }) as slime.jrunscript.file.Directory;
+			}
+		};
+
+		$export(
+			function(scope) {
+				return {
+					file: {
+						object: {
+							temporary: {
+								location: tmp.location,
+								directory: tmp.directory
+							},
+							getRelativePath: function(path) {
+								return scope.directory.getRelativePath(path);
+							}
+						}
+					},
+					$slime: jsh.unit.$slime
+				}
+			}
+		);
 	}
 //@ts-ignore
 )(jsh, $export)

--- a/tools/fifty/scope-jsh.ts
+++ b/tools/fifty/scope-jsh.ts
@@ -4,8 +4,19 @@
 //
 //	END LICENSE
 
+namespace slime.fifty.test.internal.scope.jsh {
+	export interface Scope {
+		loader: slime.Loader
+		directory: slime.jrunscript.file.Directory
+	}
+
+	export type Export = (scope: slime.fifty.test.internal.scope.jsh.Scope) => slime.fifty.test.kit["jsh"]
+
+	export type Script = slime.loader.Script<void,Export>
+}
+
 (
-	function(jsh: slime.jsh.Global, $export: (value: (scope: { directory: slime.jrunscript.file.Directory }) => slime.fifty.test.kit["jsh"]) => void) {
+	function($api: slime.$api.Global, jsh: slime.jsh.Global, $export: slime.loader.Export<slime.fifty.test.internal.scope.jsh.Export>) {
 		var tmp = {
 			location: function() {
 				var directory = jsh.shell.TMPDIR.createTemporary({ directory: true });
@@ -32,10 +43,20 @@
 							}
 						}
 					},
+					plugin: {
+						mock: function(p) {
+							return jsh.$fifty.plugin.mock(
+								$api.Object.compose(
+									p,
+									{ $loader: scope.loader }
+								)
+							)
+						}
+					},
 					$slime: jsh.unit.$slime
 				}
 			}
 		);
 	}
 //@ts-ignore
-)(jsh, $export)
+)($api, jsh, $export)

--- a/tools/fifty/test-browser.js
+++ b/tools/fifty/test-browser.js
@@ -186,6 +186,7 @@
 
 				return implementation(
 					loader,
+					{},
 					path.file,
 					part
 				);

--- a/tools/fifty/test.fifty.ts
+++ b/tools/fifty/test.fifty.ts
@@ -21,11 +21,12 @@ namespace slime.fifty.test.internal {
 
 namespace slime.fifty.test.internal.test {
 	export interface Context {
-		promises: slime.definition.test.promises.Export
 		library: {
 			Verify: slime.definition.verify.Export
 		}
 		console: slime.fifty.test.internal.Console
+
+		promises?: slime.definition.test.promises.Export
 	}
 
 	export type Result = {
@@ -58,6 +59,11 @@ namespace slime.fifty.test.internal.test {
 	export type Export = (
 		/** A loader. */
 		loader: slime.fifty.test.$loader,
+		scopes: {
+			jsh?: {
+				directory: slime.jrunscript.file.Directory
+			}
+		},
 		path: string,
 		part?: string
 	) => Result

--- a/tools/fifty/test.fifty.ts
+++ b/tools/fifty/test.fifty.ts
@@ -58,10 +58,11 @@ namespace slime.fifty.test.internal.test {
 	 */
 	export type Export = (
 		/** A loader. */
-		loader: slime.fifty.test.$loader,
+		loader: slime.Loader,
 		scopes: {
 			jsh?: {
 				directory: slime.jrunscript.file.Directory
+				loader: slime.Loader
 			}
 		},
 		path: string,

--- a/tools/fifty/test.jsh.js
+++ b/tools/fifty/test.jsh.js
@@ -152,8 +152,9 @@
 		var execute = function(file,part,view) {
 			var fiftyLoader = jsh.script.loader;
 
-			/** @type { slime.fifty.test.internal.run } */
-			var implementation = fiftyLoader.module("test.js", {
+			/** @type { slime.fifty.test.internal.test.Script } */
+			var script = fiftyLoader.script("test.js");
+			var implementation = script({
 				library: {
 					Verify: verify
 				},
@@ -166,6 +167,11 @@
 
 			return implementation(
 				loader,
+				{
+					jsh: {
+						directory: file.parent
+					}
+				},
 				file.pathname.basename,
 				part
 			)

--- a/tools/fifty/test.jsh.js
+++ b/tools/fifty/test.jsh.js
@@ -111,44 +111,6 @@
 			})()
 		};
 
-		var Loader = function recurse(delegate,directory) {
-			/** @type { slime.fifty.test.$loader["jsh"]["plugin"]["mock"] } */
-			var mockPlugin = function(p) {
-				return jsh.$fifty.plugin.mock(
-					$api.Object.compose(
-						p,
-						{ $loader: delegate }
-					)
-				);
-			}
-
-			var loader = Object.assign(
-				delegate,
-				{
-					getRelativePath: function(path) { return directory.getRelativePath(path); },
-					plugin: {
-						mock: mockPlugin
-					},
-					jsh: {
-						$slime: jsh.unit.$slime,
-						plugin: {
-							mock: mockPlugin
-						}
-					},
-					Child: (function(was) {
-						return function(path) {
-							var rv = was.apply(this,arguments);
-							var container = directory.getRelativePath(path).directory;
-							recurse(rv,container);
-							return rv;
-						}
-					})(delegate.Child)
-				}
-			);
-
-			return loader;
-		}
-
 		var execute = function(file,part,view) {
 			var fiftyLoader = jsh.script.loader;
 
@@ -161,15 +123,14 @@
 				console: view
 			});
 
-			var delegate = new jsh.file.Loader({ directory: file.parent });
-
-			var loader = Loader(delegate,file.parent);
+			var loader = new jsh.file.Loader({ directory: file.parent });
 
 			return implementation(
 				loader,
 				{
 					jsh: {
-						directory: file.parent
+						directory: file.parent,
+						loader: loader
 					}
 				},
 				file.pathname.basename,

--- a/tools/fifty/test/data/getRelativePath.fifty.ts
+++ b/tools/fifty/test/data/getRelativePath.fifty.ts
@@ -8,7 +8,7 @@
 	function(
 		fifty: slime.fifty.test.kit
 	) {
-		var relative = fifty.$loader.getRelativePath("module.js");
+		var relative = fifty.jsh.file.object.getRelativePath("module.js");
 
 		fifty.tests.suite = function() {
 			var r = relative;

--- a/tools/fifty/test/data/module.fifty.ts
+++ b/tools/fifty/test/data/module.fifty.ts
@@ -37,7 +37,7 @@ namespace slime.fifty.internal.test.data {
 			fifty: slime.fifty.test.kit,
 			verify: slime.fifty.test.verify,
 			tests: slime.fifty.test.tests,
-			$loader: slime.fifty.test.$loader,
+			$loader: slime.Loader,
 			run: slime.fifty.test.kit["run"],
 			load: slime.fifty.test.load
 		) {

--- a/tools/wf/plugin-standard.jsh.fifty.ts
+++ b/tools/wf/plugin-standard.jsh.fifty.ts
@@ -16,11 +16,11 @@ namespace slime.jsh.wf {
 						repository.config({ set: { name: "user.email", value: "bar@example.com" }});
 					}
 
-					var src: slime.jrunscript.file.Directory = fifty.$loader.getRelativePath("../..").directory;
+					var src: slime.jrunscript.file.Directory = fifty.jsh.file.object.getRelativePath("../..").directory;
 
 					function fixture() {
-						var project = fifty.jsh.file.location();
-						fifty.$loader.getRelativePath("test/data/plugin-standard").directory.copy(project);
+						var project = fifty.jsh.file.object.temporary.location();
+						fifty.jsh.file.object.getRelativePath("test/data/plugin-standard").directory.copy(project);
 						var repository = jsh.tools.git.init({
 							pathname: project
 						});
@@ -59,11 +59,11 @@ namespace slime.jsh.wf {
 					}
 
 					return {
-						wf: fifty.$loader.getRelativePath("../wf.bash").file,
+						wf: fifty.jsh.file.object.getRelativePath("../wf.bash").file,
 						project: function() {
 							var origin = fixture();
 							var repository = origin.clone({
-								to: fifty.jsh.file.location()
+								to: fifty.jsh.file.object.temporary.location()
 							});
 							repository.submodule.update({
 								init: true

--- a/tools/wf/plugin.jsh.fifty.ts
+++ b/tools/wf/plugin.jsh.fifty.ts
@@ -381,7 +381,7 @@ namespace slime.jsh.wf {
 
 				var c = fifty.global.jsh.wf
 
-				var mock = fifty.$loader.jsh.plugin.mock({
+				var mock = fifty.jsh.plugin.mock({
 					jsh: {
 						file: jsh.file,
 						tools: {
@@ -417,12 +417,11 @@ namespace slime.jsh.wf {
 
 (
 	function(
-		jsh: slime.jsh.Global,
-		verify: slime.definition.verify.Verify,
-		run: slime.fifty.test.kit["run"],
-		tests: any,
-		$loader: slime.Loader & { getRelativePath: any, plugin: any }
+		fifty: slime.fifty.test.kit
 	) {
+		const { tests, verify, run } = fifty;
+		const { jsh } = fifty.global;
+
 		tests.types.Exports = function(module: slime.jsh.wf.Exports,jsh: slime.jsh.Global) {
 			(function() {
 				var invocation = {
@@ -493,7 +492,7 @@ namespace slime.jsh.wf {
 				ui: jsh.ui,
 				tools: jsh.tools
 			};
-			var mock = $loader.plugin.mock({
+			var mock = fifty.jsh.plugin.mock({
 				jsh: mockjsh
 			});
 			var plugin = mock.jsh.wf;
@@ -507,4 +506,4 @@ namespace slime.jsh.wf {
 		}
 	}
 //@ts-ignore
-)( (function() { return this; })().jsh, verify, run, tests, $loader)
+)(fifty)

--- a/wf.fifty.ts
+++ b/wf.fifty.ts
@@ -11,9 +11,9 @@ namespace slime {
 				const jsh = fifty.global.jsh;
 				return {
 					clone: function() {
-						var src : slime.jrunscript.file.Directory = fifty.$loader.getRelativePath(".").directory;
+						var src : slime.jrunscript.file.Directory = fifty.jsh.file.object.getRelativePath(".").directory;
 						var origin = new jsh.tools.git.Repository({ directory: src });
-						var rv = origin.clone({ to: fifty.jsh.file.location() });
+						var rv = origin.clone({ to: fifty.jsh.file.object.temporary.location() });
 						//	copy code so that we get local modifications in our "clone"
 						src.copy(rv.directory.pathname, {
 							filter: function(p) {


### PR DESCRIPTION
In preparation for adding world-oriented file APIs to fifty scripts running in `jsh`