### PR TITLE
Add UNIX socket capability to HTTP curl SPI

### DIFF
--- a/rhino/http/client/curl.fifty.ts
+++ b/rhino/http/client/curl.fifty.ts
@@ -23,14 +23,55 @@ namespace slime.jrunscript.http.client.curl {
 		}
 	}
 
-	export type Exports = slime.jrunscript.http.client.Exports["world"]["request"]
+	export type Exports = (configuration?: {
+		unixSocket?: string
+	}) => slime.jrunscript.http.client.Exports["world"]["request"]
 
 	(
 		function(
 			fifty: slime.fifty.test.Kit
 		) {
-			fifty.tests.suite = function() {
+			const { jsh } = fifty.global;
 
+			var script: Script = fifty.$loader.script("curl.js");
+
+			var api = script({
+				console: jsh.shell.console,
+				library: {
+					io: jsh.io,
+					shell: jsh.shell
+				}
+			});
+
+			fifty.tests.lab = function() {
+				var subject = api();
+				fifty.load("module.fifty.ts", "types.spi.Implementation", subject);
+			}
+
+			fifty.tests.manual = {};
+
+			fifty.tests.manual.docker = function() {
+				var implementation = api({
+					unixSocket: "/var/run/docker.sock"
+				});
+				var response = implementation({
+					request: {
+						method: "GET",
+						url: "http://docker.local.unix/info",
+						headers: []
+					},
+					timeout: {
+						connect: void(0),
+						read: void(0)
+					}
+				})();
+				jsh.shell.console("status = " + response.status);
+				jsh.shell.console("headers = " + JSON.stringify(response.headers));
+				jsh.shell.console("stream = " + JSON.stringify(JSON.parse(response.stream.character().asString()), void(0), 4));
+			}
+
+			fifty.tests.suite = function() {
+				fifty.run(fifty.tests.lab);
 			}
 		}
 	//@ts-ignore

--- a/rhino/http/client/curl.js
+++ b/rhino/http/client/curl.js
@@ -13,107 +13,102 @@
 	 * @param { slime.loader.Export<slime.jrunscript.http.client.curl.Exports> } $export
 	 */
 	function($api,$context,$export) {
-		//	TODO	get rid of this shim
-		var jsh = {
-			/** @type { { Buffer: any, mime: slime.jrunscript.io.mime.Exports } } */
-			io: {
-				Buffer: $context.library.io.Buffer,
-				mime: $context.library.io.mime
-			},
-			/** @type { Pick<slime.jrunscript.shell.Exports,"world"|"Invocation"> & { console: (message: string) => void } } */
-			shell: {
-				Invocation: $context.library.shell.Invocation,
-				world: $context.library.shell.world,
-				console: $context.console
-			}
-		};
-
 		/**
-		 *
-		 * @param { slime.jrunscript.http.client.spi.Argument } argument
-		 * @returns { ReturnType<slime.jrunscript.http.client.World["request"]> }
+		 * @type { slime.jrunscript.http.client.curl.Exports }
 		 */
-		var curl = function(argument) {
-			return $api.Function.impure.ask(function(events) {
-				/** @type { slime.jrunscript.http.client.spi.Response } */
-				var response;
+		var curl = function(p) {
+			if (!p) p = {};
+			/**
+			 *
+			 * @param { slime.jrunscript.http.client.spi.Argument } argument
+			 * @returns { ReturnType<slime.jrunscript.http.client.World["request"]> }
+			 */
+			function implementation(argument) {
+				return $api.Function.impure.ask(function(events) {
+					/** @type { slime.jrunscript.http.client.spi.Response } */
+					var response;
 
-				jsh.shell.world.run(
-					jsh.shell.Invocation.create({
-						command: "curl",
-						arguments: $api.Array.build(function(rv) {
-							//	TODO	consider --max-time, though there is no URLConnection equivalent
-							//	TODO	--connect-timeout
-							rv.push("--include");
-							rv.push("--request", argument.request.method);
-							if (argument.request.headers) {
-								argument.request.headers.forEach(function(header) {
-									rv.push("--header", header.name + ": " + header.value);
-								});
+					$context.library.shell.world.run(
+						$context.library.shell.Invocation.create({
+							//	TODO	should not assume location and/or PATH
+							command: "curl",
+							arguments: $api.Array.build(function(rv) {
+								if (p.unixSocket) rv.push("--unix-socket", p.unixSocket);
+								//	TODO	consider --max-time, though there is no URLConnection equivalent
+								//	TODO	--connect-timeout
+								rv.push("--include");
+								rv.push("--request", argument.request.method);
+								if (argument.request.headers) {
+									argument.request.headers.forEach(function(header) {
+										rv.push("--header", header.name + ": " + header.value);
+									});
+								}
+								if (argument.request.body) {
+									rv.push("--header", "Content-Type: " + $context.library.io.mime.Type.codec.declaration.encode(argument.request.body.type));
+									//	TODO	does not handle binary data
+									rv.push("--data", argument.request.body.stream.character().asString());
+								}
+								if (argument.timeout && argument.timeout.connect) {
+									rv.push("--connect-timeout", (argument.timeout.connect / 1000).toFixed(3));
+								}
+								rv.push(argument.request.url);
+							}),
+							stdio: {
+								output: "string",
+								error: "line"
 							}
-							if (argument.request.body) {
-								rv.push("--header", "Content-Type: " + jsh.io.mime.Type.codec.declaration.encode(argument.request.body.type));
-								//	TODO	does not handle binary data
-								rv.push("--data", argument.request.body.stream.character().asString());
+						})
+					)({
+						stderr: function(e) {
+							$context.console(e.detail.line);
+						},
+						exit: function(e) {
+							var output = e.detail.stdio.output;
+							var lines = output.split("\n");
+
+							var noCarriageReturn = function(line) {
+								if ($api.Function.string.endsWith("\r")(line)) {
+									line = line.substring(0,line.length-1);
+								}
+								return line;
+							};
+
+							var notBlank = function(line) {
+								return noCarriageReturn(line).length != 0;
+							};
+
+							var statusLine = noCarriageReturn(lines[0]);
+							var statusTokens = statusLine.split(" ");
+							var index = 1;
+							var headers = [];
+
+
+							while(notBlank(lines[index])) {
+								var parsed = noCarriageReturn(lines[index]).split(": ");
+								headers.push({ name: parsed[0], value: parsed.slice(1).join(": ") });
+								index++;
 							}
-							if (argument.timeout.connect) {
-								rv.push("--connect-timeout", (argument.timeout.connect / 1000).toFixed(3));
+							response = {
+								status: {
+									code: Number(statusTokens[1]),
+									reason: statusTokens.slice(2).join(" "),
+								},
+								headers: headers,
+								stream: (function(string) {
+									var buffer = new $context.library.io.Buffer();
+									buffer.writeText().write(string);
+									buffer.writeText().close();
+									return buffer.readBinary();
+								})(lines.slice(index+1).join("\n"))
 							}
-							rv.push(argument.request.url);
-						}),
-						stdio: {
-							output: "string",
-							error: "line"
 						}
-					})
-				)({
-					stderr: function(e) {
-						jsh.shell.console(e.detail.line);
-					},
-					exit: function(e) {
-						var output = e.detail.stdio.output;
-						var lines = output.split("\n");
-
-						var noCarriageReturn = function(line) {
-							if ($api.Function.string.endsWith("\r")(line)) {
-								line = line.substring(0,line.length-1);
-							}
-							return line;
-						};
-
-						var notBlank = function(line) {
-							return noCarriageReturn(line).length != 0;
-						};
-
-						var statusLine = noCarriageReturn(lines[0]);
-						var statusTokens = statusLine.split(" ");
-						var index = 1;
-						var headers = [];
-
-
-						while(notBlank(lines[index])) {
-							var parsed = noCarriageReturn(lines[index]).split(": ");
-							headers.push({ name: parsed[0], value: parsed.slice(1).join(": ") });
-							index++;
-						}
-						response = {
-							status: {
-								code: Number(statusTokens[1]),
-								reason: statusTokens.slice(2).join(" "),
-							},
-							headers: headers,
-							stream: (function(string) {
-								var buffer = new jsh.io.Buffer();
-								buffer.writeText().write(string);
-								buffer.writeText().close();
-								return buffer.readBinary();
-							})(lines.slice(index+1).join("\n"))
-						}
-					}
+					});
+					return response;
 				});
-				return response;
-			});
-		};
+			}
+
+			return implementation;
+		}
 
 		$export(curl);
 	}

--- a/rhino/shell/jsh.fifty.ts
+++ b/rhino/shell/jsh.fifty.ts
@@ -89,7 +89,7 @@ namespace slime.jsh.shell {
 			url: any
 		}
 		HOME: slime.jrunscript.file.Directory
-		PATH: any
+		PATH: slime.jrunscript.file.Searchpath
 		browser: slime.jrunscript.shell.browser.Exports
 		listeners: any
 		system: {

--- a/tools/fifty/module.fifty.ts
+++ b/tools/fifty/module.fifty.ts
@@ -85,8 +85,9 @@ namespace slime.fifty {
 
 			test: {
 				/**
-				 * Creates a test that simply loops through its own properties and executes those as tests. Can be used to easily
-				 * create a test hiearchy without having to have the parent repeat the names of all its children.
+				 * Creates a test that simply loops through its own properties (and if its properties are objects, those properties'
+				 * properties, recursively) and executes those as tests. Can be used to easily create a test hierarchy without
+				 * having to have the parent repeat the names of all its children.
 				 */
 				Parent: () => () => void
 			}


### PR DESCRIPTION
Also:
* Add manual test for Docker UNIX domain socket to curl SPI
* Run HTTP client type test on curl SPI
* Add curl SPI to test suite
* Refine type definition for jsh.shell.PATH
* Improve documetation for fifty.test.Parent()