### PR TITLE
Fix bug for error type

### DIFF
--- a/loader/$api.fifty.ts
+++ b/loader/$api.fifty.ts
@@ -493,6 +493,15 @@ namespace slime.$api {
 				verify(c).properties.baz.is("bizzy");
 				verify(c).properties.evaluate.property("foo").is.type("undefined");
 				verify(c).stack.is.type("string");
+
+				var NoSupertype = $api.Error.type({
+					name: "Standalone",
+					getMessage: function(p: {}): string {
+						return "foo";
+					}
+				});
+				var n = new NoSupertype();
+				verify(n).is.type("object");
 			}
 		}
 	//@ts-ignore

--- a/loader/$api.js
+++ b/loader/$api.js
@@ -509,7 +509,8 @@
 						return new CustomError(properties);
 					}
 				}
-				CustomError.prototype = Object.assign(p.extends(), { properties: void(0) });
+				var prototypeFactory = p.extends || Error;
+				CustomError.prototype = Object.assign(prototypeFactory(), { properties: void(0) });
 				return CustomError;
 			}
 		}


### PR DESCRIPTION
Although 'extends' was an optional property, omitting it would cause
runtime error