### PR TITLE
Migrate js/time Year definition to Fifty

### DIFF
--- a/README.html
+++ b/README.html
@@ -161,15 +161,7 @@ END LICENSE
 					<ul>
 						<li>
 							<div>
-								Running individual definitions in Fifty:
-								<ul>
-									<li><code>./fifty test.jsh [--debug:rhino] <i>file</i>.fifty.ts [--part <i>part</i>]</code></li>
-									<li>
-										<code>./fifty test.browser [--interactive] [--chrome:data <i>pathname</i>] [--chrome:debug:vscode] <i>file</i>.fifty.ts [--part <i>part</i>]</code>:
-										Invokes a <a href="tools/fifty/test-browser.jsh.js">script</a> to run Fifty browser tests;
-										see the script for command-line argument definitions.
-									</li>
-								</ul>
+								Running Fifty definitions: See the <a href="local/doc/typedoc/modules/slime.fifty.test.html">Fifty documentation</a>.
 							</div>
 						</li>
 						<li>

--- a/js/time/api.html
+++ b/js/time/api.html
@@ -105,36 +105,6 @@ END LICENSE
 				scope.katemas = new api.Day(1958,7,30);
 			</script>
 			<li class="constructor">
-				<div class="name">Year</div>
-				<span>__DESCRIPTION__</span>
-				<div class="arguments">
-					<div class="label">Arguments</div>
-					<ol>
-					</ol>
-				</div>
-				<div class="type">
-					<a class="type" name="types.Year">Year</a>
-					<span>Represents a calendar year.</span>
-					<div class="label">has properties:</div>
-					<ul>
-						<li class="value">
-							<div class="name">value</div>
-							<span class="type">number</span>
-							<span>__DESCRIPTION__</span>
-						</li>
-					</ul>
-				</div>
-				<div class="instances">
-					<div class="label">Instances</div>
-					<span class="type"><a href="#types.Year">Year</a></span>
-					<span>__DESCRIPTION__</span>
-				</div>
-				<script type="application/x.jsapi#tests">
-					var nineteen = new api.Year(2019);
-					verify(nineteen).value.is(2019);
-				</script>
-			</li>
-			<li class="constructor">
 				<div class="name">Month</div>
 				<span>__DESCRIPTION__</span>
 				<div class="arguments">

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -12,10 +12,15 @@ namespace slime.time {
 	}
 
 	export namespace old {
+		/**
+		 * Represents a calendar year.
+		 */
+		export interface Year {
+			value: number
+		}
+
 		export interface Day {
-			year: {
-				value: number
-			}
+			year: Year
 			at: Function
 			format(mask: string): string
 			month: Month
@@ -156,9 +161,6 @@ namespace slime.time {
 
 	}
 
-	export interface Exports {
-	}
-
 	export namespace exports {
 		export interface Day {
 			new (year: number, month: number, day: number): old.Day
@@ -180,7 +182,27 @@ namespace slime.time {
 	}
 
 	export interface Exports {
-		Year: Function
+		Year: {
+			new (year: number): old.Year
+		}
+	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			const { verify } = fifty;
+
+			fifty.tests.Year = function() {
+				var nineteen = new test.subject.Year(2019);
+				verify(nineteen).value.is(2019);
+			}
+		}
+	//@ts-ignore
+	)(fifty);
+
+
+	export interface Exports {
 		Month: Function
 		Day: exports.Day
 		Time: {
@@ -247,10 +269,14 @@ namespace slime.time {
 				var formatted = rounding.local().format("yyyy-mm-dd HR:mi:sc");
 				verify(formatted).is("2021-01-01 11:59:59");
 
+				fifty.run(fifty.tests.Year);
+
 				fifty.run(fifty.tests.Day);
 
 				fifty.run(fifty.tests.Day.old.constructor);
 			}
+
+			if (fifty.global.jsh) fifty.tests.platforms = fifty.jsh.platforms(fifty);
 		}
 	//@ts-ignore
 	)(fifty,$loader,verify,tests)

--- a/loader/expression.fifty.ts
+++ b/loader/expression.fifty.ts
@@ -722,23 +722,7 @@ namespace slime {
 					fifty.load("Loader.fifty.ts");
 				}
 
-				if (jsh) fifty.tests.platforms = function() {
-					fifty.run(function jsh() {
-						fifty.tests.suite();
-					});
-					var runBrowser = jsh.shell.world.question(
-						jsh.shell.Invocation.create({
-							command: fifty.jsh.file.relative("../fifty").pathname,
-							arguments: [
-								"test.browser",
-								fifty.jsh.file.relative("expression.fifty.ts").pathname
-							]
-						})
-					);
-					var getBrowserResult = $api.Function.world.ask(runBrowser);
-					var result = getBrowserResult();
-					verify(result, "browserResult").status.is(0);
-				}
+				if (jsh) fifty.tests.platforms = fifty.jsh.platforms(fifty);
 			}
 		//@ts-ignore
 		)( (function() { return this; })().Packages, fifty)

--- a/tools/fifty/module.fifty.ts
+++ b/tools/fifty/module.fifty.ts
@@ -45,6 +45,40 @@ namespace slime.fifty {
 	 * `fifty.verify()` function, which creates subjects that have various methods that can be invoked to represent assertions.
 	 *
 	 * For details, see the documentation on {@link slime.fifty.test.Kit | the `fifty` object}.
+	 *
+	 * ## Working with Fifty tests
+	 *
+	 * Fifty tests can be run using `jsh`.
+	 *
+	 * ### Running Fifty tests under `jsh`
+	 *
+	 * To run a Fifty test definition on the `jsh` platform:
+	 * `./fifty test.jsh [--debug:rhino] file.fifty.ts [--part part]`
+	 *
+	 * ### Running Fifty tests in a browser
+	 *
+	 * To run a Fifty test definition under a browser:
+	 * `/fifty test.browser [--interactive] [--chrome:data pathname] [--chrome:debug:vscode] file.fifty.ts [--part part]`
+	 *
+	 * This invokes the underlying `tools/fifty/test-browser.jsh.js` script. The
+	 * [script's code](../src/tools/fifty/test-browser.jsh.js?as=text) defines the semantics of the
+	 * command-line arguments.
+	 *
+	 * ### Running Fifty tests in both `jsh` and a browser
+	 *
+	 * To run a test suite that runs the same definition in both `jsh` and a browser:
+	 *
+	 * First, make sure the test suite defines a test using `fifty.jsh.platforms` (usually named `fifty.tests.platforms` by
+	 * convention), like this one:
+	 *
+	 * `fifty.tests.platforms = fifty.jsh.platforms(fifty);`
+	 *
+	 * Then, the suite can be run via:
+	 *
+	 * `./fifty test.jsh file.fifty.ts --part platforms`.
+	 *
+	 * This will run the platforms test under `jsh`, which first runs the suite under `jsh`, then launches a browser to run it
+	 * again. See {@link slime.fifty.test.Kit}, specifically the `jsh.platforms` method.
 	 */
 	export namespace test {
 		export type verify = slime.definition.verify.Verify
@@ -159,7 +193,12 @@ namespace slime.fifty {
 						plugins?: { [x: string]: any }
 						$slime?: slime.jsh.plugin.$slime
 					}) => ReturnType<slime.jsh.loader.internal.plugins.Export["mock"]>
-				}
+				},
+				/**
+				 * Creates a test that will run the test suite (the `suite` part) under `jsh`, and then again under the browser,
+				 * and pass only if both parts pass.
+				 */
+				platforms: (fifty: Kit) => void
 			}
 		}
 

