### PR TITLE
Extract old rhino/shell run() implementation

### DIFF
--- a/jsh/script/plugin.jsh.fifty.ts
+++ b/jsh/script/plugin.jsh.fifty.ts
@@ -192,100 +192,80 @@ namespace slime.jsh.script {
 					fifty.verify(after).arguments[1].is("A");
 					fifty.verify(after).arguments[2].is("--c");
 					fifty.verify(after).arguments[3].is("C");
+
+					fifty.run(function harvestedFromWf() {
+						fifty.run(
+							function() {
+								var invocation = {
+									options: {},
+									arguments: ["--foo", "bar"]
+								};
+								subject.cli.option.string({
+									longname: "baz"
+								})(invocation);
+								verify(invocation).options.evaluate.property("foo").is(void(0));
+								verify(invocation).arguments.length.is(2);
+							}
+						);
+
+						fifty.run(
+				 			function() {
+								var invocation = {
+									options: {},
+									arguments: ["--foo", "bar"]
+								};
+								subject.cli.option.string({
+									longname: "foo"
+								})(invocation);
+								verify(invocation).options.evaluate.property("foo").is("bar");
+								verify(invocation).arguments.length.is(0);
+							}
+						);
+
+						fifty.run(
+				 			function() {
+								var invocation = {
+									options: {
+										baz: false
+									},
+									arguments: ["--baz", "--bizzy"]
+								};
+								subject.cli.option.boolean({
+									longname: "baz"
+								})(invocation);
+								verify(invocation).options.baz.is(true);
+								verify(invocation).options.evaluate.property("bizzy").is(void(0));
+								verify(invocation).arguments.length.is(1);
+								verify(invocation).arguments[0].is("--bizzy");
+							}
+						);
+
+						fifty.run(
+				 			function() {
+								var processor = $api.Function.pipe(
+									subject.cli.option.string({ longname: "a" }),
+									subject.cli.option.boolean({ longname: "b" }),
+									subject.cli.option.string({ longname: "aa" }),
+									subject.cli.option.boolean({ longname: "bb" })
+								)
+								var invocation = processor({
+									options: {},
+									arguments: ["--a", "aaa", "--b", "--c", "c"]
+								});
+								verify(invocation).arguments.length.is(2);
+								verify(invocation).arguments[0] == "--c";
+								verify(invocation).arguments[1] == "c";
+								verify(invocation).options.a.is("aaa");
+								verify(invocation).options.b.is(true);
+								verify(invocation).options.evaluate.property("aa").is(void(0));
+								verify(invocation).options.evaluate.property("bb").is(void(0));
+							}
+						)
+					})
 				};
-
-				//	TODO	Remove or incorporate the below tests harvested when the jsh.wf CLI handling was removed
-
-				// (
-				// 	function(
-				// 		fifty: slime.fifty.test.Kit
-				// 	) {
-				// 		const { verify } = fifty;
-				// 		const { jsh } = fifty.global;
-
-				// 		fifty.tests.exports.cli = function() {
-				// 			var mockjsh = {
-				// 				script: {
-				// 					arguments: ["--a", "aaa", "--b", "--c", "c"]
-				// 				},
-				// 				file: jsh.file,
-				// 				shell: jsh.shell,
-				// 				ui: jsh.ui,
-				// 				tools: jsh.tools
-				// 			};
-				// 			var mock = fifty.jsh.plugin.mock({
-				// 				jsh: mockjsh
-				// 			});
-				// 			var plugin: Exports = mock.jsh.wf;
-				// 			if (!plugin) {
-				// 				throw new TypeError("No jsh.wf loaded.");
-				// 			}
-				// 			const module = plugin;
-
-				// 			(function() {
-				// 				var invocation = {
-				// 					options: {},
-				// 					arguments: ["--foo", "bar"]
-				// 				};
-				// 				module.cli.$f.option.string({
-				// 					longname: "baz"
-				// 				})(invocation);
-				// 				verify(invocation).options.evaluate.property("foo").is(void(0));
-				// 				verify(invocation).arguments.length.is(2);
-				// 			})();
-
-				// 			(function() {
-				// 				var invocation = {
-				// 					options: {},
-				// 					arguments: ["--foo", "bar"]
-				// 				};
-				// 				module.cli.$f.option.string({
-				// 					longname: "foo"
-				// 				})(invocation);
-				// 				verify(invocation).options.evaluate.property("foo").is("bar");
-				// 				verify(invocation).arguments.length.is(0);
-				// 			})();
-
-				// 			(function() {
-				// 				var invocation = {
-				// 					options: {
-				// 						baz: false
-				// 					},
-				// 					arguments: ["--baz", "--bizzy"]
-				// 				};
-				// 				module.cli.$f.option.boolean({
-				// 					longname: "baz"
-				// 				})(invocation);
-				// 				verify(invocation).options.baz.is(true);
-				// 				verify(invocation).options.evaluate.property("bizzy").is(void(0));
-				// 				verify(invocation).arguments.length.is(1);
-				// 				verify(invocation).arguments[0].is("--bizzy");
-				// 			})();
-
-				// 			(function() {
-				// 				var invocation: { arguments: string[], options: { a: string, b: boolean }} = <{ arguments: string[], options: { a: string, b: boolean }}>module.cli.invocation(
-				// 					//	TODO	should module.$f.option.string("a") work?
-				// 					module.cli.$f.option.string({ longname: "a" }),
-				// 					module.cli.$f.option.boolean({ longname: "b" }),
-				// 					module.cli.$f.option.string({ longname: "aa" }),
-				// 					module.cli.$f.option.boolean({ longname: "bb" })
-				// 				);
-				// 				verify(invocation).arguments.length.is(2);
-				// 				verify(invocation).arguments[0] == "--c";
-				// 				verify(invocation).arguments[1] == "c";
-				// 				verify(invocation).options.a.is("aaa");
-				// 				verify(invocation).options.b.is(true);
-				// 				verify(invocation).options.evaluate.property("aa").is(void(0));
-				// 				verify(invocation).options.evaluate.property("bb").is(void(0));
-				// 			})();
-				// 		}
-				// 	}
-				// //@ts-ignore
-				// )(fifty);
 			}
 		//@ts-ignore
 		)(fifty);
