### PR TITLE
Resolve #633: Allow exit under debugger

### DIFF
--- a/jsh/loader/rhino/java/inonit/script/jsh/Rhino.java
+++ b/jsh/loader/rhino/java/inonit/script/jsh/Rhino.java
@@ -260,19 +260,19 @@ public class Rhino {
 				});
 				Integer status = future.get();
 				service.shutdown();
-				LOG.log(Level.INFO, "Exiting normally with status %d.", status);
 				if (status != null) {
+					LOG.log(Level.INFO, "Exiting via provided exit status %d.", status);
 					shell.getEnvironment().exit(status.intValue());
 				} else {
 					Set<Thread> threads = Thread.getAllStackTraces().keySet();
+					LOG.log(Level.INFO, "No exit status provided; destroying debugger (if any). JVM will exit when threads complete.", status);
+					engineConfiguration.getEngine().getDebugger().destroy();
 					for (Thread t : threads) {
 						if (t != null && t != Thread.currentThread() && !t.isDaemon()) {
 							LOG.log(Level.FINER, "Active thread: " + t + " daemon = " + t.isDaemon());
 							t.join();
 						}
 					}
-					LOG.log(Level.INFO, "Exiting normally with status %d.", status);
-					engineConfiguration.getEngine().getDebugger().destroy();
 					//	JVM will exit normally when non-daemon threads complete.
 				}
 			} catch (Throwable t) {

--- a/rhino/file/spi.js
+++ b/rhino/file/spi.js
@@ -9,7 +9,7 @@
 	/**
 	 *
 	 * @param { slime.jrunscript.Packages } Packages
-å	 * @param { slime.loader.Export<slime.jrunscript.file.internal.spi.Exports> } $export
+	 * @param { slime.loader.Export<slime.jrunscript.file.internal.spi.Exports> } $export
 	 */
 	function(Packages,$export) {
 		var javaSpiAvailable = typeof(Packages.inonit.script.runtime.io.Filesystem.Optimizations) == "function";


### PR DESCRIPTION
Previously we would join all non-daemon threads, which included AWT
threads, and only destroy the debugger *after* joining them

Also:
* Improve log messages surrounding Rhino jsh shell exit