### PR TITLE
Implement standard post-checkout git hook

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,7 @@
 			"problemMatcher": []
 		},
 		{
-			"label": "status",
+			"label": "Show git status",
 			"type": "shell",
 			"command": "./wf status",
 			"problemMatcher": [],
@@ -29,19 +29,14 @@
 			}
 		},
 		{
-			"label": "Switch to trunk",
-			"type" :"shell",
-			"command": "./wf git.trunk",
-			"problemMatcher": []
-		},
-		{
-			"label": "Switch to branch",
+			"label": "Create branch",
+			"detail": "Creates a new branch based on newly-fetched origin/master and checks it out.",
 			"type": "shell",
 			"command": "./wf git.branch ${input:branchName}",
 			"problemMatcher": []
 		},
 		{
-			"label": "eslint",
+			"label": "Run eslint",
 			"type": "shell",
 			"command": "./wf eslint",
 			"problemMatcher": [],
@@ -55,7 +50,7 @@
 			}
 		},
 		{
-			"label": "ESLint Report",
+			"label": "Show ESLint report",
 			"type": "shell",
 			"command": "./jsh.bash contributor/eslint-report.jsh.js",
 			"problemMatcher": [],
@@ -69,7 +64,7 @@
 			}
 		},
 		{
-			"label": "tsc",
+			"label": "Check static types",
 			"type": "shell",
 			"command": "./wf tsc",
 			"problemMatcher": [],
@@ -83,7 +78,7 @@
 			}
 		},
 		{
-			"label": "documentation",
+			"label": "Show Documentation",
 			"detail": "Serves the project documentation and opens a browser to view it",
 			"type": "shell",
 			"command": "./wf documentation",
@@ -98,21 +93,6 @@
 			},
 			"runOptions": {
 				"runOn": "folderOpen"
-			}
-		},
-		{
-			"label": "document",
-			"detail": "Serves the project documentation and opens a browser to view it, re-rendering the documentation as it changes",
-			"type": "shell",
-			"command": "./wf document",
-			"problemMatcher": [],
-			"presentation": {
-				"echo": true,
-				"reveal": "always",
-				"focus": false,
-				"panel": "shared",
-				"showReuseMessage": true,
-				"clear": true
 			}
 		}
 	],

--- a/rhino/tools/git/module.fifty.ts
+++ b/rhino/tools/git/module.fifty.ts
@@ -770,6 +770,24 @@ namespace slime.jrunscript.tools.git {
 		status: Command<void,command.status.Result>
 	}
 
+	export interface Commands {
+		fetch: Command<void,void>
+	}
+
+	export interface Commands {
+		merge: Command<{ name: string }, void>
+	}
+
+	export interface Exports {
+		/**
+		 * An opinionated object that provides a set of {@link Command} implementations deemed to be useful for `git` automation.
+		 * If the exact combination of git commands and options for your use case is not provided here, you can implement your own
+		 * {@link Command} which can be tailored to any set of commands, arguments, and options, any way of parsing output, and so
+		 * forth.
+		 */
+		commands: Commands
+	}
+
 	export namespace world {
 		export interface Invocation<P,R> {
 			program: Program
@@ -808,10 +826,6 @@ namespace slime.jrunscript.tools.git {
 				run: (invocation: slime.jrunscript.shell.run.Invocation) => slime.$api.fp.impure.Tell<slime.jrunscript.shell.run.Events>
 			}
 		}
-	}
-
-	export interface Exports {
-		commands: Commands
 	}
 
 	export namespace exports {

--- a/rhino/tools/git/module.js
+++ b/rhino/tools/git/module.js
@@ -70,6 +70,29 @@
 			}
 		}
 