-
 	}
 
 	export namespace cli {

--- a/loader/$api-Function.fifty.ts
+++ b/loader/$api-Function.fifty.ts
@@ -690,11 +690,10 @@ namespace slime.$api.fp {
 		export type Ask<E,T> = (on?: slime.$api.events.Handler<E>) => T
 		export type Tell<E> = (on?: slime.$api.events.Handler<E>) => void
 
+		export type Action<P,E> = (p?: P) => Tell<E>
+
 		/** @deprecated Replaced by {@link Ask} */
 		export type State<T> = Ask<void,T>
-
-		/** @experimental Identical to {@link Ask} but has slightly different semantics (analogous to HTTP POST). */
-		export type Action<E,R> = (on?: slime.$api.events.Handler<E>) => R
 
 		export type Update<T extends Object> = (t: T) => void
 
@@ -703,6 +702,11 @@ namespace slime.$api.fp {
 		 * `undefined`, or returns a completely new value to replace the argument.
 		 */
 		export type Revision<M> = (mutable: M) => M | void
+
+		export namespace old {
+			/** @deprecated Identical to {@link Ask} but has slightly different semantics (analogous to HTTP POST). */
+			export type Action<E,R> = (on?: slime.$api.events.Handler<E>) => R
+		}
 	}
 
 	export interface Exports {

--- a/rhino/file/module.fifty.ts
+++ b/rhino/file/module.fifty.ts
@@ -158,7 +158,7 @@ namespace slime.jrunscript.file {
 		}
 
 		action: {
-			delete: (location: string) => slime.$api.fp.impure.Action<{
+			delete: (location: string) => slime.$api.fp.impure.old.Action<{
 				deleted: string
 			},void>
 
@@ -168,7 +168,7 @@ namespace slime.jrunscript.file {
 					content: string
 					createDirectory?: boolean
 					exists: "fail" | "leave" | "overwrite"
-				}): slime.$api.fp.impure.Action<{
+				}): slime.$api.fp.impure.old.Action<{
 					wrote: string
 				},void>
 			}

--- a/rhino/shell/invocation.fifty.ts
+++ b/rhino/shell/invocation.fifty.ts
@@ -260,7 +260,7 @@ namespace slime.jrunscript.shell.internal.invocation {
 		library: {
 			io: slime.jrunscript.io.Exports
 		}
-		run: slime.jrunscript.shell.internal.run.Export
+		run: slime.jrunscript.shell.internal.run.Exports
 	}
 
 	export type Configuration = Pick<slime.jrunscript.shell.invocation.old.Argument, "command" | "arguments">

--- a/rhino/shell/jsh.fifty.ts
+++ b/rhino/shell/jsh.fifty.ts
@@ -47,6 +47,10 @@ namespace slime.jsh.shell {
 			}
 		}
 
+		world: slime.jrunscript.shell.Exports["world"] & {
+			exit: slime.$api.fp.impure.Action<number,void>
+		}
+
 		//	TODO	run.evaluate.wrap
 		exit: (code: number) => void
 		stdio: {

--- a/rhino/shell/jsh.js
+++ b/rhino/shell/jsh.js
@@ -576,6 +576,12 @@
 		} else if ($exports.jsh.home) {
 			$exports.jsh.lib = $exports.jsh.home.getSubdirectory("lib");
 		}
+
+		$exports.world.exit = function(status) {
+			return function() {
+				$exports.exit(status);
+			}
+		}
 	}
 //@ts-ignore
 )(Packages,JavaAdapter,$api,$context,$exports);

