### PR TITLE
Resolve #452: Use mv for install if present

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 		"dbaeumer.vscode-eslint"
 	],
 	"settings": {
-		"java.jdt.ls.java.home": "/slime/local/jdk/11"
+		"java.jdt.ls.java.home": "/slime/local/jdk/17"
 	},
 	"service": "test",
 	"workspaceFolder": "/slime",

--- a/.devcontainer/post-create-command.bash
+++ b/.devcontainer/post-create-command.bash
@@ -5,4 +5,4 @@
 #	END LICENSE
 
 ./wf initialize
-./jsh.bash --add-jdk-11
+./jsh.bash --add-jdk-17

--- a/contributor/docker-compose-run
+++ b/contributor/docker-compose-run
@@ -6,5 +6,5 @@
 #	END LICENSE
 
 SLIME="$(dirname $0)/.."
-docker compose -f $SLIME/contributor/docker-compose.yaml build slime \
-	&& docker compose -f $SLIME/contributor/docker-compose.yaml run -w /slime slime /bin/bash "$@"
+docker compose -f $SLIME/contributor/docker-compose.yaml build test \
+	&& docker compose -f $SLIME/contributor/docker-compose.yaml run -w /slime test /bin/bash "$@"

--- a/jrunscript/tools/install/module.js
+++ b/jrunscript/tools/install/module.js
@@ -172,10 +172,20 @@
 			var unzippedTo = untardir.getSubdirectory(unzippedDestination);
 			if (!unzippedTo) throw new TypeError("Expected directory " + unzippedDestination + " not found in " + untardir);
 			events.fire("console", "Directory is: " + unzippedTo);
-			unzippedTo.move(p.to, {
-				overwrite: p.replace,
-				recursive: true
-			});
+			//	TODO	right now, we will use the mv command preferentially because it works in some situations the Java
+			//			java.io.File renameTo implementation does not (notable on our Docker setup, moving from a temporary
+			//			directory to the installation directory, as we are doing here).
+			if ($context.api.shell.PATH.getCommand("mv")) {
+				$context.api.shell.run({
+					command: "mv",
+					arguments: [unzippedTo.pathname.toString(), p.to.toString()]
+				});
+			} else {
+				unzippedTo.move(p.to, {
+					overwrite: p.replace,
+					recursive: true
+				});
+			}
 			return p.to.directory;
 		};
 

--- a/jrunscript/tools/install/module.js
+++ b/jrunscript/tools/install/module.js
@@ -176,6 +176,11 @@
 			//			java.io.File renameTo implementation does not (notable on our Docker setup, moving from a temporary
 			//			directory to the installation directory, as we are doing here).
 			if ($context.api.shell.PATH.getCommand("mv")) {
+				p.to.parent.createDirectory({
+					exists: function(dir) {
+						return false;
+					}
+				});
 				$context.api.shell.run({
 					command: "mv",
 					arguments: [unzippedTo.pathname.toString(), p.to.toString()]

--- a/jsh.bash
+++ b/jsh.bash
@@ -164,9 +164,12 @@ install_jdk_8_corretto() {
 	install_jdk_corretto "8.332.08.1" "8" $1
 }
 
-#	TODO	a lot of copy-paste with install_jdk_8_corretto
 install_jdk_11_corretto() {
 	install_jdk_corretto "11.0.15.9.1" "11" $1
+}
+
+install_jdk_17_corretto() {
+	install_jdk_corretto "17.0.3.6.1" "17" $1
 }
 
 install_jdk_8() {
@@ -175,6 +178,10 @@ install_jdk_8() {
 
 install_jdk_11() {
 	install_jdk_11_corretto "$@"
+}
+
+install_jdk_17() {
+	install_jdk_17_corretto "$@"
 }
 
 install_jdk() {
@@ -198,6 +205,11 @@ fi
 
 if [ "$1" == "--add-jdk-11" ]; then
 	install_jdk_11 ${JSH_LOCAL_JDKS}/11
+	exit $?
+fi
+
+if [ "$1" == "--add-jdk-17" ]; then
+	install_jdk_17 ${JSH_LOCAL_JDKS}/17
 	exit $?
 fi
 

--- a/rhino/file/java/inonit/script/runtime/io/Filesystem.java
+++ b/rhino/file/java/inonit/script/runtime/io/Filesystem.java
@@ -304,9 +304,6 @@ public abstract class Filesystem {
 						copy(file, new File(to, file.getName()));
 					}
 				} else {
-					if (!to.getParentFile().exists()) {
-						to.getParentFile().mkdirs();
-					}
 					Files.copy(from.toPath(), to.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
 				}
 			}

--- a/tools/fifty/test.jsh.js
+++ b/tools/fifty/test.jsh.js
@@ -11,7 +11,29 @@
 	 * @param { slime.jsh.Global } jsh
 	 */
 	function($api,jsh) {
-		jsh.wf.typescript.require();
+		var isTypescriptInstalled = function() {
+			var installation = jsh.shell.tools.node.installation;
+			var nodeExists = $api.Function.world.ask(
+				jsh.shell.tools.node.world.Installation.exists(installation)
+			)();
+			if (!nodeExists) return false;
+			var typescript = jsh.shell.tools.node.world.Installation.modules.installed("typescript");
+			var tsInstalled = $api.Function.world.now.question(
+				typescript,
+				installation
+			);
+			//	TODO	this simply ensures that *some* version of TypeScript is installed.
+			return tsInstalled.present;
+		}
+
+		//	We need to use this method, which forks a new shell, because we need TypeScript in this running shell in order to load
+		//	the Fifty tests. May want to provide this as an API somewhere (currently there is one in jsh.wf, but it functions
+		//	slightly differently; a `jsh` script requiring TypeScript is very foreseeable, though). Could generalize to require a
+		//	specific TypeScript version, etc.
+		jsh.shell.jsh.require({
+			satisfied: isTypescriptInstalled,
+			install: function() { jsh.wf.typescript.require(); }
+		});
 
 		/** @type { slime.jsh.script.cli.Processor<any, { definition: slime.jrunscript.file.File, list: boolean, part: string, view: string }> } */
 		var processor = $api.Function.pipe(

--- a/tools/wf/plugin.jsh.js
+++ b/tools/wf/plugin.jsh.js
@@ -16,7 +16,7 @@
 	function($api,$slime,jsh,$loader,plugin) {
 		plugin({
 			isReady: function() {
-				return Boolean(jsh.file && jsh.shell && jsh.ui && jsh.tools && jsh.tools.git);
+				return Boolean(jsh.file && jsh.shell && jsh.shell.tools && jsh.ui && jsh.tools && jsh.tools.git);
 			},
 			load: function() {
 				jsh.wf = {


### PR DESCRIPTION
mv works in a wider range of scenarios, across filesystems, with
symlinks, etc.

Also:
* Make Java file move() command more robust. Now it tries to copy, then
delete, files even if java.io.File.renameTo fails (perhaps because of
crossing filesystems)
* Add JDK 17 to list of JDKs SLIME can install
* Add JDK 17 installation to devcontainer to support VSCode Java
extension
* Fix regression in docker-compose-run script
* Fix bug in which bootstrapping Fifty tests didn't work because of
change to Node / TypeScript "require" semantics
* Fix regression in wf plugin caused by incorrect isReady()