--- a/tools/fifty/scope-jsh.ts
+++ b/tools/fifty/scope-jsh.ts
@@ -8,6 +8,7 @@ namespace slime.fifty.test.internal.scope.jsh {
 	export interface Scope {
 		loader: slime.Loader
 		directory: slime.jrunscript.file.Directory
+		filename: string
 	}
 
 	export type Export = (scope: slime.fifty.test.internal.scope.jsh.Scope) => slime.fifty.test.Kit["jsh"]
@@ -67,7 +68,27 @@ namespace slime.fifty.test.internal.scope.jsh {
 							)
 						}
 					},
-					$slime: jsh.unit.$slime
+					$slime: jsh.unit.$slime,
+					platforms: function(fifty) {
+						return function() {
+							fifty.run(function jsh() {
+								fifty.tests.suite();
+							});
+							var runBrowser = jsh.shell.world.question(
+								jsh.shell.Invocation.create({
+									//	TODO	world-oriented
+									command: fifty.global.jsh.shell.jsh.src.getRelativePath("fifty").toString(),
+									arguments: [
+										"test.browser",
+										fifty.jsh.file.relative(scope.filename).pathname
+									]
+								})
+							);
+							var getBrowserResult = $api.Function.world.ask(runBrowser);
+							var result = getBrowserResult();
+							fifty.verify(result, "browserResult").status.is(0);
+						}
+					}
 				}
 			}
 		);

--- a/tools/fifty/test.js
+++ b/tools/fifty/test.js
@@ -487,7 +487,8 @@
 				},
 				jsh: (scopes.jsh) ? scopes.jsh({
 					loader: contexts.jsh.loader,
-					directory: contexts.jsh.directory
+					directory: contexts.jsh.directory,
+					filename: path
 				}) : void(0)
 			};
 


### PR DESCRIPTION
Also:
* Move documentations on running Fifty tests to Fifty
* Resolve #651: create fifty.jsh.platforms API to launch tests under
both jsh and browser
* Create test to run js/time under both jsh and browser