### PR TITLE
Simplify Fifty browser tests threading

### DIFF
--- a/jrunscript/host/module.js
+++ b/jrunscript/host/module.js
@@ -389,16 +389,15 @@
 
 			//	TODO	replace with Java logging; currently there is no way to enable this debugging without changing this file
 			var debug = function(m) {
-				//	TODO	below property could never be set in existing code
-				if (false /* arguments.callee.on */) {
-					Packages.java.lang.System.err.println(m);
-				}
+				$exports.log.named("jrunscript.host").FINE(m);
 			}
 
 			var runnable = new function() {
 				this.run = function() {
 					try {
+						debug("Running thread " + thread.getName() + " ...");
 						var rv = p.call();
+						debug("Finished " + p);
 						if (!done) {
 							synchronize(function() {
 								if (p.on && p.on.result) {
@@ -428,7 +427,13 @@
 			var _runnable = new JavaAdapter(Packages.java.lang.Runnable,runnable);
 			var thread = (factory) ? factory(_runnable) : new Packages.java.lang.Thread(_runnable);
 
+			this.toString = function() {
+				return "Java thread: " + thread.getName() + " factory=" + factory;
+			};
+
+			debug("Starting Java thread " + thread.getName());
 			thread.start();
+			debug("Started Java thread " + thread.getName());
 
 			if (p && p.timeout) {
 				debug("Starting timeout thread for " + thread + " ...");

--- a/jsh/unit/plugin.jsh.browser.js
+++ b/jsh/unit/plugin.jsh.browser.js
@@ -497,17 +497,22 @@
 					return {
 						//name: "Google Chrome",
 						open: function(p) {
-							jsh.java.Thread.start(function() {
-								chrome.run({
-									//	TODO	enhance chrome.run so it can take a Url object rather than just a string
-									uri: p.uri,
-									arguments: (configuration.debugPort) ? ["--remote-debugging-port=" + configuration.debugPort ] : [],
-									on: {
-										start: function(p) {
-											process = p;
+							var browserThread = jsh.java.Thread.start(function() {
+								try {
+									chrome.run({
+										//	TODO	enhance chrome.run so it can take a Url object rather than just a string
+										uri: p.uri,
+										arguments: (configuration.debugPort) ? ["--remote-debugging-port=" + configuration.debugPort ] : [],
+										on: {
+											start: function(p) {
+												jsh.shell.console("In plugin.jsh.browser, Chrome subprocess started (PID: " + p.pid + ")");
+												process = p;
+											}
 										}
-									}
-								});
+									});
+								} catch (e) {
+									jsh.shell.console(e.stack);
+								}
 							});
 						},
 						close: function() {

--- a/rhino/shell/browser/chrome.fifty.ts
+++ b/rhino/shell/browser/chrome.fifty.ts
@@ -62,13 +62,14 @@ namespace slime.jrunscript.shell.browser {
 		}
 	}
 }
+
 namespace slime.jrunscript.shell.browser.internal.chrome {
 	export interface Context {
 		os: any
 		run: any
 		api: {
 			js: any
-			java: any
+			java: slime.jrunscript.host.Exports
 			file: any
 		}
 		HOME: slime.jrunscript.file.Directory

--- a/rhino/shell/browser/chrome.js
+++ b/rhino/shell/browser/chrome.js
@@ -19,6 +19,8 @@
 		if (!$context.os.process) throw new Error("No $context.os.process");
 		if (!$context.os.process.list) throw new Error("No $context.os.process.list");
 
+		var log = $context.api.java.log.named("jrunscript.shell.browser.chrome");
+
 		/**
 		 *
 		 * @param { { program: slime.jrunscript.file.File, user?: slime.jrunscript.file.Directory }} b
@@ -154,7 +156,11 @@
 					}
 
 					var launch = function(m) {
+						log.FINE("Launching Chrome browser.");
+						log.FINEST("$context.os = " + $context.os);
+						log.FINER("$context.os.name = " + $context.os.name);
 						if ($context.os.name == "Mac OS X") {
+							log.FINE("Ensure default user is running ...");
 							(function startDefaultUser() {
 								var isDefaultRunning = function() {
 									return ps.isDefaultRunning();
@@ -223,6 +229,7 @@
 								args.push.apply(args,m.uris);
 							}
 						}
+						log.FINE("Running program: " + b.program + " with args " + JSON.stringify(args));
 						//Packages.java.lang.System.err.println("using program: args = " + JSON.stringify(args));
 						//	TODO	use events rather than on.start property
 						$context.run({
@@ -232,6 +239,7 @@
 							on: {
 								//	TODO	on.start is deprecated
 								start: function(p) {
+									log.FINE("Program " + b.program + " started.");
 									if ($context.os.name == "Mac OS X" && m.exitOnClose) {
 										//	TODO: The exitOnClose property is currently undocumented; it is not clear that it works correctly. More
 										//	testing needed
@@ -274,6 +282,7 @@
 								}
 							}
 						});
+						log.FINE("Program " + b.program + " terminated.");
 						if (m.on && m.on.close) {
 							m.on.close.call(m);
 						}

--- a/tools/fifty/test-browser.jsh.js
+++ b/tools/fifty/test-browser.jsh.js
@@ -200,12 +200,10 @@
 					});
 				} else {
 					var delay = (typeof(p.options["debug:delay"]) == "number") ? p.options["debug:delay"] : 4000;
-					jsh.java.Thread.start(function() {
-						var uri = getUri(host, delay);
-						jsh.shell.console("Browser opening " + uri + " ...");
-						browser.open({
-							uri: uri
-						});
+					var uri = getUri(host, delay);
+					jsh.shell.console("Browser opening " + uri + " ...");
+					browser.open({
+						uri: uri
 					});
 					var resultsUrl = new jsh.web.Url({
 						scheme: "http",


### PR DESCRIPTION
Did not find bug in existing implementation, but cannot reproduce failures that were observed.

Also:
* Add better logging to Java threading and Chrome launching