--- a/rhino/shell/module.fifty.ts
+++ b/rhino/shell/module.fifty.ts
@@ -253,181 +253,6 @@ namespace slime.jrunscript.shell {
 	}
 
 	export interface Exports {
-		run: {
-			<T>(
-				p: run.old.Argument & {
-					evaluate?: (p: run.old.Result) => T
-				},
-				events?: run.old.Handler
-			): T
-
-			(p: run.old.Argument, events?: run.old.Events): run.old.Result
-
-			evaluate: any
-			stdio: any
-		}
-	}
-
-	(
-		function(
-			fifty: slime.fifty.test.Kit
-		) {
-			var getJavaProgram = function(name) {
-				var jsh = fifty.global.jsh;
-				var to = jsh.shell.TMPDIR.createTemporary({ directory: true });
-				jsh.java.tools.javac({
-					destination: to.pathname,
-					arguments: [fifty.jsh.file.object.getRelativePath("test/java/inonit/jsh/test/" + name + ".java")]
-				});
-				return {
-					classpath: jsh.file.Searchpath([to.pathname]),
-					main: "inonit.jsh.test." + name
-				}
-			};
-
-			fifty.tests.run = function() {
-				var subject: Exports = fifty.global.jsh.shell;
-
-				var here: slime.jrunscript.file.Directory = fifty.jsh.file.object.getRelativePath(".").directory;
-
-				var on = {
-					start: void(0)
-				}
-
-				var argument: slime.jrunscript.shell.run.old.Argument = {
-					command: "ls",
-					directory: here,
-					on: {
-						start: function(target) {
-							on.start = target;
-						}
-					}
-				};
-
-				var captured: run.old.events.Events = {
-					start: void(0),
-					terminate: void(0)
-				};
-
-				var events = {
-					start: function(e) {
-						fifty.global.jsh.shell.console("start!");
-						captured.start = e.detail;
-					},
-					terminate: function(e) {
-						fifty.global.jsh.shell.console("terminate!");
-						captured.terminate = e.detail;
-					}
-				};
-
-				fifty.verify(on).start.is.type("undefined");
-
-				subject.run(argument, events);
-
-				//	TODO	appears to work in latest version of TypeScript
-				//@ts-ignore
-				fifty.verify(captured).start.command.evaluate(function(p) { return String(p) }).is("ls");
-				fifty.verify(captured).start.directory.evaluate(function(directory) { return directory.toString(); }).is(here.toString());
-				fifty.verify(captured).start.pid.is.type("number");
-				fifty.verify(captured).start.kill.is.type("function");
-
-				fifty.verify(captured).terminate.status.is(0);
-
-				fifty.verify(on).start.is.type("object");
-
-				fifty.run(function argumentChecking() {
-					fifty.verify(subject).evaluate(function() {
-						this.run({
-							command: null
-						})
-					}).threw.message.is("property 'command' must not be null; full invocation = (null)");
-					fifty.verify(subject).evaluate(function() {
-						this.run({
-							command: "java",
-							arguments: [null]
-						})
-					}).threw.message.is("property 'arguments[0]' must not be null; full invocation = java (null)");
-				});
-
-				fifty.run(fifty.tests.run.stdio);
-
-				fifty.run(function directory() {
-					var jsh = fifty.global.jsh;
-					var module = subject;
-
-					var program = getJavaProgram("Directory");
-					var dir = jsh.shell.TMPDIR.createTemporary({ directory: true });
-					var result = module.java({
-						classpath: program.classpath,
-						main: program.main,
-						stdio: {
-							output: String
-						},
-						directory: dir
-					});
-					var workdir = result.stdio.output;
-					fifty.verify(workdir).is(dir.toString());
-				})
-			}
-			fifty.tests.run.stdio = function() {
-				var subject: Exports = fifty.global.jsh.shell;
-				var jsh = fifty.global.jsh;
-				var module = subject;
-				var verify = fifty.verify;
-
-				var to = jsh.shell.TMPDIR.createTemporary({ directory: true });
-				jsh.java.tools.javac({
-					destination: to.pathname,
-					arguments: [fifty.jsh.file.object.getRelativePath("test/java/inonit/jsh/test/Echo.java")]
-				});
-				var result = module.java({
-					classpath: jsh.file.Searchpath([to.pathname]),
-					main: "inonit.jsh.test.Echo",
-					stdio: {
-						input: "Hello, World!",
-						output: String
-					}
-				});
-				verify(result).stdio.output.is("Hello, World!");
-
-				var runLines = function(input) {
-					var buffered = [];
-					var rv = module.java({
-						classpath: jsh.file.Searchpath([to.pathname]),
-						main: "inonit.jsh.test.Echo",
-						stdio: {
-							input: input,
-							output: {
-								line: function(string) {
-									buffered.push(string);
-								}
-							}
-						}
-					});
-					return {
-						stdio: {
-							output: buffered
-						}
-					};
-				};
-
-				var lines: { stdio: { output: string[] }};
-				var nl = jsh.shell.os.newline;
-				lines = runLines("Hello, World!" + nl + "Line 2");
-				verify(lines).stdio.output.length.is(2);
-				verify(lines).stdio.output[0].is("Hello, World!");
-				verify(lines).stdio.output[1].is("Line 2");
-				lines = runLines("Hello, World!" + nl + "Line 2" + nl);
-				verify(lines).stdio.output.length.is(3);
-				verify(lines).stdio.output[0].is("Hello, World!");
-				verify(lines).stdio.output[1].is("Line 2");
-				verify(lines).stdio.output[2].is("");
-			}
-		}
-	//@ts-ignore
-	)(fifty);
-
-	export interface Exports {
 		/**
 		 * Launches a Java program.
 		 */
@@ -646,14 +471,14 @@ namespace slime.jrunscript.shell {
 	}
 
 	export interface World {
-		run: (invocation: run.Invocation) => slime.$api.fp.impure.Tell<run.Events>
+		run: slime.$api.fp.impure.Action<run.Invocation,run.Events>
 
 		/**
-		 * Allows a mock implementation of `run` to be created using a function that receives an invocation as an argument
-		 * and returns an object describing what the mocked subprocess should do. The system will use this object to create
+		 * Allows a mock implementation of the `run` action to be created using a function that receives an invocation as an
+		 * argument and returns an object describing what the mocked subprocess should do. The system will use this object to create
 		 * the appropriate `Tell` and fire the appropriate events to the caller.
 		 */
-		mock: (delegate: (invocation: shell.run.Invocation) => shell.run.Mock) => World["run"]
+		mock: (delegate: (invocation: shell.run.Invocation) => shell.run.Mock) => slime.$api.fp.impure.Action<run.Invocation,run.Events>
 
 		 /** @deprecated Replaced by {@link Exports | Exports Invocation.create()} because it does not rely on external state. */
 		Invocation: (p: invocation.old.Argument) => old.Invocation
@@ -856,7 +681,7 @@ namespace slime.jrunscript.shell {
 
 	export interface Exports {
 		Tell: {
-			exit: () => (tell: slime.$api.fp.impure.Tell<run.Events>) => (run.Events["exit"])
+			exit: () => (tell: slime.$api.fp.impure.Tell<run.Events>) => run.Events["exit"]
 			mock: (stdio: Partial<Pick<slime.jrunscript.shell.run.StdioConfiguration,"output" | "error">>, result: slime.jrunscript.shell.run.Mock) => slime.$api.fp.impure.Tell<slime.jrunscript.shell.run.Events>
 		}
 	}
@@ -911,6 +736,7 @@ namespace slime.jrunscript.shell {
 
 				fifty.run(fifty.tests.exports.Tell);
 				fifty.load("invocation.fifty.ts");
+				fifty.load("run-old.fifty.ts");
 
 				fifty.run(fifty.tests.sandbox);
 			}

--- a/rhino/shell/module.js
+++ b/rhino/shell/module.js
@@ -28,6 +28,10 @@
 			return $context.api.file.Searchpath($context.api.file.filesystems.os.Searchpath.parse(searchpath).pathnames.map(toLocalPathname));
 		};
 
+		var module = {
+			events: $api.Events({ source: $exports })
+		};
+
 		$exports.environment = $context.api.java.Environment( ($context._environment) ? $context._environment : Packages.inonit.system.OperatingSystem.Environment.SYSTEM );
 
 		$exports.properties = (
@@ -81,6 +85,8 @@
 		var code = {
 			/** @type { slime.jrunscript.shell.internal.run.Script } */
 			run: $loader.script("run.js"),
+			/** @type { slime.jrunscript.shell.internal.run.old.Script } */
+			run_old: $loader.script("run-old.js"),
 			/** @type { slime.jrunscript.shell.internal.invocation.Script } */
 			invocation: $loader.script("invocation.js")
 		};
@@ -93,242 +99,43 @@
 					file: $context.api.file
 				}
 			});
