### PR TITLE
Create experimental main() API for jsh

### DIFF
--- a/jsh/loader/plugins.js
+++ b/jsh/loader/plugins.js
@@ -10,9 +10,9 @@
 	 * @param { any } Packages
 	 * @param { slime.jsh.plugin.$slime } $slime
 	 * @param { slime.jsh.Global } jsh
-	 * @param { (v: slime.jsh.loader.internal.plugins.Export) => void } $set
+	 * @param { slime.loader.Export<slime.jsh.loader.internal.plugins.Export> } $export
 	 */
-	function(Packages,$slime,jsh,$set) {
+	function(Packages,$slime,jsh,$export) {
 		var Constructor = function() {
 			//	Loads the plugin code from a specific plugin.jsh.js at the top level of a loader and returns a list of implementations
 			//	with 'declaration' properties representing the objects provided by the implementor and 'toString' methods supplied by the
@@ -221,7 +221,7 @@
 
 		var instance = new Constructor();
 
-		$set(instance);
+		$export(instance);
 	}
 //@ts-ignore
-)(Packages,$slime,jsh,$set)
+)(Packages,$slime,jsh,$export)

--- a/jsh/script/plugin.jsh.fifty.ts
+++ b/jsh/script/plugin.jsh.fifty.ts
@@ -63,7 +63,6 @@ namespace slime.jsh.script {
 	//@ts-ignore
 	)(fifty);
 
-
 	export namespace cli {
 		export interface Exports {
 			Call: {
@@ -329,6 +328,16 @@ namespace slime.jsh.script {
 			 */
 			wrap: (descriptor: cli.Descriptor<any>) => void
 		}
+
+		export type Program = (invocation: slime.jsh.script.cli.Invocation<{}>) => number | void
+
+		/**
+		 * @experimental
+		 *
+		 * A value of this type is provided to the top-level `jsh` script's scope as `main`. It can be used to essentially declare
+		 * a main function of type {@link Program}, which can be created using functional techniques.
+		 */
+		export type main = (program: Program) => void
 	}
 
 	(

--- a/jsh/script/plugin.jsh.js
+++ b/jsh/script/plugin.jsh.js
@@ -189,6 +189,8 @@
 								parser: parser
 							},
 							directory: jsh.shell.PWD,
+							//	TODO	this is now redundant with code in the loader jsh.js that converts arguments to native form
+							//			for use with the new main() function API
 							arguments: jsh.java.Array.adapt($slime.getInvocation().getArguments()).map(function(s) { return String(s); }),
 						},
 						source

--- a/jsh/test/jsh.script/hello.jsh.js
+++ b/jsh/test/jsh.script/hello.jsh.js
@@ -1,0 +1,28 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+//@ts-check
+(
+	/**
+	 * @param { slime.$api.Global } $api
+	 * @param { slime.jsh.Global } jsh
+	 * @param { slime.jsh.script.cli.main } main
+	 */
+	function($api,jsh,main) {
+		main(
+			$api.Function.pipe(
+				jsh.script.cli.option.string({ longname: "foo" }),
+				jsh.script.cli.option.number({ longname: "exit" }),
+				function(p) {
+					jsh.shell.console("Hello, World!");
+					jsh.shell.console("foo: " + p.options.foo);
+					if (typeof(p.options.exit) == "number") return p.options.exit;
+				}
+			)
+		);
+	}
+//@ts-ignore
+)($api,jsh,main);


### PR DESCRIPTION
Scripts can declare a main function by passing it to the main() function
provided in the script's global scope. This function will be invoked
with the program arguments when the program is run. This
approach provides more direct support for functional programming
techniques.

Also:
* Refine type definitions for jsh plugin implementation