### PR TITLE
Fix incorrect wf commit exit status

### DIFF
--- a/rhino/tools/github/git-credential-github-tokens-directory.bash
+++ b/rhino/tools/github/git-credential-github-tokens-directory.bash
@@ -16,4 +16,5 @@ if [ "$1" == "store" ]; then
 	exit 0
 fi
 
-${SLIME}/jsh.bash ${DIR}/git-credential-github-tokens-directory.jsh.js "$@"
+#	If PROJECT is set because wf is running, it can mess up the tools/wf plugin in the invoked shell
+env PROJECT= ${SLIME}/jsh.bash ${DIR}/git-credential-github-tokens-directory.jsh.js "$@"

--- a/tools/wf/plugin-standard.jsh.js
+++ b/tools/wf/plugin-standard.jsh.js
@@ -539,26 +539,18 @@
 						}
 
 						if (!p.options.message) throw new Error("No default commit message, and no message given.");
-						try {
-							//	TODO	removed a notest option that could be used here
-							var check = project.precommit({
-								console: function(e) {
-									jsh.shell.console(e.detail);
-								}
-							});
-							if (check) {
-								commit(jsh.tools.git.Repository({ directory: $context.base }), p.options.message);
-								jsh.shell.console("Committed changes to " + $context.base);
+
+						//	TODO	removed a notest option that could be used here
+						var check = project.precommit({
+							console: function(e) {
+								jsh.shell.console(e.detail);
 							}
-						} catch (e) {
-							//	TODO	should generalize this in the wf.jsh.js script, perhaps even adding an error handler
-							//			to jsh.script.cli.wrap or Descriptor or something
-							if (e instanceof jsh.wf.error.Failure) {
-								jsh.shell.console("ERROR: " + e.message);
-							} else {
-								jsh.shell.console(e);
-								jsh.shell.console(e.stack);
-							}
+						});
+						if (check) {
+							commit(jsh.tools.git.Repository({ directory: $context.base }), p.options.message);
+							jsh.shell.console("Committed changes to " + $context.base);
+						} else {
+							jsh.shell.console("Precommit checks failed; aborting commit.");
 							return 1;
 						}
 					}


### PR DESCRIPTION
Even when checks failed (and no commit was made), had a 0 exit status

Also:
* Unset PROJECT when running jsh git credential helper so that shell's
wf plugin is not misconfigured