+			var invocation = code.invocation({
+				library: {
+					io: $context.api.io
+				},
+				run: run
+			});
 			return {
 				run: run,
-				invocation: code.invocation({
-					library: {
-						io: $context.api.io
+				run_old: code.run_old({
+					api: {
+						file: $context.api.file
 					},
-					run: run
-				})
+					environment: $exports.environment,
+					module: module,
+					os: {
+						name: function() {
+							return $exports.os.name;
+						},
+						newline: function() {
+							return $exports.os.newline;
+						}
+					},
+					scripts: {
+						run: run,
+						invocation: invocation
+					},
+					stdio: $context.stdio
+				}),
+				invocation: invocation
 			}
 		})();
 
+		$exports.run = scripts.run_old.run;
+
 		$exports.invocation = scripts.invocation.invocation;
 
-		var module = {
-			events: $api.Events({ source: $exports })
-		};
-
 		$exports.listeners = module.events.listeners;
-
-		/**
-		 *
-		 * @param { slime.jrunscript.shell.run.old.Argument } p
-		 * @return { slime.jrunscript.shell.invocation.old.Argument["stdio"] }
-		 */
-		function extractStdioIncludingDeprecatedForm(p) {
-			if (typeof(p.stdio) != "undefined") return p.stdio;
-
-			if (typeof(p.stdin) != "undefined" || typeof(p.stdout) != "undefined" || typeof(p.stderr) != "undefined") {
-				return $api.deprecate(function() {
-					return {
-						input: p.stdin,
-						output: p.stdout,
-						error: p.stderr
-					};
-				})();
-			}
-
-			return {};
-		}
-
-		/**
-		 *
-		 * @param { Parameters<slime.jrunscript.shell.Exports["run"]>[0] } p
-		 * @param { Parameters<slime.jrunscript.shell.Exports["run"]>[1] } events
-		 */
-		var run = function(p,events) {
-			var as;
-			if (p.as) {
-				as = p.as;
-			}
-
-			p.stdio = extractStdioIncludingDeprecatedForm(p);
-
-			var context = scripts.invocation.toContext(p, $exports.environment, $context.stdio);
-
-			/** @type { slime.jrunscript.shell.internal.module.Invocation } */
-			var invocation = (
-				/**
-				 *
-				 * @returns { slime.jrunscript.shell.internal.module.Invocation }
-				 */
-				function() {
-					/** @type { slime.jrunscript.shell.internal.module.Invocation } */
-					var rv = {
-						configuration: {
-							command: void(0),
-							arguments: void(0)
-						},
-						result: {
-							command: void(0),
-							arguments: void(0),
-							as: void(0)
-						}
-					};
-
-					/**
-					 * @param { slime.jrunscript.shell.invocation.old.Argument["command"] } command
-					 * @param { slime.jrunscript.shell.invocation.old.Argument["arguments"] } args
-					 * @returns { slime.jrunscript.shell.internal.run.java.Configuration }
-					 */
-					var toConfiguration = function(command,args) {
-						/**
-						 *
-						 * @param { slime.jrunscript.shell.invocation.Token } v
-						 * @returns
-						 */
-						var toErrorMessageString = function(v) {
-							if (typeof(v) == "undefined") return "(undefined)";
-							if (v === null) return "(null)";
-							return String(v);
-						};
-
-						/**
-						 *
-						 * @param { slime.jrunscript.shell.invocation.old.Argument["command"] } command
-						 * @param { slime.jrunscript.shell.invocation.old.Argument["arguments"] } args
-						 */
-						var toErrorMessage = function(command,args) {
-							/** @type { slime.jrunscript.shell.invocation.Token[] } */
-							var full = [command];
-							if (args) full = full.concat(args);
-							return full.map(toErrorMessageString).join(" ");
-						};
-
-						try {
-							return scripts.invocation.toConfiguration({
-								command: command,
-								arguments: args
-							});
-						} catch (e) {
-							if (e instanceof scripts.invocation.error.BadCommandToken) {
-								throw new TypeError(e.message + "; full invocation = " + toErrorMessage(command, args));
-							} else {
-								throw e;
-							}
-						}
-					};
-
-					if (p.tokens) {
-						return $api.deprecate(function() {
-							//	TODO	ensure array
-							if (p.tokens.length == 0) {
-								throw new TypeError("tokens cannot be zero-length.");
-							}
-							//	Use a raw copy of the arguments for the callback
-							rv.result.command = p.tokens[0];
-							rv.result.arguments = p.tokens.slice(1);
-							rv.configuration = toConfiguration(p.tokens[0], p.tokens.slice(1));
-							return rv;
-						})();
-					} else if (typeof(p.command) != "undefined") {
-						rv.result.command = p.command;
-						//	TODO	switch to $api.Function.mutating
-						rv.result.arguments = p.arguments;
-						rv.result.as = p.as;
-						rv.configuration = toConfiguration(p.command, p.arguments);
-						return rv;
-					} else {
-						throw new TypeError("Required: command property or tokens property");
-					}
-				}
-			)();
-
-			if (as) {
-				if ($exports.os.name == "Linux") {
-					invocation.configuration.command = "sudo";
-					invocation.configuration.arguments = ["-u", as.user].concat(invocation.configuration.arguments);
-				}
-			}
-
-			var directory = (typeof(context.directory) == "string") ? $context.api.file.Pathname(context.directory).directory : context.directory;
-
-			/**
-			 * @type { slime.jrunscript.shell.run.old.Argument }
-			 */
-			var input = {
-				command: invocation.result.command,
-				arguments: invocation.result.arguments,
-				environment: context.environment,
-				directory: directory
-			};
-			input.workingDirectory = directory;
-			$api.deprecate(input,"workingDirectory");
-
-			var result = scripts.run.old.run(context, invocation.configuration, module, events, p, input, scripts.invocation.isLineListener);
-
-			var evaluate = (p["evaluate"]) ? p["evaluate"] : $exports.run.evaluate;
-			return evaluate($api.Object.compose(input, result));
-		};
-
-		$exports.run = Object.assign(
-			$api.Events.Function(run),
-			{
-				evaluate: void(0),
-				stdio: void(0)
-			}
-		);
-
-		$exports.run.evaluate = function(result) {
-			if (result.error) throw result.error;
-			if (result.status != 0) throw new Error("Exit code: " + result.status + " executing " + result.command + ((result.arguments && result.arguments.length) ? " " + result.arguments.join(" ") : ""));
-			return result;
-		};
-
-		$exports.run.stdio = Object.assign(
-			(
-				/**
-				 *
-				 * @param { Parameters<slime.jrunscript.shell.Exports["run"]>[0] } p
-				 * @return { slime.jrunscript.shell.internal.run.Stdio }
-				 */
-				function getStdio(p) {
-					//	TODO	the getStdio function is currently used in jsh.js, requiring us to export it; is that the best structure?
-					var stdio = extractStdioIncludingDeprecatedForm(p);
-
-					if (stdio) {
-						//	TODO	the below $api.Events() is highly dubious, inserted just to get past TypeScript; who knows
-						//			whether it will work but refactoring in progress may change it further
-						var fixed = scripts.invocation.updateForStringInput(stdio);
-						scripts.invocation.fallbackToParentStdio(fixed, $context.stdio);
-						var x = scripts.invocation.toStdioConfiguration(fixed);
-						var rv = scripts.run.old.buildStdio(x)($api.Events());
-						return rv;
-					}
-					if (!stdio) {
-						//	TODO	could be null if p.stdio === null. What would that mean? And what does $context.stdio have to do with
-						//			it?
-						if (!$context.stdio) {
-							if (p.stdio === null) {
-								//	That's what we thought
-							} else {
-								//	The only way rv should be anything other than an object is if p.stdio was null
-								throw new Error("Unreachable");
-							}
-						}
-						return null;
-					}
-				}
-			),
-			{
-				LineBuffered: function(o) {
-					return Object.assign({}, o, {
-						output: {
-							line: function(line) {
-								o.stdio.output.write(line + $exports.os.newline);
-							}
-						},
-						error: {
-							line: function(line) {
-								o.stdio.error.write(line + $exports.os.newline);
-							}
-						}
-					});
-				}
-			}
-		);
 
 		$exports.sudo = function(settings) {
 			return {
@@ -690,12 +497,12 @@
 			}));
 		};
 
