### PR TITLE
Fix regression with jrunscript StreamDescriptor

### DIFF
--- a/loader/jrunscript/expression.fifty.ts
+++ b/loader/jrunscript/expression.fifty.ts
@@ -42,7 +42,7 @@ namespace slime.jrunscript.runtime {
 		/**
 		 * @deprecated
 		 */
-		export interface DeprecatedStreamDescriptor {
+		export interface DeprecatedStreamDescriptor extends slime.resource.Descriptor {
 			stream?: {
 				binary: slime.jrunscript.runtime.io.InputStream
 			}

--- a/loader/jrunscript/expression.js
+++ b/loader/jrunscript/expression.js
@@ -234,6 +234,8 @@
 		 */
 		var fromStreamDescriptor = function(o) {
 			return {
+				type: o.type,
+				name: o.name,
 				read: {
 					binary: (function(stream) {
 						var _bytes;


### PR DESCRIPTION
These deprecated resource descriptors were now having their name and
type discarded when being converted to jrunscript resource Descriptors