### PR TITLE
Add mock subprocesses to rhino/shell run()

### DIFF
--- a/rhino/shell/fixtures.ts
+++ b/rhino/shell/fixtures.ts
@@ -1,0 +1,119 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+namespace slime.jrunscript.shell.test {
+	export interface Context {
+	}
+
+	export namespace run {
+		export type Delegate = (invocation: slime.jrunscript.shell.run.Invocation) => slime.jrunscript.shell.run.Mock
+	}
+
+	export interface Fixtures {
+		run: {
+			createMockWorld: (delegate: run.Delegate) => slime.jrunscript.shell.run.World
+		}
+	}
+
+	(
+		function($context: Context, $export: slime.loader.Export<Fixtures>) {
+			var isLineWithProperty = function(name) {
+				return function(line) {
+					return Boolean(line[name]);
+				}
+			}
+
+			var hasLineWithProperty = function(name) {
+				return function(lines) {
+					return lines && lines.some(isLineWithProperty(name));
+				}
+			};
+
+			var createMockWorld = function(delegate: slime.jrunscript.shell.test.run.Delegate): slime.jrunscript.shell.run.World {
+				return {
+					start: function(p) {
+						var killed = false;
+
+						var result = delegate({
+							context: p.context,
+							configuration: p.configuration
+						});
+						return {
+							pid: result.pid || 0,
+							kill: function() {
+								killed = true;
+							},
+							run: function() {
+								var stdio = p.context.stdio;
+								var events = p.events;
+
+								//	TODO	should emit at least one empty line for each if line buffering
+								//	TODO	the below appears as though it would skip blank lines; should use isLineWithProperty and then
+								//			fix that method
+								if (result.lines) result.lines.forEach(function(line) {
+									if (killed) return;
+									if (stdio.output == "line" && line["stdout"]) {
+										events.fire("stdout", { line: line["stdout"] });
+									} else if (stdio.error == "line" && line["stderr"]) {
+										events.fire("stderr", { line: line["stderr"] });
+									}
+								});
+
+								/**
+								 *
+								 * @param { string } stdioName
+								 * @param { string } eventName
+								 * @returns { string }
+								 */
+								var getStdioProperty = function(stdioName, eventName) {
+									if (stdio[stdioName] == "line" || stdio[stdioName] == "string") {
+										if (hasLineWithProperty(eventName)(result.lines)) {
+											return result.lines.filter(isLineWithProperty(eventName)).map(function(entry) {
+												return entry[eventName]
+											}).join("\n");
+										}
+										if (result.exit.stdio && result.exit.stdio[stdioName]) return result.exit.stdio[stdioName];
+										return "";
+									}
+									return void(0);
+								};
+
+								if (!killed) {
+									return {
+										status: result.exit.status,
+										stdio: {
+											output: getStdioProperty("output", "stdout"),
+											error: getStdioProperty("error", "stderr")
+										}
+									};
+								} else {
+									return {
+										status: 143,
+										//	TODO	the below is wrong, should terminate output and include only what happened
+										//			before being killed
+										stdio: {
+											output: getStdioProperty("output", "stdout"),
+											error: getStdioProperty("error", "stderr")
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			};
+
+			$export({
+				run: {
+					createMockWorld: createMockWorld
+				}
+			})
+		}
+	//@ts-ignore
+	)($context,$export);
+
+	export type Script = slime.loader.Script<Context,Fixtures>
+}

--- a/rhino/shell/invocation.fifty.ts
+++ b/rhino/shell/invocation.fifty.ts
@@ -5,7 +5,7 @@
 //	END LICENSE
 
 namespace slime.jrunscript.shell {
-	export namespace test {
+	export namespace internal.invocation.test {
 		export const subject = (function(fifty: slime.fifty.test.Kit) {
 			const code: slime.jrunscript.shell.internal.invocation.Script = fifty.$loader.script("invocation.js");
 			return code();
@@ -161,7 +161,7 @@ namespace slime.jrunscript.shell {
 			fifty.tests.invocation = {};
 
 			fifty.tests.invocation.sudo = function() {
-				var sudoed = test.subject.invocation.sudo()(fifty.global.jsh.shell.Invocation.old({
+				var sudoed = internal.invocation.test.subject.invocation.sudo()(fifty.global.jsh.shell.Invocation.old({
 					command: "ls"
 				}));
 
@@ -174,7 +174,7 @@ namespace slime.jrunscript.shell {
 				var parent = fifty.global.jsh.shell.environment;
 				fifty.verify(parent).evaluate.property("PATH").is.type("string");
 				fifty.verify(parent).evaluate.property("TO_BASH_SCRIPT_EXAMPLE").is(void(0));
-				var script = test.subject.invocation.toBashScript()({
+				var script = internal.invocation.test.subject.invocation.toBashScript()({
 					command: "foo",
 					arguments: ["bar", "baz"],
 					directory: "/path/to/use",
@@ -229,7 +229,7 @@ namespace slime.jrunscript.shell {
 		function(
 			fifty: slime.fifty.test.Kit
 		) {
-			const subject = test.subject;
+			const subject = internal.invocation.test.subject;
 
 			fifty.tests.suite = function() {
 				var jsh = fifty.global.jsh;

--- a/rhino/shell/module.fifty.ts
+++ b/rhino/shell/module.fifty.ts
@@ -34,6 +34,9 @@ namespace slime.jrunscript.shell {
 			httpd: any
 			xml: any
 		}
+		world?: {
+			run?: slime.jrunscript.shell.run.World
+		}
 	}
 
 	export interface Exports {
@@ -422,7 +425,7 @@ namespace slime.jrunscript.shell {
 		world: World
 	}
 
-	export type Loader = slime.loader.Script<Context,Exports>;
+	export type Script = slime.loader.Script<Context,Exports>;
 
 	export namespace sudo {
 		export interface Settings {
@@ -458,6 +461,9 @@ namespace slime.jrunscript.shell {
 		run: slime.$api.fp.impure.Action<run.Invocation,run.TellEvents>
 
 		/**
+		 * @deprecated Replaced by the {@link Context} `world.run` property, which allows a mock implementation to be used when
+		 * loading the module. A mock implementation is provided in {@link slime.jrunscript.shell.test.Fixtures}.
+		 *
 		 * Allows a mock implementation of the `run` action to be created using a function that receives an invocation as an
 		 * argument and returns an object describing what the mocked subprocess should do. The system will use this object to create
 		 * the appropriate `Tell` and fire the appropriate events to the caller.

--- a/rhino/shell/module.js
+++ b/rhino/shell/module.js
@@ -97,7 +97,8 @@
 					java: $context.api.java,
 					io: $context.api.io,
 					file: $context.api.file
-				}
+				},
+				world: ($context.world && $context.world.run)
 			});
 			var invocation = code.invocation({
 				library: {

--- a/rhino/shell/plugin.jsh.js
+++ b/rhino/shell/plugin.jsh.js
@@ -27,7 +27,7 @@
 				}
 
 				var code = {
-					/** @type { slime.jrunscript.shell.Loader } */
+					/** @type { slime.jrunscript.shell.Script } */
 					module: $loader.script("module.js")
 				}
 

--- a/rhino/shell/run.fifty.ts
+++ b/rhino/shell/run.fifty.ts
@@ -96,6 +96,7 @@ namespace slime.jrunscript.shell.internal.run {
 			io: slime.jrunscript.io.Exports
 			file: slime.jrunscript.file.Exports
 		}
+		world?: slime.jrunscript.shell.run.World
 	}
 
 	export interface OutputDestination {

--- a/rhino/shell/run.js
+++ b/rhino/shell/run.js
@@ -294,7 +294,9 @@
 			 * @param { slime.$api.Events<slime.jrunscript.shell.run.TellEvents> } events
 			 */
 			return function(events) {
-				var subprocess = realWorld.start({
+				var world = $context.world || realWorld;
+
+				var subprocess = world.start({
 					context: context,
 					configuration: configuration,
 					events: events
@@ -323,6 +325,7 @@
 			);
 		};
 
+		//	TODO	next two functions also copy-pasted into fixtures
 		var isLineWithProperty = function(name) {
 			return function(line) {
 				return Boolean(line[name]);

--- a/rhino/tools/gcloud/module.fifty.ts
+++ b/rhino/tools/gcloud/module.fifty.ts
@@ -45,11 +45,6 @@ namespace slime.jrunscript.tools.gcloud {
 			shell: slime.jrunscript.shell.Exports
 			install: slime.jrunscript.tools.install.Exports
 		}
-		mock?: {
-			shell?: {
-				run: Parameters<slime.jrunscript.shell.World["mock"]>[0]
-			}
-		}
 	}
 
 	export interface Exports {
@@ -113,16 +108,48 @@ namespace slime.jrunscript.tools.gcloud {
 				}
 			)();
 
+			var code: {
+				shell: {
+					module: slime.jrunscript.shell.Script
+					fixtures: slime.jrunscript.shell.test.Script
+				}
+			} = {
+				shell: {
+					module: fifty.$loader.script("../../../rhino/shell/module.js"),
+					fixtures: fifty.$loader.script("../../../rhino/shell/fixtures.ts")
+				}
+			};
+
+			var fixtures = {
+				shell: code.shell.fixtures()
+			};
+
+			var library = {
+				shell: code.shell.module({
+					_environment: void(0),
+					_properties: void(0),
+					api: {
+						js: void(0),
+						java: jsh.java,
+						io: jsh.io,
+						file: jsh.file,
+						document: void(0),
+						httpd: void(0),
+						xml: void(0)
+					},
+					kotlin: void(0),
+					stdio: void(0),
+					world: {
+						run: fixtures.shell.run.createMockWorld(captor.mock)
+					}
+				})
+			}
+
 			const subject = script({
 				library: {
 					file: jsh.file,
-					shell: jsh.shell,
+					shell: library.shell,
 					install: jsh.tools.install
-				},
-				mock: {
-					shell: {
-						run: captor.mock
-					}
 				}
 			});
 

--- a/rhino/tools/gcloud/module.js
+++ b/rhino/tools/gcloud/module.js
@@ -13,7 +13,7 @@
 	 * @param { slime.loader.Export<slime.jrunscript.tools.gcloud.Exports> } $export
 	 */
 	function($api,$context,$export) {
-		var run = ($context.mock && $context.mock.shell) ? $context.library.shell.world.mock($context.mock.shell.run) : $context.library.shell.world.run;
+		var run = $context.library.shell.world.run;
 
 		/**
 		 *


### PR DESCRIPTION
The module's run implementation can now be configured with a mock run
world via the $context.world.run property