### PR TITLE
#492: Hide profiler viewer threads under threshold

### DIFF
--- a/rhino/tools/profiler/_.fifty.ts
+++ b/rhino/tools/profiler/_.fifty.ts
@@ -157,4 +157,8 @@ namespace slime.jrunscript.tools.profiler.rhino {
 			root: Node
 		}
 	}
+
+	export type Hotspots = {
+		[key: string]: Statistics
+	}
 }

--- a/tools/wf/plugin-standard.jsh.fifty.ts
+++ b/tools/wf/plugin-standard.jsh.fifty.ts
@@ -389,6 +389,7 @@ namespace slime.jsh.wf {
 							command: getSlimePath("jsh.bash").pathname,
 							arguments: $api.Array.build(function(rv) {
 								rv.push(getSlimePath("jsh/tools/profile.jsh.js").pathname);
+								rv.push("--profiler:output:json", fifty.jsh.file.relative("../../local/wf/profile.json").pathname);
 								rv.push(getSlimePath("tools/wf.jsh.js").pathname);
 								rv.push("initialize");
 								rv.push("--test-skip-git-identity-requirement");
@@ -396,6 +397,8 @@ namespace slime.jsh.wf {
 							directory: getSlimePath(".").pathname
 						})
 					)();
+					var url = "http://documentation.slime/rhino/tools/profiler/viewer/viewer.html?profiles=../../../../local/wf/profile.json";
+					jsh.shell.console("Open " + url + " in documentation browser.");
 				}
 			}
 		//@ts-ignore


### PR DESCRIPTION
Previously nodes under a threshold were hidden, but an application with
many small threads would clutter the UI with them, obscuring the big
picture.