### PR TITLE
Improve type definitions for servlets

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -78,7 +78,7 @@
 		{
 			"label": "TypeScript: Check types",
 			"type": "shell",
-			"command": "./wf tsc",
+			"command": "./wf tsc --vscode",
 			"problemMatcher": [],
 			"presentation": {
 				"echo": false,

--- a/loader/browser/client.fifty.ts
+++ b/loader/browser/client.fifty.ts
@@ -111,7 +111,7 @@ namespace slime.browser {
 			/**
 			 * Creates a SLIME {@link slime.Loader | Loader}; see {@link slime.loader.Source}.
 			 */
-			new (p: slime.old.loader.Source): slime.Loader
+			new (p: slime.old.loader.Source): slime.old.Loader
 
 			series: slime.runtime.Exports["old"]["loader"]["series"]
 			//	TODO	JSAPI-declared properties below
@@ -236,7 +236,7 @@ namespace slime.browser {
 		/**
 		 * A loader that loads resources using the current page as the base URL for the loader.
 		 */
-		loader: slime.Loader
+		loader: slime.old.Loader
 
 		/**
 		 * Contains useful pieces of code that are exported for general use.

--- a/rhino/http/servlet/api.fifty.ts
+++ b/rhino/http/servlet/api.fifty.ts
@@ -24,7 +24,7 @@ namespace slime.servlet {
 			}
 		}
 
-		loader: slime.Loader
+		loader: slime.old.Loader
 
 		/**
 		 * @deprecated
@@ -55,7 +55,7 @@ namespace slime.servlet {
 	 */
 	export interface Scope {
 		httpd: httpd
-		$loader: slime.Loader
+		$loader: slime.old.Loader
 		$parameters: Parameters
 		$exports: Script
 	}
@@ -80,8 +80,8 @@ namespace slime.servlet {
 
 				loaders?: {
 					api: slime.Loader
-					script: slime.Loader
-					container: slime.Loader
+					script: slime.old.Loader
+					container: slime.old.Loader
 				}
 
 				Loader: {

--- a/rhino/http/servlet/api.js
+++ b/rhino/http/servlet/api.js
@@ -246,7 +246,7 @@
 
 		var loaders = (
 			/**
-			 * @return { { script: slime.Loader, container: slime.Loader, api: slime.Loader } }
+			 * @return { { script: slime.old.Loader, container: slime.old.Loader, api: slime.Loader } }
 			 */
 			function() {
 				if ($java && $servlet) {

--- a/rhino/http/servlet/plugin.jsh.fifty.ts
+++ b/rhino/http/servlet/plugin.jsh.fifty.ts
@@ -82,7 +82,7 @@ namespace slime.jsh.httpd {
 			argument: (resources: slime.old.Loader, servlet: slime.jsh.httpd.servlet.descriptor) => {
 				resources: slime.old.Loader,
 				load: servlet.byLoad["load"],
-				$loader?: slime.Loader
+				$loader?: slime.old.Loader
 			}
 		}
 		Resources: slime.jsh.httpd.resources.Export

--- a/rhino/http/servlet/plugin.jsh.js
+++ b/rhino/http/servlet/plugin.jsh.js
@@ -145,7 +145,7 @@
 					resources = getResourceLoader(resources);
 
 					/**
-					 *	@param { { load: (scope: slime.servlet.Scope) => void, $loader?: slime.Loader } } o
+					 *	@param { { load: (scope: slime.servlet.Scope) => void, $loader?: slime.old.Loader } } o
 					 */
 					var returning = function(o) {
 						return Object.assign(o, { resources: resources });

--- a/tools/wf/plugin-standard.jsh.fifty.ts
+++ b/tools/wf/plugin-standard.jsh.fifty.ts
@@ -226,7 +226,8 @@ namespace slime.jsh.wf {
 
 		export interface Interface {
 			/**
-			 * Runs the TypeScript compiler on the project.
+			 * Runs the TypeScript compiler on the project. If the `--vscode` argument is provided, the output will be reformatted
+			 * so that references to lines in error messages are clickable.
 			 */
 			tsc:  slime.jsh.script.cli.Command<Options>
 		}

--- a/tools/wf/plugin.jsh.fifty.ts
+++ b/tools/wf/plugin.jsh.fifty.ts
@@ -493,12 +493,7 @@ namespace slime.jsh.wf {
 
 	export namespace exports {
 		export interface Checks {
-			tsc: () => slime.$api.fp.world.old.Ask<
-				{
-					console: string
-				},
-				boolean
-			>
+			tsc: slime.$api.fp.world.Question<void,{ console: string, output: string },boolean>
 		}
 	}
 


### PR DESCRIPTION
Formerly, dependent projects had trouble using servlet type definitions; they were too narrow.

Also:
* Add --vscode option for wf tsc and enable it in tasks.json. See https://github.com/microsoft/vscode/issues/160895