### PR TITLE
#485: create accurate fixture failing precommit

### DIFF
--- a/rhino/tools/git/commands.fifty.ts
+++ b/rhino/tools/git/commands.fifty.ts
@@ -22,64 +22,9 @@ namespace slime.jrunscript.tools.git.internal.commands {
 		};
 
 		export const fixtures = (function(fifty: slime.fifty.test.Kit) {
-			const { $api, jsh } = fifty.global;
-
-			var program = jsh.tools.git.program({ command: "git" });
-
-			var init: slime.jrunscript.tools.git.Command<void,void> = {
-				invocation: function(p) {
-					return {
-						command: "init"
-					}
-				}
-			}
-
-			function empty(): Repository {
-				var tmp = fifty.jsh.file.temporary.directory();
-				var repository = jsh.tools.git.program({ command: "git" }).repository(tmp.pathname);
-				repository.command(init).argument().run();
-				return {
-					location: tmp,
-					api: repository
-				}
-			}
-
-			function edit(repository: Repository, path: string, change: (before: string) => string) {
-				var target = $api.Function.result(
-					repository.location,
-					jsh.file.world.Location.relative(path)
-				);
-
-				var before = $api.Function.result(
-					target,
-					$api.Function.pipe(
-						jsh.file.world.Location.file.read.string(),
-						$api.Function.world.handler.ask(),
-						$api.Function.world.input,
-						$api.Function.Maybe.else(function() {
-							return null as string;
-						})
-					)
-				);
-
-				var edited = change(before);
-
-				var process = $api.Function.result(
-					target,
-					$api.Function.pipe(
-						jsh.file.world.Location.file.write.string({ value: edited }),
-						$api.Function.world.handler.tell()
-					)
-				);
-
-				$api.Function.world.process(process);
-			}
-
-			return {
-				program,
-				empty,
-				edit
-			};
+			const script: slime.jrunscript.tools.git.test.fixtures.Script = fifty.$loader.script("fixtures.ts");
+			var setup = script();
+			return setup(fifty);
 		//@ts-ignore
 		})(fifty);
 	}

--- a/rhino/tools/git/fixtures.ts
+++ b/rhino/tools/git/fixtures.ts
@@ -1,0 +1,92 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+namespace slime.jrunscript.tools.git.test.fixtures {
+	export interface Context {
+	}
+
+	export type Exports = (fifty: slime.fifty.test.Kit) => {
+		program: ReturnType<slime.jsh.Global["tools"]["git"]["program"]>
+		empty: () => Repository
+		edit: (repository: Repository, path: string, change: (before: string) => string) => void
+	}
+
+	export type Repository = {
+		location: slime.jrunscript.file.world.Location
+		api: ReturnType<ReturnType<slime.jrunscript.tools.git.Exports["program"]>["repository"]>
+	};
+
+	(
+		function(
+			$export: slime.loader.Export<Exports>
+		) {
+			$export(function(fifty: slime.fifty.test.Kit) {
+				const { $api, jsh } = fifty.global;
+
+				var program = jsh.tools.git.program({ command: "git" });
+
+				var init: slime.jrunscript.tools.git.Command<void,void> = {
+					invocation: function(p) {
+						return {
+							command: "init"
+						}
+					}
+				}
+
+				function empty(): Repository {
+					var tmp = fifty.jsh.file.temporary.directory();
+					var repository = jsh.tools.git.program({ command: "git" }).repository(tmp.pathname);
+					repository.command(init).argument().run();
+					return {
+						location: tmp,
+						api: repository
+					}
+				}
+
+				function edit(repository: Repository, path: string, change: (before: string) => string) {
+					var target = $api.Function.result(
+						repository.location,
+						jsh.file.world.Location.relative(path)
+					);
+
+					var before = $api.Function.result(
+						target,
+						$api.Function.pipe(
+							jsh.file.world.Location.file.read.string(),
+							$api.Function.world.handler.ask(),
+							$api.Function.world.input,
+							$api.Function.Maybe.else(function() {
+								return null as string;
+							})
+						)
+					);
+
+					var edited = change(before);
+
+					var process = $api.Function.result(
+						target,
+						$api.Function.pipe(
+							jsh.file.world.Location.file.write.string({ value: edited }),
+							$api.Function.world.handler.tell()
+						)
+					);
+
+					$api.Function.world.process(process);
+				}
+
+				return {
+					program,
+					empty,
+					edit
+				};
+			//@ts-ignore
+			})
+		}
+	//@ts-ignore
+	)($export);
+
+	export type Script = slime.loader.Script<Context,Exports>
+}

--- a/tools/wf/test/data/plugin-standard/wf.js
+++ b/tools/wf/test/data/plugin-standard/wf.js
@@ -13,6 +13,7 @@
 	 * @param { slime.jsh.wf.standard.Interface } $exports
 	 */
 	function(jsh,$context,$exports) {
+		jsh.wf.project.git.installHooks();
 		jsh.wf.project.initialize(
 			$context,
 			{

--- a/tools/wf/test/fixtures.ts
+++ b/tools/wf/test/fixtures.ts
@@ -109,6 +109,8 @@ namespace slime.jsh.wf.test {
 					)();
 					var rv = jsh.tools.git.Repository({ directory: jsh.file.Pathname(destination.pathname).directory });
 					if (p.commit && rv.status().paths) {
+						//	Add untracked files
+						rv.add({ path: "." });
 						rv.commit({
 							all: true,
 							message: p.commit.message


### PR DESCRIPTION
Also:
* Create separate script for git fixtures
* In fixture standard wf project, install git hooks
* In git mock clone implementation, add untracked files to commit