### PR TITLE
Convert Node.js location at() argument to string

### DIFF
--- a/jsh/tools/install/plugin.jsh.js
+++ b/jsh/tools/install/plugin.jsh.js
@@ -669,7 +669,7 @@
 					var location = jsh.shell.jsh.lib.getRelativePath("node");
 
 					/** @type { slime.jrunscript.node.Installation } */
-					var installed = node.at({ location: location });
+					var installed = node.at({ location: location.toString() });
 
 					function update() {
 						jsh.shell.tools.node = Object.assign(

--- a/rhino/tools/node/module.fifty.ts
+++ b/rhino/tools/node/module.fifty.ts
@@ -124,10 +124,19 @@ namespace slime.jrunscript.node {
 	}
 
 	export interface Exports {
-		at: (p: { location: slime.jrunscript.file.Pathname }) => slime.jrunscript.node.Installation
+		at: (p: { location: string }) => slime.jrunscript.node.Installation
 
 		/** @deprecated Use `at()`. */
 		Installation: new (o: { directory: slime.jrunscript.file.Directory }) => slime.jrunscript.node.Installation
+
+		install: (
+			p: {
+				version?: string
+				location: slime.jrunscript.file.Pathname
+				update?: boolean
+			},
+			events?: slime.$api.events.Handler<install.Events>
+		) => slime.jrunscript.node.Installation
 	}
 
 	(
@@ -140,7 +149,7 @@ namespace slime.jrunscript.node {
 
 			fifty.tests.installation = function() {
 				var TMPDIR = fifty.jsh.file.temporary.location();
-				verify(subject).at({ location: jsh.file.Pathname(TMPDIR.pathname) }).is(null);
+				verify(subject).at({ location: TMPDIR.pathname }).is(null);
 				subject.install({
 					location: jsh.file.Pathname(TMPDIR.pathname)
 				}, {
@@ -148,7 +157,7 @@ namespace slime.jrunscript.node {
 						jsh.shell.console(e.detail);
 					}
 				});
-				verify(subject).at({ location: jsh.file.Pathname(TMPDIR.pathname) }).is.type("object");
+				verify(subject).at({ location: TMPDIR.pathname }).is.type("object");
 			}
 		}
 	//@ts-ignore
@@ -156,14 +165,6 @@ namespace slime.jrunscript.node {
 
 	export interface Exports {
 		Project: Function,
-		install: (
-			p: {
-				version?: string,
-				location: slime.jrunscript.file.Pathname,
-				update?: boolean
-			},
-			events?: slime.$api.events.Handler<install.Events>
-		) => slime.jrunscript.node.Installation
 	}
 
 	(

--- a/rhino/tools/node/module.js
+++ b/rhino/tools/node/module.js
@@ -222,9 +222,11 @@
 
 		$exports.at = function(p) {
 			if (!p.location) throw new TypeError("Required: 'location' property.");
-			if (!p.location.directory) return null;
-			return new $exports.Installation({
-				directory: p.location.directory
+			if (typeof(p.location) != "string") throw new TypeError("'location' property must be string.");
+			var location = $context.module.file.Pathname(p.location);
+			if (!location.directory) return null;
+			return new Installation({
+				directory: location.directory
 			})
 		};
 
@@ -261,7 +263,7 @@
 				if (!p) throw new TypeError();
 				//	TODO	compute this somehow?
 				if (!p.version) p.version = versions.default;
-				var existing = $exports.at({ location: p.location });
+				var existing = $exports.at({ location: p.location.toString() });
 				/** @type { slime.jrunscript.node.Installation } */
 				var rv;
 				if (!existing || (existing.version.number != p.version && p.update)) {


### PR DESCRIPTION
Tools like this should use string arguments as they cannot run these
tools from arbitrary filesystems, presumably