### PR TITLE
add .read.string() method to Resource

### DIFF
--- a/loader/Loader.fifty.ts
+++ b/loader/Loader.fifty.ts
@@ -93,7 +93,7 @@ namespace slime {
 			/**
 			 * Allows the loader to customize the way resource descriptors are turned into resources.
 			 */
-			Resource?: resource.Exports
+			Resource?: runtime.resource.Exports
 		}
 
 		export interface Scope {
@@ -102,6 +102,11 @@ namespace slime {
 			$exports: any
 			$export: ($exports: any) => void
 		}
+	}
+
+	export namespace loader.test {
+		declare type api = { convert: (input: number) => number };
+		export type factory = slime.loader.Script<{ scale: number }, api>;
 	}
 
 	(
@@ -167,7 +172,7 @@ namespace slime {
 			}
 
 			tests.closure = function() {
-				var closure: slime.test.factory = $loader.value("test/data/closure.js");
+				var closure: slime.loader.test.factory = $loader.value("test/data/closure.js");
 				var context = { scale: 2 };
 				var module = closure(context);
 				verify(module).convert(2).is(4);
@@ -175,13 +180,13 @@ namespace slime {
 
 			tests.$export = function() {
 				fifty.run(function module() {
-					var module: slime.test.factory = $loader.script("test/data/module-export.js");
+					var module: slime.loader.test.factory = $loader.script("test/data/module-export.js");
 					var api = module({ scale: 2 });
 					verify(api).convert(3).is(6);
 				});
 
 				fifty.run(function file() {
-					var file: slime.test.factory = $loader.script("test/data/file-export.js");
+					var file: slime.loader.test.factory = $loader.script("test/data/file-export.js");
 					var api = file({ scale: 2 });
 					verify(api).convert(3).is(6);
 				});
@@ -241,7 +246,7 @@ namespace slime {
 
 namespace slime.runtime.internal.loader {
 	export interface Scope {
-		Resource: slime.resource.Exports
+		Resource: slime.runtime.resource.Exports
 		methods: scripts.Exports["methods"]
 		createScriptScope: scripts.Exports["createScriptScope"]
 		$api: slime.$api.Global

--- a/loader/expression.js
+++ b/loader/expression.js
@@ -251,33 +251,40 @@
 			this.name = (o.name) ? o.name : void(0);
 
 			if (o.read && o.read.string) {
-				this.read = function(v) {
-					if (v === String) {
-						var rv = o.read.string();
-						return rv;
-					}
-					if (v === JSON) return JSON.parse(this.read(String));
+				this.read = Object.assign(
+					function(v) {
+						if (v === String) {
+							var rv = o.read.string();
+							return rv;
+						}
+						if (v === JSON) return JSON.parse(this.read(String));
 
-					var e4xRead = function() {
-						var string = this.read(String);
-						string = string.replace(/\<\?xml.*\?\>/, "");
-						string = string.replace(/\<\!DOCTYPE.*?\>/, "");
-						return string;
-					};
+						var e4xRead = function() {
+							var string = this.read(String);
+							string = string.replace(/\<\?xml.*\?\>/, "");
+							string = string.replace(/\<\!DOCTYPE.*?\>/, "");
+							return string;
+						};
 
-					if ($platform.e4x && v == $platform.e4x.XML) {
-						return $platform.e4x.XML( e4xRead.call(this) );
-					} else if ($platform.e4x && v == $platform.e4x.XMLList) {
-						return $platform.e4x.XMLList( e4xRead.call(this) );
+						if ($platform.e4x && v == $platform.e4x.XML) {
+							return $platform.e4x.XML( e4xRead.call(this) );
+						} else if ($platform.e4x && v == $platform.e4x.XMLList) {
+							return $platform.e4x.XMLList( e4xRead.call(this) );
+						}
+					},
+					{
+						string: function() {
+							return o.read.string();
+						}
 					}
-				}
+				)
 			}
 		}
 
 		var ResourceExport = Object.assign(
 			Resource,
 			{
-				/** @type { slime.resource.Exports["ReadInterface"]} */
+				/** @type { slime.runtime.resource.Exports["ReadInterface"]} */
 				ReadInterface: {
 					string: function(content) {
 						return {

--- a/loader/jrunscript/expression.js
+++ b/loader/jrunscript/expression.js
@@ -397,11 +397,10 @@
 						}).call(this,this.name);
 					}
 
-					/** @type { slime.jrunscript.runtime.Resource["read"] } */
-					var read = this.read;
+					/** @type { slime.js.Cast<slime.Resource["read"]> } */
+					var cast = $exports.$api.Function.cast;
 
-					/** @property { slime.jrunscript.runtime.Exports["Resources"] } */
-					this.read = read;
+					this.read = cast(this.read);
 
 					this.read = Object.assign(
 						(function(was,global) {
@@ -445,6 +444,7 @@
 						{
 							binary: void(0),
 							text: void(0),
+							string: void(0),
 							lines: void(0)
 						}
 					);
@@ -473,7 +473,7 @@
 						};
 					}
 
-					// TODO: Resources are not really conceptually immuntable, since they can be written, so they should probably not
+					// TODO: Resources are not really conceptually immutable, since they can be written, so they should probably not
 					// cache length and modified
 					if (isJrunscriptDescriptor(p) && Object.prototype.hasOwnProperty.call(p, "length")) {
 						Object.defineProperty(this,"length",{

--- a/tools/fifty/module.fifty.ts
+++ b/tools/fifty/module.fifty.ts
@@ -49,7 +49,9 @@ namespace slime.fifty {
 	export namespace test {
 		export type verify = slime.definition.verify.Verify
 
-		export type tests = any
+		export type tests = {
+			[x: string]: any
+		}
 
 		/**
 		 * Executes a test part from another file. The version that takes a third argument allows an argument of that type
@@ -90,6 +92,13 @@ namespace slime.fifty {
 				 * having to have the parent repeat the names of all its children.
 				 */
 				Parent: () => () => void
+			}
+
+			evaluate: {
+				create: <T,R>(
+					f: (t: T) => R,
+					string: string
+				) => (t: T) => R
 			}
 
 			tests: tests

--- a/tools/fifty/test.js
+++ b/tools/fifty/test.js
@@ -474,6 +474,18 @@
 						return rv;
 					}
 				},
+				evaluate: {
+					create: function(f,string) {
+						return Object.assign(
+							f,
+							{
+								toString: function() {
+									return string;
+								}
+							}
+						)
+					}
+				},
 				tests: tests,
 				verify: function() {
 					return verify.apply(this,arguments);


### PR DESCRIPTION
Also:
* Move interface for runtime Resource constructor exports to runtime
* Improve organization of runtime tests
* Add Fifty construct for creating evaluate functions with toString() defined