### PR TITLE
Resolve #573: Update TypeDoc to 0.23.5

### DIFF
--- a/contributor/code/license.jsh.js
+++ b/contributor/code/license.jsh.js
@@ -150,6 +150,7 @@
 			var extension = getExtension(file);
 			if (files[i].path == ".eslintrc.json") extension = "js";
 			if (files[i].path == "jsconfig.json") extension = "js";
+			if (files[i].path == "typedoc.json") extension = "js";
 			if (files[i].path == ".devcontainer/devcontainer.json") extension = "js";
 			if (files[i].path == "rhino/tools/github/tools/dtsgen.json") extension = "js";
 			if (files[i].path == "rhino/tools/docker/tools/dtsgen.json") extension = "js";

--- a/loader/expression.fifty.ts
+++ b/loader/expression.fifty.ts
@@ -542,18 +542,6 @@ namespace slime {
 			})(fifty);
 		}
 
-		/**
-		 * An object provided by SLIME to embedders who load its runtime with a suitable {@link slime.runtime.Scope}. Provides
-		 * tools that may be directly provided to callers as APIs, or may be used to build APIs useful for the embedding.
-		 *
-		 * ## Loading code
-		 *
-		 * Note that although there are global `run()`, `file()`, and `value()` methods that
-		 * can be used to execute code, there is no global `module()` method. Since modules themselves load code, in
-		 * order to create a module, code loading capability is needed. For this reason, the loader API exposes the ability to
-		 * load modules via first creating a {@link slime.Loader} implementation and then using the
-		 * `module()` method of the `Loader`.
-		 */
 		export interface Exports {
 			/**
 			 * Creates a *Loader*. A Loader loads resources from a specified source.

--- a/typedoc-index.md
+++ b/typedoc-index.md
@@ -6,4 +6,4 @@
 
 # SLIME TypeScript documentation
 
-See documentation for the [SLIME namespace](modules/slime.html).
+See documentation for the [`slime` namespace](modules/slime-1.html).

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,16 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"entryPoints": [
+		"README.fifty.ts"
+	],
+	"name": "SLIME",
+	"sort": [
+		"source-order"
+	]
+}


### PR DESCRIPTION
Also:
* Remove duplicate namespace comment detected by TypeDoc
* Make TypeDoc version handling more robust