### PR TITLE
Fix missing newline in partial Fifty comments

### DIFF
--- a/contributor/code/jsapi-to-fifty.js
+++ b/contributor/code/jsapi-to-fifty.js
@@ -381,7 +381,8 @@
 				var formatter = formatBlockUsing(format);
 				var formatted = blocks.map(formatter);
 				var formattedStrings = formatted.map(function(lines) { return lines.join("\n"); });
-				var text = formattedStrings.join("\n");
+				var text = formattedStrings.join("\n")
+				if (!blocks[blocks.length-1].hasEnd) text += "\n";
 
 				// var lines = $api.Function.Arrays.join(formatted);
 				// var text = lines.join("\n");

--- a/contributor/code/test/jsapi-to-fifty-next.txt
+++ b/contributor/code/test/jsapi-to-fifty-next.txt
@@ -1,3 +1,7 @@
 { "tabSize": 4, "lineLength": 132 }
+		 * Returns the resource associated with a given path, by invoking the <code>get</code> method of this
+									loader's <code>source</code>.
 ===
+		 * Returns the resource associated with a given path, by invoking the `get` method of this loader's `source`.
+
 ===

--- a/contributor/code/test/jsapi-to-fifty-next.txt
+++ b/contributor/code/test/jsapi-to-fifty-next.txt
@@ -1,7 +1,3 @@
 { "tabSize": 4, "lineLength": 132 }
-		 * Returns the resource associated with a given path, by invoking the <code>get</code> method of this
-									loader's <code>source</code>.
 ===
-		 * Returns the resource associated with a given path, by invoking the `get` method of this loader's `source`.
-
 ===

--- a/contributor/code/test/jsapi-to-fifty.txt
+++ b/contributor/code/test/jsapi-to-fifty.txt
@@ -13,6 +13,7 @@
 ===
 			 * Allows the loader to customize the way child sources are created when creating child loaders. if omitted, a child
 			 * that delegates requests back to the parent, prepended by the child's path, will be created
+
 ===
 { "tabSize": 4, "lineLength": 132 }
 				 * 								The created loaders currently have the following limitations:
@@ -28,4 +29,5 @@
 				 * * They are not enumerable
 				 * * They do not respect the `.child` implementations of their elements
 				 * * They do not provide a sensible `.toString` implementation.
+
 ===

--- a/contributor/code/test/jsapi-to-fifty.txt
+++ b/contributor/code/test/jsapi-to-fifty.txt
@@ -31,3 +31,10 @@
 				 * * They do not provide a sensible `.toString` implementation.
 
 ===
+{ "tabSize": 4, "lineLength": 132 }
+		 * Returns the resource associated with a given path, by invoking the <code>get</code> method of this
+									loader's <code>source</code>.
+===
+		 * Returns the resource associated with a given path, by invoking the `get` method of this loader's `source`.
+
+===


### PR DESCRIPTION
When end of comment is not included, newline should be included after
transform.