+		/**
+		 * @type { slime.jrunscript.tools.git.Exports["commands"]["fetch"] }
+		 */
+		var fetch = {
+			invocation: function() {
+				return {
+					command: "fetch"
+				}
+			}
+		}
+
+		/** @type { slime.jrunscript.tools.git.Command<{ name: string }, void> } */
+		var merge = {
+			invocation: function(p) {
+				return {
+					command: "merge",
+					arguments: $api.Array.build(function(rv) {
+						rv.push(p.name);
+					})
+				}
+			}
+		}
+
 		/** @type { new (environment: Parameters<slime.jrunscript.tools.git.Exports["Installation"]>[0] ) => slime.jrunscript.tools.git.Installation } */
 		var Installation = function(environment) {
 
@@ -1326,7 +1349,7 @@
 		});
 
 		$exports.install = Object.assign(
-			$api.Events.Function(
+			$api.events.Function(
 				function(p,events) {
 					var console = function(message) {
 						events.fire("console", message);
@@ -1385,7 +1408,9 @@
 		};
 
 		$exports.commands = {
-			status: status
+			status: status,
+			fetch: fetch,
+			merge: merge
 		};
 
 		/**

--- a/tools/wf.jsh.js
+++ b/tools/wf.jsh.js
@@ -88,7 +88,7 @@
 
 				var command = jsh.script.cli.Call.get({
 					descriptor: descriptor,
-					arguments: [match[0]]
+					arguments: jsh.script.arguments
 				});
 				if (isNoTargetProvided(command)) {
 					//	this can't happen because we already are checking whether the first argument begins with git.hook

--- a/tools/wf/plugin-standard.jsh.js
+++ b/tools/wf/plugin-standard.jsh.js
@@ -427,6 +427,19 @@
 					}
 				}
 
+				$exports.git.hooks["post-checkout"] = function() {
+					var repository = jsh.tools.git.program({ command: "git" }).repository($context.base.pathname.toString());
+					var origin = repository.command(jsh.wf.git.commands.remoteShow).argument("origin").run();
+					var trunk = origin.head;
+					var status = repository.command(jsh.tools.git.commands.status).argument().run();
+					if (status.branch == trunk) {
+						repository.command(jsh.tools.git.commands.fetch).argument().run();
+						repository.command(jsh.tools.git.commands.merge).argument({ name: "origin/" + trunk }).run();
+						//	TODO	below is implemented in top-level wf.js, and is used in git.branches.prune
+						// cleanGitBranches()();
+					}
+				}
+
 				$exports.submodule = {
 					update: (project.precommit) ? $api.Function.pipe(
 						/**

--- a/tools/wf/plugin.jsh.js
+++ b/tools/wf/plugin.jsh.js
@@ -102,6 +102,12 @@
 					},
 					git: {
 						installHooks: function(p) {
+							var ALL_GIT_HOOKS = [
+								"pre-commit",
+								"post-checkout",
+								"post-merge"
+							];
+
 							if (gitInstalled && isGitClone) {
 								var path = (p) ? p.path : "local/git/hooks";
 								var repository = jsh.tools.git.program({ command: "git" }).repository(base.toString())
@@ -114,9 +120,9 @@
 									repository.command(setConfigValue).argument({ name: "core.hookspath", value: path }).run();
 								}
 								if (!p) {
-									["pre-commit"].forEach(function(hook) {
+									ALL_GIT_HOOKS.forEach(function(hook) {
 										var location = base.getRelativePath(path + "/" + hook);
-										location.write("./wf " + "git.hooks." + hook, { append: false, recursive: true });
+										location.write("./wf " + "git.hooks." + hook + " " + "\"$@\"", { append: false, recursive: true });
 										jsh.shell.run({
 											command: "chmod",
 											arguments: $api.Array.build(function(rv) {
@@ -522,7 +528,7 @@
 					}
 
 					return $api.Function.impure.ask(function(events) {
-						events.fire("console", "Verifying git identity ...");
+						events.fire("debug", "Verifying git identity ...");
 						var config = p.repository.config({
 							arguments: ["--list"]
 						});

--- a/wf.js
+++ b/wf.js
@@ -498,24 +498,6 @@
 						}
 					);
 
-					$exports.git.trunk = function(p) {
-						/** @type { slime.jrunscript.tools.git.Command<{ name: string }, void> } */
-						var merge = {
-							invocation: function(p) {
-								return {
-									command: "merge",
-									arguments: $api.Array.build(function(rv) {
-										rv.push(p.name);
-									})
-								}
-							}
-						}
-						git.repository.command(git.command.fetch).argument().run();
-						git.repository.command(git.command.checkout).argument({ branch: "master" }).run();
-						git.repository.command(merge).argument({ name: "origin/master" }).run();
-						cleanGitBranches()();
-					};
-
 					$exports.git.branches = (jsh.tools.git.Repository) ? {
 						list: $api.Function.pipe(
 							function(p) {


### PR DESCRIPTION
The hook performs a fetch and merge if the origin HEAD was checked out.

Also:
* Remove redundant git.trunk wf command
* Improve VSCode task names / descriptions
* Add standard fetch and merge commands to git API
* Correctly pass through git hook arguments to wf git.hook.* commands