### PR TITLE
Rename TypeScript interfaces for internal scripts

### DIFF
--- a/loader/document/module.js
+++ b/loader/document/module.js
@@ -306,7 +306,8 @@
 			if (parsers.jsoup) return parsers.jsoup;
 		})();
 
-		/** @type { slime.runtime.document.source.Exports } */
+		//	TODO	switch to Script
+		/** @type { slime.runtime.document.internal.source.Exports } */
 		var source = $loader.file("source.js");
 
 		/** @type { slime.Codec<slime.runtime.document.Document,string> } */

--- a/loader/document/source.fifty.ts
+++ b/loader/document/source.fifty.ts
@@ -18,7 +18,17 @@ namespace slime.runtime.document {
 		}
 	}
 }
-namespace slime.runtime.document.source {
+
+namespace slime.runtime.document.internal.source {
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			fifty.tests.manual = {};
+		}
+	//@ts-ignore
+	)(fifty);
+
 	export type ParseEvents = {
 		startTag: string
 		startElement: string
@@ -64,7 +74,7 @@ namespace slime.runtime.document.source {
 
 	export namespace internal {
 		export namespace test {
-			export const subject: slime.runtime.document.source.Exports = (function(fifty: fifty.test.Kit) {
+			export const subject: slime.runtime.document.internal.source.Exports = (function(fifty: fifty.test.Kit) {
 				return fifty.$loader.module("source.js");
 			//@ts-ignore
 			})(fifty)
@@ -360,6 +370,13 @@ namespace slime.runtime.document.source {
 				}
 
 				fifty.verify(input == serialized, "page == serialized").is(true);
+			}
+
+			fifty.tests.manual.fidelity = function() {
+				const { jsh } = fifty.global;
+
+				var markup = jsh.file.Pathname(jsh.shell.environment.MARKUP).file.read(String);
+				fifty.tests.fidelity(markup);
 			}
 		}
 	//@ts-ignore

--- a/loader/document/source.js
+++ b/loader/document/source.js
@@ -8,14 +8,14 @@
 (
 	/**
 	 * @param { slime.$api.Global } $api
-	 * @param { slime.loader.Export<slime.runtime.document.source.Exports> } $export
+	 * @param { slime.loader.Export<slime.runtime.document.internal.source.Exports> } $export
 	 */
 	function($api,$export) {
 		//	TODO	for HTML, use this: https://html.spec.whatwg.org/multipage/syntax.html#optional-tags
 
 		/**
 		 *
-		 * @param { slime.runtime.document.source.internal.Position } position
+		 * @param { slime.runtime.document.internal.source.internal.Position } position
 		 * @returns { string }
 		 */
 		function after(position) {
@@ -46,7 +46,7 @@
 		var State = (function() {
 			/**
 			 *
-			 * @param { slime.runtime.document.source.internal.State } state
+			 * @param { slime.runtime.document.internal.source.internal.State } state
 			 * @returns
 			 */
 			var remaining = function(state) {
@@ -57,10 +57,10 @@
 
 				/**
 				 *
-				 * @param { slime.runtime.document.source.internal.State } state
+				 * @param { slime.runtime.document.internal.source.internal.State } state
 				 * @param { slime.runtime.document.Node } node
 				 * @param { number } advance
-				 * @returns { slime.runtime.document.source.internal.State }
+				 * @returns { slime.runtime.document.internal.source.internal.State }
 				 */
 				step: function(state,node,advance) {
 					return {
@@ -73,7 +73,7 @@
 				},
 				/**
 				 *
-				 * @param { slime.runtime.document.source.internal.State } state
+				 * @param { slime.runtime.document.internal.source.internal.State } state
 				 */
 				atEnd: function(state) {
 					if (state.position.offset > state.position.document.length) throw new Error("Attempt to read past end of input.");
@@ -131,7 +131,7 @@
 		});
 
 		/**
-		 * @type { slime.runtime.document.source.internal.Step }
+		 * @type { slime.runtime.document.internal.source.internal.Step }
 		 */
 		var parseXmlDeclaration = function(state) {
 			var end = state.position.document.indexOf("?>");
@@ -143,7 +143,7 @@
 		}
 
 		/**
-		 * @type { slime.runtime.document.source.internal.Step }
+		 * @type { slime.runtime.document.internal.source.internal.Step }
 		 */
 		var parseCdata = function(state) {
 			var remaining = State.remaining(state);
@@ -159,7 +159,7 @@
 		}
 
 		/**
-		 * @type { slime.runtime.document.source.internal.Step }
+		 * @type { slime.runtime.document.internal.source.internal.Step }
 		 */
 		var parseComment = function(state) {
 			var left = State.remaining(state);
@@ -174,7 +174,7 @@
 		}
 
 		/**
-		 * @type { slime.runtime.document.source.internal.Step }
+		 * @type { slime.runtime.document.internal.source.internal.Step }
 		 */
 		var parseDoctype = function(state) {
 			var left = State.remaining(state);
@@ -194,7 +194,7 @@
 		}
 
 		/**
-		 * @type { slime.runtime.document.source.internal.Step }
+		 * @type { slime.runtime.document.internal.source.internal.Step }
 		 */
 		var parseText = function(state) {
 			var left = State.remaining(state);
@@ -245,10 +245,10 @@
 			return /\s/.test(c);
 		}
 
-		/** @type { slime.runtime.document.source.internal.Export["parseStartTag"] } */
+		/** @type { slime.runtime.document.internal.source.internal.Export["parseStartTag"] } */
 		function parseStartTag(string) {
 			var index = 0;
-			/** @type { ReturnType<slime.runtime.document.source.internal.Export["parseStartTag"]> } */
+			/** @type { ReturnType<slime.runtime.document.internal.source.internal.Export["parseStartTag"]> } */
 			var rv = {
 				tag: "",
 				attributes: "",
@@ -277,10 +277,10 @@
 		}
 
 		/**
-		 * @param { slime.runtime.document.source.internal.State } state
-		 * @param { slime.$api.Events<slime.runtime.document.source.ParseEvents> } events
-		 * @param { slime.runtime.document.source.internal.Parser<slime.runtime.document.Parent> } recurse
-		 * @returns { slime.runtime.document.source.internal.State }
+		 * @param { slime.runtime.document.internal.source.internal.State } state
+		 * @param { slime.$api.Events<slime.runtime.document.internal.source.ParseEvents> } events
+		 * @param { slime.runtime.document.internal.source.internal.Parser<slime.runtime.document.Parent> } recurse
+		 * @returns { slime.runtime.document.internal.source.internal.State }
 		 */
 		var parseElement = function(state,events,recurse) {
 			//	TODO	special handling for SCRIPT
@@ -375,7 +375,7 @@
 
 			var attributes = toAttributes([], parsed.attributes);
 
-			/** @type { slime.runtime.document.source.internal.State<slime.runtime.document.Element> } */
+			/** @type { slime.runtime.document.internal.source.internal.State<slime.runtime.document.Element> } */
 			var substate = {
 				parsed: {
 					type: "element",
@@ -444,21 +444,21 @@
 			}
 		}
 
-		/** @returns { slime.runtime.document.source.internal.Parser<slime.runtime.document.Parent> } */
+		/** @returns { slime.runtime.document.internal.source.internal.Parser<slime.runtime.document.Parent> } */
 		var Parser = function(configuration) {
 			/**
 			 *
-			 * @param { slime.runtime.document.source.internal.State } state
-			 * @param { slime.$api.Events<slime.runtime.document.source.ParseEvents> } events
-			 * @param { (state: slime.runtime.document.source.internal.State) => boolean } finished
-			 * @returns { slime.runtime.document.source.internal.State }
+			 * @param { slime.runtime.document.internal.source.internal.State } state
+			 * @param { slime.$api.Events<slime.runtime.document.internal.source.ParseEvents> } events
+			 * @param { (state: slime.runtime.document.internal.source.internal.State) => boolean } finished
+			 * @returns { slime.runtime.document.internal.source.internal.State }
 			 */
 			return function recurse(state,events,finished) {
 				if (finished(state)) {
 					return state;
 				}
 
-				/** @type { slime.runtime.document.source.internal.State } */
+				/** @type { slime.runtime.document.internal.source.internal.State } */
 				var next;
 
 				//	HTML stuff
@@ -494,7 +494,7 @@
 					next = parseText(state);
 				} else {
 					//	skip to end of the thing
-					/** @type { slime.runtime.document.source.internal.Unparsed } */
+					/** @type { slime.runtime.document.internal.source.internal.Unparsed } */
 					var rest = {
 						type: "unparsed",
 						string: State.remaining(state)
@@ -610,7 +610,7 @@
 
 		/**
 		 *
-		 * @param { Parameters<slime.runtime.document.source.Exports["parse"]>[0] } input
+		 * @param { Parameters<slime.runtime.document.internal.source.Exports["parse"]>[0] } input
 		 * @returns
 		 */
 		var parse = function(input) {
@@ -659,7 +659,7 @@
 					/** @type { string[] } */
 					var stack = [];
 					/**
-					 * @type { slime.$api.events.Handler<slime.runtime.document.source.ParseEvents> }
+					 * @type { slime.$api.events.Handler<slime.runtime.document.internal.source.ParseEvents> }
 					 */
 					var rv = {
 						startElement: function(e) {

--- a/loader/document/test/manual/fidelity.jsh.js
+++ b/loader/document/test/manual/fidelity.jsh.js
@@ -19,7 +19,7 @@
 		//	TODO	there should be jsh.loader.script
 		var base = jsh.shell.jsh.src;
 		var loader = new jsh.file.Loader({ directory: base });
-		/** @type { slime.runtime.document.source.Script } */
+		/** @type { slime.runtime.document.internal.source.Script } */
 		var script = loader.script("loader/document/source.js");
 		var subject = script();
 		jsh.shell.console("markup = " + invocation.options.markup);


### PR DESCRIPTION
Adds .internal to the name

Also:
* Implement manual test for parser/serializer fidelity that takes a
pathname environment parameter and tests the file for fidelity