-		if ($context.kotlin) $exports.kotlin = $api.Events.Function(function(p,events) {
+		if ($context.kotlin) $exports.kotlin = $api.events.Function(function(p,events) {
 			//	TODO	remove script property
 			var copy = $api.Object.properties(p).filter(function(property) {
 				return property.name != "script";
 			}).object();
-			return run(Object.assign({}, copy, {
+			return scripts.run_old.$run(Object.assign({}, copy, {
 				command: $context.kotlin.compiler,
 				arguments: function(rv) {
 					rv.push("-script", p.script);
@@ -726,7 +533,7 @@
 
 		$exports.Tell = {
 			exit: function() {
-				function rv(tell) {
+				return function(tell) {
 					var rv;
 
 					tell({
@@ -736,9 +543,7 @@
 					});
 
 					return rv;
-				}
-
-				return rv;
+				};
 			},
 			mock: scripts.run.mock.tell
 		}

--- a/rhino/shell/run-old.fifty.ts
+++ b/rhino/shell/run-old.fifty.ts
@@ -1,0 +1,221 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+namespace slime.jrunscript.shell {
+	export interface Exports {
+		run: {
+			<T>(
+				p: run.old.Argument & {
+					evaluate?: (p: run.old.Result) => T
+				},
+				events?: run.old.Handler
+			): T
+
+			(p: run.old.Argument, events?: run.old.Events): run.old.Result
+
+			evaluate: any
+			stdio: any
+		}
+	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			var getJavaProgram = function(name) {
+				var jsh = fifty.global.jsh;
+				var to = jsh.shell.TMPDIR.createTemporary({ directory: true });
+				jsh.java.tools.javac({
+					destination: to.pathname,
+					arguments: [fifty.jsh.file.object.getRelativePath("test/java/inonit/jsh/test/" + name + ".java")]
+				});
+				return {
+					classpath: jsh.file.Searchpath([to.pathname]),
+					main: "inonit.jsh.test." + name
+				}
+			};
+
+			fifty.tests.run = function() {
+				var subject: Exports = fifty.global.jsh.shell;
+
+				var here: slime.jrunscript.file.Directory = fifty.jsh.file.object.getRelativePath(".").directory;
+
+				var on = {
+					start: void(0)
+				}
+
+				var argument: slime.jrunscript.shell.run.old.Argument = {
+					command: "ls",
+					directory: here,
+					on: {
+						start: function(target) {
+							on.start = target;
+						}
+					}
+				};
+
+				var captured: run.old.events.Events = {
+					start: void(0),
+					terminate: void(0)
+				};
+
+				var events = {
+					start: function(e) {
+						fifty.global.jsh.shell.console("start!");
+						captured.start = e.detail;
+					},
+					terminate: function(e) {
+						fifty.global.jsh.shell.console("terminate!");
+						captured.terminate = e.detail;
+					}
+				};
+
+				fifty.verify(on).start.is.type("undefined");
+
+				subject.run(argument, events);
+
+				//	TODO	appears to work in latest version of TypeScript
+				//@ts-ignore
+				fifty.verify(captured).start.command.evaluate(function(p) { return String(p) }).is("ls");
+				fifty.verify(captured).start.directory.evaluate(function(directory) { return directory.toString(); }).is(here.toString());
+				fifty.verify(captured).start.pid.is.type("number");
+				fifty.verify(captured).start.kill.is.type("function");
+
+				fifty.verify(captured).terminate.status.is(0);
+
+				fifty.verify(on).start.is.type("object");
+
+				fifty.run(function argumentChecking() {
+					fifty.verify(subject).evaluate(function() {
+						this.run({
+							command: null
+						})
+					}).threw.message.is("property 'command' must not be null; full invocation = (null)");
+					fifty.verify(subject).evaluate(function() {
+						this.run({
+							command: "java",
+							arguments: [null]
+						})
+					}).threw.message.is("property 'arguments[0]' must not be null; full invocation = java (null)");
+				});
+
+				fifty.run(fifty.tests.run.stdio);
+
+				fifty.run(function directory() {
+					var jsh = fifty.global.jsh;
+					var module = subject;
+
+					var program = getJavaProgram("Directory");
+					var dir = jsh.shell.TMPDIR.createTemporary({ directory: true });
+					var result = module.java({
+						classpath: program.classpath,
+						main: program.main,
+						stdio: {
+							output: String
+						},
+						directory: dir
+					});
+					var workdir = result.stdio.output;
+					fifty.verify(workdir).is(dir.toString());
+				})
+			}
+			fifty.tests.run.stdio = function() {
+				var subject: Exports = fifty.global.jsh.shell;
+				var jsh = fifty.global.jsh;
+				var module = subject;
+				var verify = fifty.verify;
+
+				var to = jsh.shell.TMPDIR.createTemporary({ directory: true });
+				jsh.java.tools.javac({
+					destination: to.pathname,
+					arguments: [fifty.jsh.file.object.getRelativePath("test/java/inonit/jsh/test/Echo.java")]
+				});
+				var result = module.java({
+					classpath: jsh.file.Searchpath([to.pathname]),
+					main: "inonit.jsh.test.Echo",
+					stdio: {
+						input: "Hello, World!",
+						output: String
+					}
+				});
+				verify(result).stdio.output.is("Hello, World!");
+
+				var runLines = function(input) {
+					var buffered = [];
+					var rv = module.java({
+						classpath: jsh.file.Searchpath([to.pathname]),
+						main: "inonit.jsh.test.Echo",
+						stdio: {
+							input: input,
+							output: {
+								line: function(string) {
+									buffered.push(string);
+								}
+							}
+						}
+					});
+					return {
+						stdio: {
+							output: buffered
+						}
+					};
+				};
+
+				var lines: { stdio: { output: string[] }};
+				var nl = jsh.shell.os.newline;
+				lines = runLines("Hello, World!" + nl + "Line 2");
+				verify(lines).stdio.output.length.is(2);
+				verify(lines).stdio.output[0].is("Hello, World!");
+				verify(lines).stdio.output[1].is("Line 2");
+				lines = runLines("Hello, World!" + nl + "Line 2" + nl);
+				verify(lines).stdio.output.length.is(3);
+				verify(lines).stdio.output[0].is("Hello, World!");
+				verify(lines).stdio.output[1].is("Line 2");
+				verify(lines).stdio.output[2].is("");
+			}
+		}
+	//@ts-ignore
+	)(fifty);
+}
+
+namespace slime.jrunscript.shell.internal.run.old {
+	export interface Context {
+		environment: slime.jrunscript.host.Environment
+		stdio: slime.jrunscript.shell.Stdio
+		api: {
+			file: slime.jrunscript.file.Exports
+		}
+		os: {
+			name: () => string
+			newline: () => string
+		}
+		scripts: {
+			invocation: slime.jrunscript.shell.internal.invocation.Export
+			run: slime.jrunscript.shell.internal.run.Exports
+		}
+		module: {
+			events: $api.Events<any>
+		}
+	}
+
+	export interface Exports {
+		run: slime.jrunscript.shell.Exports["run"]
+		$run: any
+	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			fifty.tests.suite = function() {
+				fifty.run(fifty.tests.run);
+			}
+		}
+	//@ts-ignore
+	)(fifty);
+
+	export type Script = slime.loader.Script<Context,Exports>
+}

--- a/rhino/shell/run-old.js
+++ b/rhino/shell/run-old.js
@@ -1,0 +1,244 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+//@ts-check
+(
+	/**
+	 *
+	 * @param { slime.$api.Global } $api
+	 * @param { slime.jrunscript.shell.internal.run.old.Context } $context
+	 * @param { slime.loader.Export<slime.jrunscript.shell.internal.run.old.Exports> } $export
+	 */
+	function($api,$context,$export) {
+		var scripts = $context.scripts;
+		/**
+		 *
+		 * @param { slime.jrunscript.shell.run.old.Argument } p
+		 * @return { slime.jrunscript.shell.invocation.old.Argument["stdio"] }
+		 */
+		function extractStdioIncludingDeprecatedForm(p) {
+			if (typeof(p.stdio) != "undefined") return p.stdio;
+
+			if (typeof(p.stdin) != "undefined" || typeof(p.stdout) != "undefined" || typeof(p.stderr) != "undefined") {
+				return $api.deprecate(function() {
+					return {
+						input: p.stdin,
+						output: p.stdout,
+						error: p.stderr
+					};
+				})();
+			}
+
+			return {};
+		}
+
+		/**
+		 *
+		 * @param { Parameters<slime.jrunscript.shell.Exports["run"]>[0] } p
+		 * @param { Parameters<slime.jrunscript.shell.Exports["run"]>[1] } events
+		 */
+		var run = function(p,events) {
+			var as;
+			if (p.as) {
+				as = p.as;
+			}
+
+			p.stdio = extractStdioIncludingDeprecatedForm(p);
+
+			var context = scripts.invocation.toContext(p, $context.environment, $context.stdio);
+
+			/** @type { slime.jrunscript.shell.internal.module.Invocation } */
+			var invocation = (
+				/**
+				 *
+				 * @returns { slime.jrunscript.shell.internal.module.Invocation }
+				 */
+				function() {
+					/** @type { slime.jrunscript.shell.internal.module.Invocation } */
+					var rv = {
+						configuration: {
+							command: void(0),
+							arguments: void(0)
+						},
+						result: {
+							command: void(0),
+							arguments: void(0),
+							as: void(0)
+						}
+					};
+
+					/**
+					 * @param { slime.jrunscript.shell.invocation.old.Argument["command"] } command
+					 * @param { slime.jrunscript.shell.invocation.old.Argument["arguments"] } args
+					 * @returns { slime.jrunscript.shell.internal.run.java.Configuration }
+					 */
+					var toConfiguration = function(command,args) {
+						/**
+						 *
+						 * @param { slime.jrunscript.shell.invocation.Token } v
+						 * @returns
+						 */
+						var toErrorMessageString = function(v) {
+							if (typeof(v) == "undefined") return "(undefined)";
+							if (v === null) return "(null)";
+							return String(v);
+						};
+
+						/**
+						 *
+						 * @param { slime.jrunscript.shell.invocation.old.Argument["command"] } command
+						 * @param { slime.jrunscript.shell.invocation.old.Argument["arguments"] } args
+						 */
+						var toErrorMessage = function(command,args) {
+							/** @type { slime.jrunscript.shell.invocation.Token[] } */
+							var full = [command];
+							if (args) full = full.concat(args);
+							return full.map(toErrorMessageString).join(" ");
+						};
+
+						try {
+							return scripts.invocation.toConfiguration({
+								command: command,
+								arguments: args
+							});
+						} catch (e) {
+							if (e instanceof scripts.invocation.error.BadCommandToken) {
+								throw new TypeError(e.message + "; full invocation = " + toErrorMessage(command, args));
+							} else {
+								throw e;
+							}
+						}
+					};
+
+					if (p.tokens) {
+						return $api.deprecate(function() {
+							//	TODO	ensure array
+							if (p.tokens.length == 0) {
+								throw new TypeError("tokens cannot be zero-length.");
+							}
+							//	Use a raw copy of the arguments for the callback
+							rv.result.command = p.tokens[0];
+							rv.result.arguments = p.tokens.slice(1);
+							rv.configuration = toConfiguration(p.tokens[0], p.tokens.slice(1));
+							return rv;
+						})();
+					} else if (typeof(p.command) != "undefined") {
+						rv.result.command = p.command;
+						//	TODO	switch to $api.Function.mutating
+						rv.result.arguments = p.arguments;
+						rv.result.as = p.as;
+						rv.configuration = toConfiguration(p.command, p.arguments);
+						return rv;
+					} else {
+						throw new TypeError("Required: command property or tokens property");
+					}
+				}
+			)();
+
+			if (as) {
+				if ($context.os.name() == "Linux") {
+					invocation.configuration.command = "sudo";
+					invocation.configuration.arguments = ["-u", as.user].concat(invocation.configuration.arguments);
+				}
+			}
+
+			var directory = (typeof(context.directory) == "string") ? $context.api.file.Pathname(context.directory).directory : context.directory;
+
+			/**
+			 * @type { slime.jrunscript.shell.run.old.Argument }
+			 */
+			var input = {
+				command: invocation.result.command,
+				arguments: invocation.result.arguments,
+				environment: context.environment,
+				directory: directory
+			};
+			input.workingDirectory = directory;
+			$api.deprecate(input,"workingDirectory");
+
+			var result = scripts.run.old.run(context, invocation.configuration, $context.module, events, p, input, scripts.invocation.isLineListener);
+
+			var evaluate = (p["evaluate"]) ? p["evaluate"] : $exports.run.evaluate;
+			return evaluate($api.Object.compose(input, result));
+		};
+
+		/** @type { slime.jrunscript.shell.internal.run.old.Exports } */
+		var $exports = {
+			run: void(0),
+			$run: run
+		};
+
+		$exports.run = Object.assign(
+			$api.events.Function(run),
+			{
+				evaluate: void(0),
+				stdio: void(0)
+			}
+		);
+
+		$exports.run.evaluate = function(result) {
+			if (result.error) throw result.error;
+			if (result.status != 0) throw new Error("Exit code: " + result.status + " executing " + result.command + ((result.arguments && result.arguments.length) ? " " + result.arguments.join(" ") : ""));
+			return result;
+		};
+
+		$exports.run.stdio = Object.assign(
+			(
+				/**
+				 *
+				 * @param { Parameters<slime.jrunscript.shell.Exports["run"]>[0] } p
+				 * @return { slime.jrunscript.shell.internal.run.Stdio }
+				 */
+				function getStdio(p) {
+					//	TODO	the getStdio function is currently used in jsh.js, requiring us to export it; is that the best structure?
+					var stdio = extractStdioIncludingDeprecatedForm(p);
+
+					if (stdio) {
+						//	TODO	the below $api.Events() is highly dubious, inserted just to get past TypeScript; who knows
+						//			whether it will work but refactoring in progress may change it further
+						var fixed = scripts.invocation.updateForStringInput(stdio);
+						scripts.invocation.fallbackToParentStdio(fixed, $context.stdio);
+						var x = scripts.invocation.toStdioConfiguration(fixed);
+						var rv = scripts.run.old.buildStdio(x)($api.Events());
+						return rv;
+					}
+					if (!stdio) {
+						//	TODO	could be null if p.stdio === null. What would that mean? And what does $context.stdio have to do with
+						//			it?
+						if (!$context.stdio) {
+							if (p.stdio === null) {
+								//	That's what we thought
+							} else {
+								//	The only way rv should be anything other than an object is if p.stdio was null
+								throw new Error("Unreachable");
+							}
+						}
+						return null;
+					}
+				}
+			),
+			{
+				LineBuffered: function(o) {
+					return Object.assign({}, o, {
+						output: {
+							line: function(line) {
+								o.stdio.output.write(line + $context.os.newline());
+							}
+						},
+						error: {
+							line: function(line) {
+								o.stdio.error.write(line + $context.os.newline());
+							}
+						}
+					});
+				}
+			}
+		);
+
+		$export($exports);
+	}
+//@ts-ignore
+)($api,$context,$export);

--- a/rhino/shell/run.fifty.ts
+++ b/rhino/shell/run.fifty.ts
@@ -81,7 +81,7 @@ namespace slime.jrunscript.shell.internal.run {
 	}
 
 	export namespace test {
-		export const subject: Export = (function(fifty: slime.fifty.test.Kit) {
+		export const subject: Exports = (function(fifty: slime.fifty.test.Kit) {
 			var script: Script = fifty.$loader.script("run.js");
 			return script({
 				api: {
@@ -94,7 +94,7 @@ namespace slime.jrunscript.shell.internal.run {
 		})(fifty)
 	}
 
-	export interface Export {
+	export interface Exports {
 		run: shell.World["run"]
 
 		mock: {
@@ -156,14 +156,14 @@ namespace slime.jrunscript.shell.internal.run {
 	//@ts-ignore
 	)(fifty);
 
-	export type Script = slime.loader.Script<Context,Export>
+	export type Script = slime.loader.Script<Context,Exports>
 
 	(
 		function(
 			fifty: slime.fifty.test.Kit
 		) {
 			var loader: Script = fifty.$loader.script("run.js");
-			var subject: Export = loader({
+			var subject: Exports = loader({
 				api: {
 					java: fifty.global.jsh.java,
 					io: fifty.global.jsh.io,

--- a/rhino/shell/run.js
+++ b/rhino/shell/run.js
@@ -12,7 +12,7 @@
 	 * @param { any } JavaAdapter
 	 * @param { slime.$api.Global } $api
 	 * @param { slime.jrunscript.shell.internal.run.Context } $context
-	 * @param { slime.loader.Export<slime.jrunscript.shell.internal.run.Export> } $export
+	 * @param { slime.loader.Export<slime.jrunscript.shell.internal.run.Exports> } $export
 	 */
 	function(Packages,JavaAdapter,$api,$context,$export) {
 		/** @returns { slime.jrunscript.shell.internal.run.OutputDestination } */
@@ -396,7 +396,7 @@
 			)
 		};
 
-		/** @type { slime.jrunscript.shell.internal.run.Export["old"]["run"] } */
+		/** @type { slime.jrunscript.shell.internal.run.Exports["old"]["run"] } */
 		function oldRun(context, configuration, module, events, p, invocation, isLineListener) {
 			var rv;
 			var tell = run(context, configuration);

--- a/tools/wf.jsh.js
+++ b/tools/wf.jsh.js
@@ -95,7 +95,6 @@
 				} else {
 					//	TODO	this weird redeclaration should not be needed; type narrowing should apply to `command` here
 					var target = command;
-					//	probably run the hook?
 					return function() {
 						return target({
 							options: invocation.options,


### PR DESCRIPTION
It is now in a separate run_old.js file.

Also:
* Add slime.$api.fp.impore.Action
* Harvest tests from wf CLI into jsh.script.cli
* Add untested jsh.shell.world.exit Action
* Rename slime.jrunscript.shell.internal.run.Export to Exports