### PR TITLE
Rename $api.Function to $api.fp

### DIFF
--- a/contributor/code/find-untyped-usages.jsh.js
+++ b/contributor/code/find-untyped-usages.jsh.js
@@ -54,7 +54,7 @@
 		};
 
 		main(
-			$api.Function.pipe(
+			$api.fp.pipe(
 				jsh.script.cli.option.string({ longname: "pattern" }),
 				function(p) {
 					var directory = jsh.script.file.parent.parent.parent;

--- a/contributor/code/jsapi-to-fifty.js
+++ b/contributor/code/jsapi-to-fifty.js
@@ -23,7 +23,7 @@
 							var r = cases[i](p);
 							if (r.present) return r;
 						}
-						return $api.Function.Maybe.nothing();
+						return $api.fp.Maybe.nothing();
 					}
 				},
 				/** @type { <P,R1,R2>(fs: [(p: P) => R1, (p: P) => R2]) => (p: P) => [R1, R2] } */
@@ -38,13 +38,13 @@
 				Array: {
 					/** @type { <T>(ts: T[]) => slime.$api.fp.Maybe<T> } */
 					first: function(array) {
-						if (array.length > 0) return $api.Function.Maybe.value(array[0]);
-						return $api.Function.Maybe.nothing();
+						if (array.length > 0) return $api.fp.Maybe.value(array[0]);
+						return $api.fp.Maybe.nothing();
 					},
 					/** @type { <T>(ts: T[]) => slime.$api.fp.Maybe<T> } */
 					last: function(array) {
-						if (array.length > 0) return $api.Function.Maybe.value(array[array.length-1]);
-						return $api.Function.Maybe.nothing();
+						if (array.length > 0) return $api.fp.Maybe.value(array[array.length-1]);
+						return $api.fp.Maybe.nothing();
 					}
 				}
 			}
@@ -55,7 +55,7 @@
 			return function(f) {
 				return function() {
 					var result = f.apply(this,arguments);
-					return $api.Function.Maybe.from(result);
+					return $api.fp.Maybe.from(result);
 				}
 			}
 		};
@@ -69,21 +69,21 @@
 		 */
 		function getLineIndent(line) {
 			if (line.trim().substring(0,3) == "/**") {
-				return $api.Function.Maybe.value(line.substring(0,line.indexOf("/**")));
+				return $api.fp.Maybe.value(line.substring(0,line.indexOf("/**")));
 			}
 			if (line.trim().substring(0,1) == "*") {
 				var at = line.indexOf("*");
 				if (line.substring(at-1,at) != " ") {
-					return $api.Function.Maybe.nothing();
+					return $api.fp.Maybe.nothing();
 				}
-				return $api.Function.Maybe.value(line.substring(0,at-1));
+				return $api.fp.Maybe.value(line.substring(0,at-1));
 			}
 			var leadingWhitespacePattern = /^(\s+)/;
 			var leadingWhitespaceMatch = leadingWhitespacePattern.exec(line);
 			if (leadingWhitespaceMatch) {
-				return $api.Function.Maybe.value(leadingWhitespaceMatch[1]);
+				return $api.fp.Maybe.value(leadingWhitespaceMatch[1]);
 			}
-			return $api.Function.Maybe.nothing();
+			return $api.fp.Maybe.nothing();
 		}
 
 		/**
@@ -100,7 +100,7 @@
 
 		/** @typedef { { section: slime.project.jsapi.internal.InputLine["section"], content: string } } ParsedCommentLine */
 
-		var parseComment = $api.Function.pipe(
+		var parseComment = $api.fp.pipe(
 			$$api.Function.switch(
 				toMaybe(
 					/** @type { (rest: string) => ParsedCommentLine } */
@@ -140,7 +140,7 @@
 				)
 			),
 			//	TODO	we have to force this else because of the inability to define the switch statement with an else currently
-			$api.Function.Maybe.else(
+			$api.fp.Maybe.else(
 				/** @returns { ParsedCommentLine } */
 				function() {
 					if (true) throw new Error("Unreachable.");
@@ -180,16 +180,16 @@
 			}
 		}
 
-		var applyInlineStyles = $api.Function.pipe(
+		var applyInlineStyles = $api.fp.pipe(
 			startEndTagReplace("code", "`"),
 			startEndTagReplace("i", "*"),
 			startEndTagReplace("em", "*")
 		);
 
-		var parseInputLines = $api.Function.pipe(
+		var parseInputLines = $api.fp.pipe(
 			applyInlineStyles,
-			$api.Function.string.split("\n"),
-			$api.Function.Array.map(parseLine)
+			$api.fp.string.split("\n"),
+			$api.fp.Array.map(parseLine)
 		);
 
 		/**
@@ -198,20 +198,20 @@
 		 * @return { slime.project.jsapi.internal.Block }
 		 */
 		function parseBlock(inputLines) {
-			var hasStart = $api.Function.result(
+			var hasStart = $api.fp.result(
 				inputLines,
-				$api.Function.pipe(
+				$api.fp.pipe(
 					$$api.Function.Array.first,
-					$api.Function.Maybe.map($api.Function.property("section")),
-					$api.Function.Maybe.map($api.Function.is("start")),
-					$api.Function.Maybe.else($api.Function.returning(false))
+					$api.fp.Maybe.map($api.fp.property("section")),
+					$api.fp.Maybe.map($api.fp.is("start")),
+					$api.fp.Maybe.else($api.fp.returning(false))
 				)
 			);
 
-			var hasEnd = $api.Function.result(
+			var hasEnd = $api.fp.result(
 				inputLines,
-				$api.Function.pipe(
-					$api.Function.Array.find(function(line) {
+				$api.fp.pipe(
+					$api.fp.Array.find(function(line) {
 						return line.section == "end";
 					}),
 					function(line) {
@@ -220,7 +220,7 @@
 				)
 			);
 
-			var content = inputLines.map($api.Function.property("content")).reduce(
+			var content = inputLines.map($api.fp.property("content")).reduce(
 				/**
 				 * @param { string[] } rv
 				 * @param { string } content
@@ -294,11 +294,11 @@
 		 */
 		function renderInlineNode(child) {
 			if ($context.library.document.Node.isText(child)) {
-				return $api.Function.Maybe.value(child.data);
+				return $api.fp.Maybe.value(child.data);
 			} else if ($context.library.document.Node.isComment(child)) {
-				return $api.Function.Maybe.value("<!---" + child.data + "--->");
+				return $api.fp.Maybe.value("<!---" + child.data + "--->");
 			} else {
-				return $api.Function.Maybe.nothing();
+				return $api.fp.Maybe.nothing();
 			}
 		}
 

--- a/contributor/code/license.jsh.fifty.ts
+++ b/contributor/code/license.jsh.fifty.ts
@@ -29,7 +29,7 @@ namespace slime.project.license {
 					}
 				});
 				cloned.directory.getRelativePath("a.js").write("", { append: false });
-				var result = $api.Function.world.now.question(
+				var result = $api.fp.world.now.question(
 					jsh.shell.world.question,
 					jsh.shell.Invocation.create({
 						command: cloned.directory.getRelativePath("jsh.bash"),

--- a/contributor/code/license.jsh.js
+++ b/contributor/code/license.jsh.js
@@ -12,7 +12,7 @@
 	 */
 	function($api,jsh) {
 		var invocation = jsh.script.cli.invocation(
-			$api.Function.pipe(
+			$api.fp.pipe(
 				jsh.script.cli.option.boolean({ longname: "fix" })
 			)
 		);

--- a/contributor/code/module.fifty.ts
+++ b/contributor/code/module.fifty.ts
@@ -58,8 +58,8 @@ namespace slime.project.code {
 				)
 			);
 
-			fifty.tests.wip = $api.Function.pipe(
-				$api.Function.impure.Input.value(loader),
+			fifty.tests.wip = $api.fp.pipe(
+				$api.fp.impure.Input.value(loader),
 				function(loader) {
 					return {
 						loader: loader,

--- a/contributor/code/module.js
+++ b/contributor/code/module.js
@@ -56,7 +56,7 @@
 				}
 
 				/** @type { slime.tools.code.isText } */
-				var isText = $api.Function.series(
+				var isText = $api.fp.series(
 					function(entry) {
 						if (entry.path == "contributor/docker-compose-run") return true;
 						if (entry.path == "tools/wf/test/data/plugin-standard/wf") return true;
@@ -102,8 +102,8 @@
 						if (entry.path == "tools/wf") return true;
 						if (entry.path == "wf") return true;
 					},
-					$api.Function.pipe(
-						$api.Function.world.question(
+					$api.fp.pipe(
+						$api.fp.world.question(
 							$context.library.code.File.isText()
 						),
 						function(maybe) {
@@ -208,7 +208,7 @@
 				}
 
 				var excludes = {
-					directory: $api.Function.Predicate.or(
+					directory: $api.fp.Predicate.or(
 						$context.library.code.defaults.exclude.directory,
 						isVscodeJavaExtensionDirectory
 					)
@@ -238,9 +238,9 @@
 			files: files,
 			directory: {
 				lastModified: function(p) {
-					return $api.Function.result(
+					return $api.fp.result(
 						p.loader,
-						$api.Function.pipe(
+						$api.fp.pipe(
 							$context.library.io.loader.entries({
 								filter: {
 									resource: function(path, name) {
@@ -255,14 +255,14 @@
 								},
 								map: p.map
 							}),
-							$api.Function.Array.first($context.library.io.Entry.mostRecentlyModified()),
-							$api.Function.Maybe.map(function(latest) {
+							$api.fp.Array.first($context.library.io.Entry.mostRecentlyModified()),
+							$api.fp.Maybe.map(function(latest) {
 								// jsh.shell.console("latest = " + ((latest.path.length) ? latest.path.join("/") + "/" : "") + latest.name);
 								return latest.resource.modified();
 							}),
 							function(it) {
 								if (it.present) return it.value;
-								return $api.Function.Maybe.nothing();
+								return $api.fp.Maybe.nothing();
 							}
 						)
 					);

--- a/contributor/code/openapi-update.js
+++ b/contributor/code/openapi-update.js
@@ -27,7 +27,7 @@
 
 		$export({
 			initialize: function(jsh) {
-				$api.Function.world.execute(jsh.shell.tools.node.require());
+				$api.fp.world.execute(jsh.shell.tools.node.require());
 				jsh.shell.tools.node.installed.modules.require({ name: "dtsgenerator", version: "3.12.1" });
 				jsh.shell.tools.node.installed.modules.require({ name: "tslib", version: "2.3.0" });
 				jsh.shell.tools.node.installed.modules.require({ name: "@dtsgenerator/replace-namespace", version: "1.5.0" });

--- a/contributor/committers.jsh.js
+++ b/contributor/committers.jsh.js
@@ -13,7 +13,7 @@
 	function($api,jsh) {
 		var repository = jsh.tools.git.Repository({ directory: jsh.script.file.parent.parent });
 		var log = repository.log();
-		var byCommitter = $api.Function.Array.groupBy({
+		var byCommitter = $api.fp.Array.groupBy({
 			/**
 			 *
 			 * @param { slime.jrunscript.tools.git.Commit } v
@@ -22,7 +22,7 @@
 				return v.committer.name + " <" + v.committer.email + ">";
 			}
 		});
-		var byAuthor = $api.Function.Array.groupBy({
+		var byAuthor = $api.fp.Array.groupBy({
 			/**
 			 *
 			 * @param { slime.jrunscript.tools.git.Commit } v

--- a/contributor/eslint-report.jsh.js
+++ b/contributor/eslint-report.jsh.js
@@ -22,7 +22,7 @@
 		});
 		//jsh.shell.console("rules = " + Object.keys(configuration.rules));
 
-		$api.Function.world.execute(jsh.shell.tools.node.require());
+		$api.fp.world.execute(jsh.shell.tools.node.require());
 
 		var node = jsh.shell.tools.node.installed;
 

--- a/contributor/eslint.jsh.js
+++ b/contributor/eslint.jsh.js
@@ -18,7 +18,7 @@
 			}
 		});
 
-		$api.Function.world.execute(jsh.shell.tools.node.require());
+		$api.fp.world.execute(jsh.shell.tools.node.require());
 		jsh.shell.tools.node.installed.modules.require({ name: "eslint" });
 
 		jsh.shell.tools.node.installed.run({

--- a/contributor/metrics.js
+++ b/contributor/metrics.js
@@ -20,7 +20,7 @@
 		 */
 		function getSourceFiles(base) {
 			/** @type { slime.js.Cast<slime.jrunscript.file.File> } */
-			var castToFile = $api.Function.cast;
+			var castToFile = $api.fp.cast;
 			return base.list({
 				type: $context.library.file.list.ENTRY,
 				filter: function(item) {
@@ -140,15 +140,15 @@
 					hasTypeChecking: function(entry) {
 						if (isJavascript(entry)) {
 							var code = entry.file.read(String);
-							return $api.Function.Maybe.value(code.indexOf("ts-check") != -1);
+							return $api.fp.Maybe.value(code.indexOf("ts-check") != -1);
 						}
-						return $api.Function.Maybe.nothing();
+						return $api.fp.Maybe.nothing();
 					}
 				}
 			},
 			jsapi: function(base) {
 				var src = getSourceFiles(base);
-				var grouper = $api.Function.Array.groupBy({
+				var grouper = $api.fp.Array.groupBy({
 					/** @type { (p: slime.project.metrics.SourceFile) => string } */
 					group: function(entry) {
 						if (isJsapi(entry)) return "jsapi";

--- a/contributor/metrics.jsh.js
+++ b/contributor/metrics.jsh.js
@@ -73,7 +73,7 @@
 					};
 
 					var src = getSourceFiles();
-					var grouper = $api.Function.Array.groupBy({
+					var grouper = $api.fp.Array.groupBy({
 						/** @type { (entry: slime.project.metrics.SourceFile) => string } */
 						group: function(entry) {
 							if (model.SourceFile.isJavascript(entry)) return "js";
@@ -157,11 +157,11 @@
 						return file.file.read(String).split("\n").length - 1;
 					}
 
-					var files = $api.Function.result(
+					var files = $api.fp.result(
 						getSourceFiles(),
-						$api.Function.Array.filter($api.Function.Predicate.not(model.SourceFile.isGenerated)),
-						$api.Function.Array.filter($api.Function.Predicate.not(model.SourceFile.isJsapi)),
-						$api.Function.Array.filter(function(file) {
+						$api.fp.Array.filter($api.fp.Predicate.not(model.SourceFile.isGenerated)),
+						$api.fp.Array.filter($api.fp.Predicate.not(model.SourceFile.isJsapi)),
+						$api.fp.Array.filter(function(file) {
 							return getLines(file) > 500;
 						})
 					).sort(function(a,b) {

--- a/jrunscript/host/module.js
+++ b/jrunscript/host/module.js
@@ -80,7 +80,7 @@
 		$exports.Array = JavaArray;
 
 		$exports.Map = function(o) {
-			return $api.Function.result(
+			return $api.fp.result(
 				o.object,
 				Object.entries,
 				function(entries) {

--- a/jrunscript/host/plugin.jsh.js
+++ b/jrunscript/host/plugin.jsh.js
@@ -21,7 +21,7 @@
 					jsh,
 					"java",
 					{
-						get: $api.Function.memoized(function() {
+						get: $api.fp.memoized(function() {
 							return $loader.module("module.js", {
 								globals: true,
 								$slime: $slime,

--- a/jrunscript/io/module.js
+++ b/jrunscript/io/module.js
@@ -58,7 +58,7 @@
 		/** @type { slime.jrunscript.io.Exports["InputStream"] } */
 		var InputStream = {
 			string: function(stream) {
-				return $api.Function.world.old.ask(function() {
+				return $api.fp.world.old.ask(function() {
 					return stream.character().asString();
 				});
 			},

--- a/jrunscript/tools/install/apache.js
+++ b/jrunscript/tools/install/apache.js
@@ -41,7 +41,7 @@
 					url: void(0)
 				};
 				Object.defineProperty(argument, "url", {
-					get: $api.Function.memoized(function() {
+					get: $api.fp.memoized(function() {
 						return mirror + p.path
 					})
 				});

--- a/jrunscript/tools/install/module.js
+++ b/jrunscript/tools/install/module.js
@@ -102,9 +102,9 @@
 		 * @returns { slime.$api.fp.Maybe<slime.jrunscript.tools.install.download.Format> }
 		 */
 		var getFormat = function(type) {
-			if (type.media == "application" && type.subtype == "zip") return $api.Function.Maybe.value(newFormats.zip);
-			if (type.media == "application" && type.subtype == "gzip") return $api.Function.Maybe.value(newFormats.targz);
-			return $api.Function.Maybe.nothing();
+			if (type.media == "application" && type.subtype == "zip") return $api.fp.Maybe.value(newFormats.zip);
+			if (type.media == "application" && type.subtype == "gzip") return $api.fp.Maybe.value(newFormats.targz);
+			return $api.fp.Maybe.nothing();
 		}
 
 		/**
@@ -262,7 +262,7 @@
 
 		/** @type { (p: slime.jrunscript.tools.install.old.WorldInstallation) => slime.$api.fp.world.old.Tell<slime.jrunscript.tools.install.events.Console> } */
 		var newInstall = function(p) {
-			return $api.Function.world.old.tell(function(events) {
+			return $api.fp.world.old.tell(function(events) {
 				if (typeof(p.source.file) != "string" && typeof(p.source.file) != "undefined") {
 					throw new TypeError("source.file must be string.");
 				}
@@ -313,17 +313,17 @@
 					var getFileMimeType = function(file) {
 						var basename = file.pathname.basename;
 						var decode = $api.mime.Type.codec.declaration.decode;
-						if (/\.zip$/.test(basename)) return $api.Function.Maybe.value(decode("application/zip"));
-						if (/\.tgz$/.test(basename)) return $api.Function.Maybe.value(decode("application/gzip"));
-						if (/\.tar.gz$/.test(basename)) return $api.Function.Maybe.value(decode("application/gzip"));
-						return $api.Function.Maybe.nothing();
+						if (/\.zip$/.test(basename)) return $api.fp.Maybe.value(decode("application/zip"));
+						if (/\.tgz$/.test(basename)) return $api.fp.Maybe.value(decode("application/gzip"));
+						if (/\.tar.gz$/.test(basename)) return $api.fp.Maybe.value(decode("application/gzip"));
+						return $api.fp.Maybe.nothing();
 					};
 
 					/** @param { slime.jrunscript.http.client.spi.Response } response */
 					var getResponseMimeType = function(response) {
-						return $api.Function.result(
+						return $api.fp.result(
 							$context.api.http.Header.value("Content-Type")(response.headers),
-							$api.Function.Maybe.map($api.mime.Type.codec.declaration.decode)
+							$api.fp.Maybe.map($api.mime.Type.codec.declaration.decode)
 						);
 					};
 
@@ -369,7 +369,7 @@
 							local = $context.api.shell.TMPDIR.createTemporary({ directory: true }).getRelativePath("archive" + format.extension);
 						}
 						var write = $context.api.file.world.Location.file.write.stream({ input: response.stream });
-						$api.Function.world.now.action(write, local.os.adapt());
+						$api.fp.world.now.action(write, local.os.adapt());
 						return { file: local.file, type: getResponseMimeType(response) };
 					}
 
@@ -379,7 +379,7 @@
 					 * @returns
 					 */
 					var createFetcher = function(events) {
-						return $api.Function.world.question(
+						return $api.fp.world.question(
 							$context.api.http.world.Client.withFollowRedirects($context.api.http.world.request),
 							{
 								request: function(e) {
@@ -417,7 +417,7 @@
 			get: $exports.get,
 			//	TODO	find is completely untested
 			find: function(p) {
-				return $api.Function.world.old.ask(function(events) {
+				return $api.fp.world.old.ask(function(events) {
 					get(p,events);
 					return p.file;
 				});
@@ -475,7 +475,7 @@
 
 						return function(p,on) {
 							var listeners = new Listeners({
-								on: $api.Function.evaluator(
+								on: $api.fp.evaluator(
 									function() { return on; },
 									function() { return defaultOn; },
 									function() { return {}; }

--- a/jrunscript/tools/install/world/fetch.jsh.js
+++ b/jrunscript/tools/install/world/fetch.jsh.js
@@ -13,7 +13,7 @@
 	 */
 	function($api,jsh,main) {
 		main(
-			$api.Function.pipe(
+			$api.fp.pipe(
 				jsh.script.cli.option.string({ longname: "url" }),
 				jsh.script.cli.option.string({ longname: "format" }),
 				function(p) {
@@ -22,7 +22,7 @@
 					var destination = jsh.shell.TMPDIR.createTemporary({ directory: true }).pathname;
 					destination.directory.remove();
 
-					$api.Function.world.now.action(
+					$api.fp.world.now.action(
 						jsh.tools.install.Download.install,
 						{
 							download: {

--- a/js/codec/ini.js
+++ b/js/codec/ini.js
@@ -153,8 +153,8 @@
 					valueOf: function(name) {
 						return function(file) {
 							var x = parse(file.split("\n")).value(name);
-							if (x === null) return $api.Function.Maybe.nothing();
-							return $api.Function.Maybe.value(x);
+							if (x === null) return $api.fp.Maybe.nothing();
+							return $api.fp.Maybe.value(x);
 						}
 					},
 					values: function(file) {

--- a/js/debug/plugin.jsh.js
+++ b/js/debug/plugin.jsh.js
@@ -4,102 +4,117 @@
 //
 //	END LICENSE
 
-plugin({
-	isReady: function() {
-		return Boolean(jsh.js) && Object.prototype.hasOwnProperty.call(jsh, "java");
-	},
-	load: function() {
-		Object.defineProperty(
-			jsh,
-			"debug",
-			{
-				get: $api.Function.memoized(function() {
-					var rv = $loader.module("module.js", $loader.file("context.java.js"));
+//@ts-check
+(
+	/**
+	 *
+	 * @param { slime.$api.Global } $api
+	 * @param { slime.jsh.plugin.$slime & { getDebugger: () => any } } $slime
+	 * @param { slime.jsh.Global } jsh
+	 * @param { slime.jsh.plugin.plugin } plugin
+	 * @param { slime.Loader } $loader
+	 */
+	function($api,$slime,jsh,plugin,$loader) {
+		//	TODO	decide what to do about getDebugger() in type definition above
+		plugin({
+			isReady: function() {
+				return Boolean(jsh.js) && Object.prototype.hasOwnProperty.call(jsh, "java");
+			},
+			load: function() {
+				Object.defineProperty(
+					jsh,
+					"debug",
+					{
+						get: $api.fp.memoized(function() {
+							var rv = $loader.module("module.js", $loader.file("context.java.js"));
 
-					var Dumper = function(indent,p) {
-						var top;
+							var Dumper = function(indent,p) {
+								var top;
 
-						var getTitle = function(data) {
-							var title = (function() {
-								if (typeof(data.node) == "undefined") {
-									return (top) ? top : "(top)";
-								} else if (data.node == null) {
-									return "(self)";
-								} else if (typeof(data.node == "function")) {
-									if (data.label) {
-										return data.label;
+								var getTitle = function(data) {
+									var title = (function() {
+										if (typeof(data.node) == "undefined") {
+											return (top) ? top : "(top)";
+										} else if (data.node == null) {
+											return "(self)";
+										} else if (typeof(data.node == "function")) {
+											if (data.label) {
+												return data.label;
+											}
+											var code = String(data.node);
+											code = code.split("\n").map(function(line) {
+												return indent + line;
+											}).slice(0,-1).join("\n")
+											return code;
+										} else {
+											throw new Error("Unknown node type: " + data.node);
+										}
+									})();
+									return title;
+								}
+
+								this.start = function(id) {
+									top = id;
+								}
+
+								this.child = function() {
+									return new Dumper(indent + p.indent, p);
+								}
+
+								this.dump = function(data) {
+									if (data.calls > 0) {
+										debugger;
+										var title = getTitle(data);
+										var counts = [
+											"Elapsed: " + String( (data.elapsed / 1000).toFixed(3) )
+											,"calls: " + data.calls
+											,"average: " + String( (data.elapsed / data.calls / 1000).toFixed(6) )
+										].join(" ");
+										if (title.indexOf("\n") == -1) {
+											p.log(indent + title + " " + counts);
+										} else {
+											p.log(indent + counts + " " + title);
+										}
+									} else {
+										p.log(indent + getTitle(data));
 									}
-									var code = String(data.node);
-									code = code.split("\n").map(function(line) {
-										return indent + line;
-									}).slice(0,-1).join("\n")
-									return code;
-								} else {
-									throw new Error("Unknown node type: " + data.node);
 								}
-							})();
-							return title;
-						}
-
-						this.start = function(id) {
-							top = id;
-						}
-
-						this.child = function() {
-							return new Dumper(indent + p.indent, p);
-						}
-
-						this.dump = function(data) {
-							if (data.calls > 0) {
-								debugger;
-								var title = getTitle(data);
-								var counts = [
-									"Elapsed: " + String( (data.elapsed / 1000).toFixed(3) )
-									,"calls: " + data.calls
-									,"average: " + String( (data.elapsed / data.calls / 1000).toFixed(6) )
-								].join(" ");
-								if (title.indexOf("\n") == -1) {
-									p.log(indent + title + " " + counts);
-								} else {
-									p.log(indent + counts + " " + title);
-								}
-							} else {
-								p.log(indent + getTitle(data));
 							}
-						}
+
+							rv.profile.cpu.dump = (function(f) {
+								return function(p) {
+									if (p.indent && p.log) {
+										//	TODO	use $api.deprecate? Would it work in a plugin?
+										debugger;
+										return f.call(this, new Dumper("", p));
+									} else {
+										return f.call(this, p);
+									}
+								}
+							})(rv.profile.cpu.dump);
+
+							rv.disableBreakOnExceptionsFor = $api.deprecate($api.debug.disableBreakOnExceptionsFor);
+
+							return rv;
+						})
 					}
+				)
 
-					rv.profile.cpu.dump = (function(f) {
-						return function(p) {
-							if (p.indent && p.log) {
-								//	TODO	use $api.deprecate? Would it work in a plugin?
-								debugger;
-								return f.call(this, new Dumper("", p));
-							} else {
-								return f.call(this, p);
-							}
+				if ($slime.getDebugger) {
+					$api.debugger = {};
+					Object.defineProperty($api.debugger, "breakOnExceptions", {
+						get: function() {
+							return $slime.getDebugger().isBreakOnExceptions();
+						},
+						set: function(v) {
+							$slime.getDebugger().setBreakOnExceptions(v);
 						}
-					})(rv.profile.cpu.dump);
-
-					rv.disableBreakOnExceptionsFor = $api.deprecate($api.debug.disableBreakOnExceptionsFor);
-
-					return rv;
-				})
-			}
-		)
-
-		if ($slime.getDebugger) {
-			$api.debugger = {};
-			Object.defineProperty($api.debugger, "breakOnExceptions", {
-				get: function() {
-					return $slime.getDebugger().isBreakOnExceptions();
-				},
-				set: function(v) {
-					$slime.getDebugger().setBreakOnExceptions(v);
+					});
 				}
-			});
-		}
 
-		jsh.js.Error.Type = $api.debug.disableBreakOnExceptionsFor(jsh.js.Error.Type);
+				jsh.js.Error.Type = $api.debug.disableBreakOnExceptionsFor(jsh.js.Error.Type);
+			}
+		})
 	}
-})
+//@ts-ignore
+)($api,$slime,jsh,plugin,$loader);

--- a/js/object/module.fifty.ts
+++ b/js/object/module.fifty.ts
@@ -28,7 +28,7 @@ namespace slime.js.old {
 		Error: any
 		Task: any
 
-		Function: slime.$api.Global["Function"]
+		Function: slime.$api.Global["fp"]
 
 		/**
 		 * @deprecated

--- a/js/object/module.js
+++ b/js/object/module.js
@@ -341,7 +341,7 @@
 			}
 		}
 
-		$exports.Function = $api.Function;
+		$exports.Function = $api.fp;
 		$api.deprecate($exports, "Function");
 
 		$exports.Filter = new function() {

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -108,7 +108,7 @@ namespace slime.time {
 
 			fifty.tests.Date.today = function() {
 				var subject = test.load({
-					now: $api.Function.returning(1643907600000)
+					now: $api.fp.returning(1643907600000)
 				});
 				var today = subject.Date.input.today();
 				verify(today, "today", function(it) {

--- a/js/web/module.js
+++ b/js/web/module.js
@@ -286,8 +286,8 @@
 		 * @param { slime.web.form.Control[] } controls
 		 * @returns { { [x: string]: string } }
 		 */
-		var controlsToObject = $api.Function.pipe(
-			$api.Function.Array.map(
+		var controlsToObject = $api.fp.pipe(
+			$api.fp.Array.map(
 				/** @returns { readonly [string, string] } */
 				function(control) {
 					return [control.name,control.value]
@@ -327,7 +327,7 @@
 			},
 			Control: {
 				isNamed: function(name) {
-					return $api.Function.Predicate.property("name", $api.Function.is(name));
+					return $api.fp.Predicate.property("name", $api.fp.is(name));
 				}
 			}
 		}
@@ -363,18 +363,18 @@
 
 				this.query = {
 					controls: function() {
-						return $api.Function.pipe(
+						return $api.fp.pipe(
 							$exports.window.url,
-							$api.Function.property("query"),
+							$api.fp.property("query"),
 							$exports.Url.query.parse
 						)(void(0))
 					},
 					object: function() {
 						var controls = $exports.window.query.controls();
 						if (controls === null) return null;
-						return $api.Function.result(
+						return $api.fp.result(
 							controls,
-							$api.Function.Array.map(
+							$api.fp.Array.map(
 								/** @returns { readonly [string, string] } */
 								function(control) {
 									return [control.name,control.value]

--- a/jsh/launcher/test/suite.js
+++ b/jsh/launcher/test/suite.js
@@ -109,7 +109,7 @@
 				events.fire("buildStart");
 				var tmpdir = $context.library.shell.TMPDIR.createTemporary({ directory: true });
 				events.fire("buildLocation", tmpdir);
-				$api.Function.world.now.action(
+				$api.fp.world.now.action(
 					_buildShell(p.src, void(0)),
 					tmpdir,
 					{
@@ -164,7 +164,7 @@
 		};
 
 		/** @type { (invocation: slime.jsh.internal.launcher.test.ShellInvocation) => slime.jsh.internal.launcher.test.Result } */
-		var getShellResultFor = $api.Function.world.question(shellResultQuestion, {
+		var getShellResultFor = $api.fp.world.question(shellResultQuestion, {
 			invocation: function(e) {
 				//	TODO	can we use console for this and the next call?
 				$context.console("Command: " + e.detail.command + " " + e.detail.arguments.join(" "));
@@ -353,7 +353,7 @@
 		 * @returns
 		 */
 		var getHome = function(context,built,console) {
-			return $api.Function.world.now.question(
+			return $api.fp.world.now.question(
 				requireBuiltShellHomeDirectory,
 				$api.Object.compose(context, {
 					specified: built
@@ -380,7 +380,7 @@
 
 		/** @type { <T>(input: slime.$api.fp.impure.Input<T>) => slime.$api.fp.impure.Input<T> } */
 		var memoized = function(input) {
-			return $api.Function.memoized(input);
+			return $api.fp.memoized(input);
 		}
 
 		var getBuiltShellHomeDirectory = function(p) {
@@ -396,7 +396,7 @@
 			 * @returns
 			 */
 			function(jsh,options,runner) {
-				var getJsh = $api.Function.impure.Input.value(jsh);
+				var getJsh = $api.fp.impure.Input.value(jsh);
 
 				var Context = {
 					src: getContextSrc,
@@ -411,13 +411,13 @@
 					}
 				};
 
-				var getContext = $api.Function.impure.Input.map(getJsh, Context.from.jsh);
+				var getContext = $api.fp.impure.Input.map(getJsh, Context.from.jsh);
 
-				var getSrc = $api.Function.impure.Input.map(getContext, Context.src);
+				var getSrc = $api.fp.impure.Input.map(getContext, Context.src);
 
-				var getEngines = memoized($api.Function.impure.Input.map(getSrc, getJavascriptEngines));
+				var getEngines = memoized($api.fp.impure.Input.map(getSrc, getJavascriptEngines));
 
-				var getUnbuilt = $api.Function.impure.Input.map(getSrc, function(src) {
+				var getUnbuilt = $api.fp.impure.Input.map(getSrc, function(src) {
 					/** @type { slime.jsh.internal.launcher.test.ShellImplementation } */
 					var unbuilt = {
 						type: "unbuilt",
@@ -439,7 +439,7 @@
 					});
 				});
 
-				var getBuilt = $api.Function.impure.Input.map(getHome, function(home) {
+				var getBuilt = $api.fp.impure.Input.map(getHome, function(home) {
 					/** @type { slime.jsh.internal.launcher.test.ShellImplementation } */
 					var built = {
 						type: "built",

--- a/jsh/script/plugin.jsh.fifty.ts
+++ b/jsh/script/plugin.jsh.fifty.ts
@@ -198,12 +198,12 @@ namespace slime.jsh.script {
 				fifty.tests.cli.option = function() {
 					const subject = test.subject;
 
-					var invoked = $api.Function.result(
+					var invoked = $api.fp.result(
 						{
 							options: {},
 							arguments: ["--foo", "bar", "--baz", 42]
 						},
-						$api.Function.pipe(
+						$api.fp.pipe(
 							subject.cli.option.string({ longname: "foo" }),
 							subject.cli.option.number({ longname: "baz" })
 						)
@@ -316,7 +316,7 @@ namespace slime.jsh.script {
 
 						fifty.run(
 				 			function() {
-								var processor = $api.Function.pipe(
+								var processor = $api.fp.pipe(
 									subject.cli.option.string({ longname: "a" }),
 									subject.cli.option.boolean({ longname: "b" }),
 									subject.cli.option.string({ longname: "aa" }),
@@ -405,7 +405,7 @@ namespace slime.jsh.script {
 			fifty.tests.cli.invocation = function() {
 				const subject = test.subject;
 
-				var parser = fifty.global.$api.Function.pipe(
+				var parser = fifty.global.$api.fp.pipe(
 					subject.cli.option.string({ longname: "foo" })
 				);
 				var was = fifty.global.jsh.unit.$slime;
@@ -443,7 +443,7 @@ namespace slime.jsh.script {
 					descriptor: {
 						options: subject.cli.option.string({ longname: "global" }),
 						commands: {
-							universe: $api.Function.pipe(
+							universe: $api.fp.pipe(
 								subject.cli.option.string({ longname: "command" }),
 								function(invocation) {
 									invocationWas(invocation);
@@ -495,7 +495,7 @@ namespace slime.jsh.script {
 					shell: fifty.global.jsh.shell.jsh.src,
 					script: fifty.jsh.file.object.getRelativePath("test/cli.jsh.js").file,
 					arguments: ["status"],
-					evaluate: $api.Function.identity
+					evaluate: $api.fp.identity
 				});
 				fifty.verify(result).status.is(0);
 
@@ -503,7 +503,7 @@ namespace slime.jsh.script {
 					shell: fifty.global.jsh.shell.jsh.src,
 					script: fifty.jsh.file.object.getRelativePath("test/cli.jsh.js").file,
 					arguments: ["status", "42"],
-					evaluate: $api.Function.identity
+					evaluate: $api.fp.identity
 				});
 				fifty.verify(result).status.is(42);
 
@@ -511,7 +511,7 @@ namespace slime.jsh.script {
 					shell: fifty.global.jsh.shell.jsh.src,
 					script: fifty.jsh.file.object.getRelativePath("test/cli.jsh.js").file,
 					arguments: [],
-					evaluate: $api.Function.identity
+					evaluate: $api.fp.identity
 				});
 				fifty.verify(result).status.is(1);
 			};

--- a/jsh/script/plugin.jsh.js
+++ b/jsh/script/plugin.jsh.js
@@ -133,7 +133,7 @@
 					}
 					if ($slime.getPackaged()) {
 						/** @type { slime.js.Cast<slime.old.Loader> } */
-						var toJavaLoader = $api.Function.cast;
+						var toJavaLoader = $api.fp.cast;
 						var x = toJavaLoader(new jsh.io.Loader({ _source: $slime.getPackaged().getCode() }));
 						rv.packaged = {
 							file: jsh.file.filesystem.java.adapt($slime.getPackaged().getFile()).file,
@@ -214,7 +214,7 @@
 							}
 							p.arguments = args;
 						};
-						return $api.Function.object.revise(rv);
+						return $api.fp.object.revise(rv);
 					}
 				};
 
@@ -279,7 +279,7 @@
 				/** @type { slime.jsh.script.cli.Exports["Call"]["get"] } */
 				var getCall = function(p) {
 					/** @type { slime.jsh.script.cli.Processor<{},{}> } */
-					var emptyOptions = $api.Function.identity;
+					var emptyOptions = $api.fp.identity;
 
 					var options = p.descriptor.options || emptyOptions;
 					var global = options({ options: {}, arguments: p.arguments });
@@ -356,7 +356,7 @@
 						});
 					},
 					option: {
-						string: option($api.Function.identity),
+						string: option($api.fp.identity),
 						boolean: function(o) {
 							var rv = function(p) {
 								var args = [];
@@ -369,7 +369,7 @@
 								}
 								p.arguments = args;
 							}
-							return $api.Function.object.revise(rv);
+							return $api.fp.object.revise(rv);
 						},
 						number: option(Number),
 						pathname: option(jsh.script.getopts.parser.Pathname),
@@ -386,7 +386,7 @@
 								}
 								p.arguments = args;
 							}
-							return $api.Function.object.revise(rv);
+							return $api.fp.object.revise(rv);
 						}
 					},
 					error: {
@@ -401,7 +401,7 @@
 					 */
 					invocation: function(f) {
 						/** @type { slime.js.Cast<T> } */
-						var cast = $api.Function.cast;
+						var cast = $api.fp.cast;
 						return f({
 							options: cast({}),
 							arguments: Array.prototype.slice.call(jsh.script.arguments)

--- a/jsh/test/jsh.script/hello.jsh.js
+++ b/jsh/test/jsh.script/hello.jsh.js
@@ -13,7 +13,7 @@
 	 */
 	function($api,jsh,main) {
 		main(
-			$api.Function.pipe(
+			$api.fp.pipe(
 				jsh.script.cli.option.string({ longname: "foo" }),
 				jsh.script.cli.option.number({ longname: "exit" }),
 				function(p) {

--- a/jsh/test/manual/https/main.jsh.js
+++ b/jsh/test/manual/https/main.jsh.js
@@ -14,7 +14,7 @@
 	function($api,jsh) {
 		var port = jsh.ip.getEphemeralPort().number;
 		var invocation = jsh.script.cli.invocation(
-			$api.Function.pipe(
+			$api.fp.pipe(
 				jsh.script.cli.option.pathname({ longname: "keystore" }),
 				jsh.script.cli.option.string({ longname: "password" })
 			)

--- a/jsh/tools/install/homebrew.js
+++ b/jsh/tools/install/homebrew.js
@@ -98,7 +98,7 @@
 										})
 									);
 									return {
-										run: $api.Function.world.old.ask(function(events) {
+										run: $api.fp.world.old.ask(function(events) {
 											var rv;
 											tell({
 												stdout: function(e) {

--- a/jsh/tools/install/mkcert.jsh.js
+++ b/jsh/tools/install/mkcert.jsh.js
@@ -15,7 +15,7 @@
 			commands: {
 				install: function() {
 					var invocation = jsh.script.cli.invocation(
-						$api.Function.pipe(
+						$api.fp.pipe(
 							jsh.script.cli.option.pathname({ longname: "destination", default: jsh.shell.jsh.lib.getRelativePath("bin/mkcert") })
 						)
 					);

--- a/jsh/tools/install/node.jsh.js
+++ b/jsh/tools/install/node.jsh.js
@@ -13,11 +13,11 @@
 	 */
 	function($api,jsh,main) {
 		main(
-			$api.Function.pipe(
+			$api.fp.pipe(
 				jsh.script.cli.option.pathname({ longname: "to" }),
 				jsh.script.cli.option.string({ longname: "version" }),
 				function(p) {
-					$api.Function.world.now.action(
+					$api.fp.world.now.action(
 						jsh.shell.tools.node.install,
 						{
 							location: p.options.to,

--- a/jsh/tools/install/plugin.jsh.js
+++ b/jsh/tools/install/plugin.jsh.js
@@ -164,7 +164,7 @@
 							});
 
 							/** @type { slime.js.Cast<slime.jrunscript.file.File> } */
-							var castToFile = $api.Function.cast;
+							var castToFile = $api.fp.cast;
 
 							var distribution = src.directory.getSubdirectory("build/distributions").list().map(castToFile)[0];
 							jsh.tools.install.install({
@@ -254,7 +254,7 @@
 					 * @returns { slime.jsh.shell.tools.mkcert.Installation }
 					 */
 					function Installation(program) {
-						var CAROOT = $api.Function.memoized(function() {
+						var CAROOT = $api.fp.memoized(function() {
 							var result = jsh.shell.run({
 								command: program,
 								arguments: ["-CAROOT"],
@@ -277,7 +277,7 @@
 									output: null,
 									error: null
 								},
-								evaluate: $api.Function.identity
+								evaluate: $api.fp.identity
 							});
 							return result.status === 0;
 						}

--- a/jsh/tools/install/selenium.jsh.js
+++ b/jsh/tools/install/selenium.jsh.js
@@ -42,7 +42,7 @@
 			 * @param { number } majorVersion
 			 */
 			var getLatestVersion = function(majorVersion) {
-				var response = $api.Function.world.input(jsh.http.world.request({
+				var response = $api.fp.world.input(jsh.http.world.request({
 					request: {
 						method: "GET",
 						url: jsh.web.Url.codec.string.decode("https://chromedriver.storage.googleapis.com/LATEST_RELEASE_" + majorVersion),

--- a/jsh/tools/npm.jsh.js
+++ b/jsh/tools/npm.jsh.js
@@ -17,7 +17,7 @@
 			jsh.shell.exit(1);
 		}
 
-		$api.Function.result(
+		$api.fp.result(
 			jsh.shell.tools.node.installed.modules.installed,
 			Object.entries,
 			function(entries) {

--- a/jsh/tools/profile.jsh.js
+++ b/jsh/tools/profile.jsh.js
@@ -12,7 +12,7 @@
 	 * @param { slime.jsh.Global } jsh
 	 */
 	function($api,jsh) {
-		var options = $api.Function.pipe(
+		var options = $api.fp.pipe(
 			jsh.script.cli.option.pathname({ longname: "profiler:javassist" }),
 			jsh.script.cli.option.pathname({ longname: "profiler:output:html" }),
 			jsh.script.cli.option.pathname({ longname: "profiler:output:json" }),
@@ -29,7 +29,7 @@
 		 * @param { slime.jrunscript.file.Pathname } pathname
 		 */
 		var isUnderSlime = function(pathname) {
-			return $api.Function.string.startsWith(jsh.shell.jsh.src.toString())(pathname.toString());
+			return $api.fp.string.startsWith(jsh.shell.jsh.src.toString())(pathname.toString());
 		};
 
 		var pathUnderSlime = function(pathname) {
@@ -38,7 +38,7 @@
 		}
 
 		jsh.script.cli.run(
-			$api.Function.pipe(
+			$api.fp.pipe(
 				options,
 				function(parameters) {
 					var output = (function() {

--- a/jsh/unit/plugin.jsh.web.js
+++ b/jsh/unit/plugin.jsh.web.js
@@ -200,7 +200,7 @@
 					})();
 
 					var getHgServerProxy = (httpd)
-						? $api.Function.memoized(function() {
+						? $api.fp.memoized(function() {
 							// Packages.java.lang.System.err.println("Invoke startHgServer");
 							var server = startHgServer();
 							// Packages.java.lang.System.err.println("Return httpd.Handler.Proxy");

--- a/loader/$api-Function-old.fifty.ts
+++ b/loader/$api-Function-old.fifty.ts
@@ -77,7 +77,7 @@ namespace slime.$api.fp.internal.old {
 			fifty: slime.fifty.test.Kit
 		) {
 			const { verify } = fifty;
-			const $api = fifty.global.$api as unknown as Exports;
+			const $api = fifty.global.$api;
 
 			fifty.tests.jsapi = fifty.test.Parent();
 
@@ -87,7 +87,7 @@ namespace slime.$api.fp.internal.old {
 					foo: "bar"
 				};
 
-				var mutating = $api.Function.mutating(function(p) {
+				var mutating = $api.fp.mutating(function(p) {
 					p.foo = "baz";
 				} as slime.$api.fp.old.Mutator<T>);
 
@@ -95,7 +95,7 @@ namespace slime.$api.fp.internal.old {
 				verify(result).foo.is("baz");
 				verify(result).is(object);
 
-				var swapper = $api.Function.mutating(function(p) {
+				var swapper = $api.fp.mutating(function(p) {
 					return { a: "b" }
 				}) as slime.$api.fp.old.Mutator<T>;
 
@@ -103,8 +103,8 @@ namespace slime.$api.fp.internal.old {
 				verify(swap).a.is("b");
 				verify(swap).is.not(object);
 
-				var voiding = $api.Function.mutating(function(p) {
-					return $api.Function.value.UNDEFINED;
+				var voiding = $api.fp.mutating(function(p) {
+					return $api.fp.value.UNDEFINED;
 				});
 
 				var voided = {
@@ -113,7 +113,7 @@ namespace slime.$api.fp.internal.old {
 				verify(voided).evaluate.property("value").is(void(0));
 
 				var k = { foo: "k" };
-				var valuer = $api.Function.mutating(k);
+				var valuer = $api.fp.mutating(k);
 				var valued = valuer(object);
 				verify(valued).foo.is("k");
 				verify(valued).is.not(object);
@@ -121,7 +121,7 @@ namespace slime.$api.fp.internal.old {
 				object = {
 					foo: "bar"
 				};
-				var missinger: (t: T) => T = $api.Function.mutating(void(0));
+				var missinger: (t: T) => T = $api.fp.mutating(void(0));
 				var missinged = missinger(object);
 				verify(missinged).foo.is("bar");
 				verify(missinged).is(object);

--- a/loader/$api-Function-stream.fifty.ts
+++ b/loader/$api-Function-stream.fifty.ts
@@ -44,20 +44,20 @@ namespace slime.$api.fp {
 
 			fifty.tests.suite = function() {
 				fifty.run(function testEmptyStream() {
-					var stream = $api.Function.Stream.from.empty();
-					var first = $api.Function.Stream.first(stream);
+					var stream = $api.fp.Stream.from.empty();
+					var first = $api.fp.Stream.first(stream);
 					verify(first).present.is(false);
-					var collected = $api.Function.Stream.collect(stream);
+					var collected = $api.fp.Stream.collect(stream);
 					verify(collected).length.is(0);
 				});
 
 				fifty.run(function testArrayStream() {
 					var array = [1,2,3,4];
-					var stream = $api.Function.Stream.from.array(array);
-					var first = $api.Function.Stream.first(stream);
+					var stream = $api.fp.Stream.from.array(array);
+					var first = $api.fp.Stream.first(stream);
 					verify(first).present.is(true);
 					verify(first).evaluate.property("value").is(1);
-					var collected = $api.Function.Stream.collect(stream);
+					var collected = $api.fp.Stream.collect(stream);
 					verify(collected).length.is(4);
 					verify(collected)[0].is(1);
 					verify(collected)[1].is(2);
@@ -78,12 +78,12 @@ namespace slime.$api.fp {
 					return function() {
 						if (start < limit) {
 							return {
-								next: $api.Function.Maybe.value(start),
+								next: $api.fp.Maybe.value(start),
 								remaining: streamRange(start+1, limit)
 							}
 						} else {
 							return {
-								next: $api.Function.Maybe.nothing(),
+								next: $api.fp.Maybe.nothing(),
 								remaining: emptyStream()
 							}
 						}
@@ -97,32 +97,32 @@ namespace slime.$api.fp {
 				var isOdd: Predicate<number> = (n: number) => n % 2 == 1;
 
 				fifty.run(function testStream() {
-					var rv = $api.Function.Stream.collect(streamTo(10));
+					var rv = $api.fp.Stream.collect(streamTo(10));
 					verify(rv.join(",")).is("0,1,2,3,4,5,6,7,8,9")
 				});
 
 				fifty.run(function testFilter() {
-					var rv = $api.Function.result(
+					var rv = $api.fp.result(
 						streamTo(10),
-						$api.Function.pipe(
-							$api.Function.Stream.filter(isOdd),
-							$api.Function.Stream.collect
+						$api.fp.pipe(
+							$api.fp.Stream.filter(isOdd),
+							$api.fp.Stream.collect
 						)
 					);
 					verify(rv.join(",")).is("1,3,5,7,9");
 				});
 
 				fifty.run(function testFind() {
-					var firstOdd = $api.Function.result(
+					var firstOdd = $api.fp.result(
 						streamTo(10),
-						$api.Function.Stream.find(isOdd)
+						$api.fp.Stream.find(isOdd)
 					);
 					verify(firstOdd).present.is(true);
 					verify(firstOdd).evaluate.property("value").is(1);
 
-					var firstOver10 = $api.Function.result(
+					var firstOver10 = $api.fp.result(
 						streamTo(10),
-						$api.Function.Stream.find(function(v) { return v > 10; })
+						$api.fp.Stream.find(function(v) { return v > 10; })
 					);
 					verify(firstOver10).present.is(false);
 				});

--- a/loader/$api-Function.fifty.ts
+++ b/loader/$api-Function.fifty.ts
@@ -6,12 +6,12 @@
 
 namespace slime.$api {
 	export interface Global {
-		Function: slime.$api.fp.Exports
+		fp: slime.$api.fp.Exports
 	}
 }
 
 /**
- * The {@link slime.$api.fp.Exports | Exports} member of this namespace is available as `$api.Function` in all scripts loaded by the
+ * The {@link slime.$api.fp.Exports | Exports} member of this namespace is available as `$api.fp` in all scripts loaded by the
  * SLIME loader.
  */
 namespace slime.$api.fp {
@@ -69,7 +69,7 @@ namespace slime.$api.fp {
 				};
 
 				verify(calls).is(void(0));
-				var memoized = fifty.global.$api.Function.memoized(counter);
+				var memoized = fifty.global.$api.fp.memoized(counter);
 				verify(calls).is(void(0));
 				var result = memoized();
 				verify(result).is(42);
@@ -228,9 +228,9 @@ namespace slime.$api.fp {
 					}
 				};
 
-				var x = fifty.global.$api.Function.result(
+				var x = fifty.global.$api.fp.result(
 					2,
-					fifty.global.$api.Function.pipe(
+					fifty.global.$api.fp.pipe(
 						times(3),
 						plus(4)
 					)
@@ -273,7 +273,7 @@ namespace slime.$api.fp {
 			const { verify } = fifty;
 
 			fifty.tests.is = function() {
-				var is2 = fifty.global.$api.Function.is(2);
+				var is2 = fifty.global.$api.fp.is(2);
 
 				verify(is2(2)).is(true);
 				//@ts-ignore
@@ -332,7 +332,7 @@ namespace slime.$api.fp {
 				const { $api } = fifty.global;
 
 				fifty.tests.exports.string.replace = function() {
-					var replacer = $api.Function.string.replace(/xmas/i, "Christmas");
+					var replacer = $api.fp.string.replace(/xmas/i, "Christmas");
 					var input = "Twas the night before Xmas...";
 					var output = "Twas the night before Christmas...";
 					verify(input).evaluate(replacer).is(output);
@@ -361,8 +361,8 @@ namespace slime.$api.fp {
 				const { $api } = fifty.global;
 
 				fifty.tests.exports.string.leftPad = function() {
-					var lpad4 = $api.Function.string.leftPad({ length: 4 });
-					var lpad4zero = $api.Function.string.leftPad({ length: 4, padding: "0" });
+					var lpad4 = $api.fp.string.leftPad({ length: 4 });
+					var lpad4zero = $api.fp.string.leftPad({ length: 4, padding: "0" });
 
 					verify("1").evaluate(lpad4).is("   1");
 					verify("1").evaluate(lpad4zero).is("0001");
@@ -370,8 +370,8 @@ namespace slime.$api.fp {
 				}
 
 				fifty.tests.exports.string.rightPad = function() {
-					var pad4 = $api.Function.string.rightPad({ length: 4 });
-					var pad4zero = $api.Function.string.rightPad({ length: 4, padding: "0" });
+					var pad4 = $api.fp.string.rightPad({ length: 4 });
+					var pad4zero = $api.fp.string.rightPad({ length: 4, padding: "0" });
 
 					verify("1").evaluate(pad4).is("1   ");
 					verify("1").evaluate(pad4zero).is("1000");
@@ -384,7 +384,7 @@ namespace slime.$api.fp {
 	}
 
 	/**
-	 * This object is available as `$api.Function` in all scripts loaded by the SLIME loader.
+	 * This object is available as `$api.fp` in all scripts loaded by the SLIME loader.
 	 */
 	export interface Exports {
 		string: exports.String
@@ -395,14 +395,14 @@ namespace slime.$api.fp {
 			fifty: slime.fifty.test.Kit
 		) {
 			fifty.tests.string = function() {
-				var subject = fifty.global.$api.Function.string;
+				var subject = fifty.global.$api.fp.string;
 
 				fifty.run(function repeat() {
-					var one = fifty.global.$api.Function.string.repeat(1)("foo");
+					var one = fifty.global.$api.fp.string.repeat(1)("foo");
 					fifty.verify(one).is("foo");
-					var three = fifty.global.$api.Function.string.repeat(3)("foo");
+					var three = fifty.global.$api.fp.string.repeat(3)("foo");
 					fifty.verify(three).is("foofoofoo");
-					var zero = fifty.global.$api.Function.string.repeat(0)("foo");
+					var zero = fifty.global.$api.fp.string.repeat(0)("foo");
 					fifty.verify(zero).is("");
 				});
 
@@ -440,7 +440,7 @@ namespace slime.$api.fp {
 			fifty.tests.Object = function() {
 				run(function fromEntries() {
 					var array = [ ["a", 2], ["b", 3] ];
-					var result: { a: number, b: number } = fifty.global.$api.Function.result(
+					var result: { a: number, b: number } = fifty.global.$api.fp.result(
 						array,
 						Object.fromEntries
 					) as { a: number, b: number };
@@ -508,7 +508,7 @@ namespace slime.$api.fp {
 				var n24 = [2, 4];
 
 				fifty.tests.exports.Array.concat = function() {
-					var append24 = $api.Function.Array.concat(n24);
+					var append24 = $api.fp.Array.concat(n24);
 
 					var n0124 = append24([0,1]);
 
@@ -520,7 +520,7 @@ namespace slime.$api.fp {
 				};
 
 				fifty.tests.exports.Array.prepend = function() {
-					var prepend24 = $api.Function.Array.prepend(n24);
+					var prepend24 = $api.fp.Array.prepend(n24);
 
 					var n2468 = prepend24([6,8]);
 					verify(n2468).length.is(4);
@@ -586,7 +586,7 @@ namespace slime.$api.fp {
 						[4],
 						[5,6]
 					];
-					var joined = $api.Function.Arrays.join(arrays);
+					var joined = $api.fp.Arrays.join(arrays);
 					verify(joined).length.is(6);
 					verify(joined)[0].is(1);
 					verify(joined)[1].is(2);
@@ -640,8 +640,8 @@ namespace slime.$api.fp {
 						{ a: 2, b: "b" }
 					]
 
-					const f1: Predicate<T> = fifty.global.$api.Function.Predicate.property("a", function(v) { return v == 1; });
-					const f2: Predicate<T> = fifty.global.$api.Function.Predicate.property("b", function(v) { return v == "b"; });
+					const f1: Predicate<T> = fifty.global.$api.fp.Predicate.property("a", function(v) { return v == 1; });
+					const f2: Predicate<T> = fifty.global.$api.fp.Predicate.property("b", function(v) { return v == "b"; });
 
 					verify(ts).evaluate(function(ts) { return ts.filter(f1); }).length.is(1);
 					verify(ts.filter(f1))[0].a.is(1);
@@ -685,7 +685,7 @@ namespace slime.$api.fp {
 			fifty: slime.fifty.test.Kit
 		) {
 			const { verify } = fifty;
-			const subject = fifty.global.$api.Function.RegExp;
+			const subject = fifty.global.$api.fp.RegExp;
 
 			fifty.tests.exports.RegExp = fifty.test.Parent();
 
@@ -767,7 +767,7 @@ namespace slime.$api.fp {
 			$api: slime.$api.Global
 		) {
 			const { verify, run } = fifty;
-			const $f = fifty.global.$api.Function;
+			const $f = fifty.global.$api.fp;
 
 			fifty.tests.compare = function() {
 				run(function orderingArray() {
@@ -790,27 +790,27 @@ namespace slime.$api.fp {
 					{ name: "b", value: 0 },
 					{ name: "c", value: 2 }
 				];
-				var comparator: slime.$api.fp.CompareFn<{ name: string, value: number }> = fifty.global.$api.Function.comparator.create(
-					fifty.global.$api.Function.property("value"),
-					fifty.global.$api.Function.comparator.operators
+				var comparator: slime.$api.fp.CompareFn<{ name: string, value: number }> = fifty.global.$api.fp.comparator.create(
+					fifty.global.$api.fp.property("value"),
+					fifty.global.$api.fp.comparator.operators
 				);
 				array.sort(comparator);
 				verify(array)[0].name.is("b");
 				verify(array)[1].name.is("a");
 				verify(array)[2].name.is("c");
-				array.sort(fifty.global.$api.Function.comparator.reverse(comparator));
+				array.sort(fifty.global.$api.fp.comparator.reverse(comparator));
 				verify(array)[0].name.is("c");
 				verify(array)[1].name.is("a");
 				verify(array)[2].name.is("b");
 
-				var tiebreaking: slime.$api.fp.CompareFn<{ name: string, value: number, tiebreaker: number }> = fifty.global.$api.Function.comparator.create(
-					fifty.global.$api.Function.property("tiebreaker"),
-					fifty.global.$api.Function.comparator.operators
+				var tiebreaking: slime.$api.fp.CompareFn<{ name: string, value: number, tiebreaker: number }> = fifty.global.$api.fp.comparator.create(
+					fifty.global.$api.fp.property("tiebreaker"),
+					fifty.global.$api.fp.comparator.operators
 				);
 
-				var multicomparator: slime.$api.fp.CompareFn<{ name: string, value: number, tiebreaker: number }> = fifty.global.$api.Function.comparator.compose(
-					fifty.global.$api.Function.comparator.reverse(comparator),
-					fifty.global.$api.Function.comparator.reverse(tiebreaking)
+				var multicomparator: slime.$api.fp.CompareFn<{ name: string, value: number, tiebreaker: number }> = fifty.global.$api.fp.comparator.compose(
+					fifty.global.$api.fp.comparator.reverse(comparator),
+					fifty.global.$api.fp.comparator.reverse(tiebreaking)
 				);
 
 				var multi = [
@@ -876,7 +876,7 @@ namespace slime.$api.fp {
 				var f3 = function(p: { number: number }) {
 					p.number -= 3;
 				}
-				var f = fifty.global.$api.Function.object.compose(f1, f2, f3);
+				var f = fifty.global.$api.fp.object.compose(f1, f2, f3);
 				var input = { number: 4 };
 				var output = f(input);
 				verify(output).number.is(7);
@@ -885,14 +885,14 @@ namespace slime.$api.fp {
 					return { number: 9 };
 				};
 
-				var r = fifty.global.$api.Function.object.compose(f1, r1, f3);
+				var r = fifty.global.$api.fp.object.compose(f1, r1, f3);
 				var rinput = { number: 4 };
 				var routput = r(rinput);
 				verify(routput).number.is(6);
 
 				fifty.run(function() {
-					var nullRevision = fifty.global.$api.Function.object.revise(null);
-					var undefinedRevision = fifty.global.$api.Function.object.revise(void(0));
+					var nullRevision = fifty.global.$api.fp.object.revise(null);
+					var undefinedRevision = fifty.global.$api.fp.object.revise(void(0));
 
 					var two = { number: 2 }
 
@@ -908,7 +908,7 @@ namespace slime.$api.fp {
 						function(a: A) { a.b++ },
 						function(a: A) { a.c = 0 }
 					];
-					var update = fifty.global.$api.Function.object.Update.compose(updates);
+					var update = fifty.global.$api.fp.object.Update.compose(updates);
 					update(a);
 					verify(a).a.is(2);
 					verify(a).b.is(3);
@@ -931,7 +931,7 @@ namespace slime.$api.fp {
 
 			fifty.tests.series = function() {
 				var api = fifty.global.$api;
-				var one = api.Function.series(
+				var one = api.fp.series(
 					function() {
 						return 1;
 					},
@@ -940,7 +940,7 @@ namespace slime.$api.fp {
 					}
 				);
 				verify(one()).is(1);
-				var two = api.Function.series(
+				var two = api.fp.series(
 					function(): number {
 						return void(0);
 					},
@@ -963,7 +963,7 @@ namespace slime.$api.fp {
 		 * * It may directly modify the value (if the value is mutable, like an object) in its implementation,
 		 * * It may _replace_ the value entirely by returning a value.
 		 *
-		 * The special value $api.Function.value.UNDEFINED can be returned to replace the value with `undefined`.
+		 * The special value $api.fp.value.UNDEFINED can be returned to replace the value with `undefined`.
 		 *
 		 * @param p A value to mutate or replace.
 		 *
@@ -1020,7 +1020,7 @@ namespace slime.$api.fp {
 			const { verify } = fifty;
 
 			fifty.tests.deprecated = function() {
-				var check = fifty.global.$api.Function.argument.check;
+				var check = fifty.global.$api.fp.argument.check;
 
 				var tester = {
 					invoke: function(argument,array) {

--- a/loader/$api-fp-impure.fifty.ts
+++ b/loader/$api-fp-impure.fifty.ts
@@ -82,7 +82,7 @@ namespace slime.$api.fp.world {
 				var captor = fifty.$api.Events.Captor({
 					argument: void(0)
 				});
-				var map = $api.Function.world.question(doubler, captor.handler);
+				var map = $api.fp.world.question(doubler, captor.handler);
 
 				verify(captor).events.length.is(0);
 				verify(2).evaluate(map).is(4);

--- a/loader/$api.api.html
+++ b/loader/$api.api.html
@@ -51,7 +51,7 @@ END LICENSE
 				</div>
 			</div>
 			<div>
-				<h2><code><a href="$api-Function.fifty.ts?as=text">$api.Function</a></code></h2>
+				<h2><code><a href="$api-Function.fifty.ts?as=text">$api.fp</a></code></h2>
 				<div>
 					Provides functional programming constructs.
 				</div>

--- a/loader/$api.js
+++ b/loader/$api.js
@@ -73,7 +73,7 @@
 		(function() {
 			var old = code.Function_old({ deprecate: $exports.deprecate });
 			var current = code.Function({ $api: $exports, events: events, old: old, deprecate: $exports.deprecate, script: script });
-			Object.assign($exports, { Function: current });
+			Object.assign($exports, { fp: current, Function: old.Function });
 		})();
 
 		$exports.debug = {
@@ -104,8 +104,8 @@
 		};
 
 		$exports.Filter = {
-			and: $exports.deprecate($exports.Function.Predicate.and),
-			or: $exports.deprecate($exports.Function.Predicate.or),
+			and: $exports.deprecate($exports.fp.Predicate.and),
+			or: $exports.deprecate($exports.fp.Predicate.or),
 		};
 
 		$exports.Constructor = {};
@@ -534,7 +534,7 @@
 		})($exports);
 
 		$exports.mime = code.mime({
-			Function: $exports.Function,
+			Function: $exports.fp,
 			deprecate: $exports.deprecate
 		});
 

--- a/loader/api/test/portable.jsh.js
+++ b/loader/api/test/portable.jsh.js
@@ -12,7 +12,7 @@
 	 */
 	function($api,jsh) {
 		(
-			$api.Function.pipe(
+			$api.fp.pipe(
 				jsh.script.cli.option.pathname({ longname: "definition" }),
 				function run(p) {
 					var suite = new jsh.unit.html.Suite();

--- a/loader/api/tools/snippets.jsh.js
+++ b/loader/api/tools/snippets.jsh.js
@@ -81,10 +81,10 @@
 			/**
 			 * @type { slime.tools.snippets.ApiHtmlSnippet[] }
 			 */
-			var snippets = $api.Function.result(
+			var snippets = $api.fp.result(
 				snippetAbbreviations,
 				Object.entries,
-				$api.Function.Array.map(
+				$api.fp.Array.map(
 					function(p) {
 						return {
 							name: p[0],
@@ -149,9 +149,9 @@
 			}
 
 			return function() {
-				var pattern = $api.Function.result(
+				var pattern = $api.fp.result(
 					snippetPattern,
-					$api.Function.RegExp.modify(function(pattern) {
+					$api.fp.RegExp.modify(function(pattern) {
 						return pattern.replace(/zzz/g, p.extension)
 					})
 				);
@@ -224,7 +224,7 @@
 			typescript: snippetFiles({ extension: "ts" })
 		}
 
-		$api.Function.result(
+		$api.fp.result(
 			{ options: {}, arguments: jsh.script.arguments },
 			jsh.script.cli.option.string({ longname: "language" }),
 			jsh.script.cli.option.string({ longname: "format" }),
@@ -235,9 +235,9 @@
 
 				var toObject = function(array) {
 					return array.reduce(function(rv,element) {
-						rv[element.name] = $api.Function.result(element, $api.Function.pipe(
+						rv[element.name] = $api.fp.result(element, $api.fp.pipe(
 							Object.entries,
-							$api.Function.Array.filter(function(entry) { return entry[0] != "name"; }),
+							$api.fp.Array.filter(function(entry) { return entry[0] != "name"; }),
 							Object.fromEntries
 						));
 						return rv;

--- a/loader/api/verify.js
+++ b/loader/api/verify.js
@@ -231,7 +231,7 @@
 										error: e,
 										message: name + " threw " + e
 									};
-									scope($api.Function.returning(result));
+									scope($api.fp.returning(result));
 								}
 							}
 
@@ -242,13 +242,13 @@
 									if (success) return name + " threw expected " + type.name;
 									return "Threw " + e + ", not " + new type().name;
 								})(success);
-								scope($api.Function.returning({
+								scope($api.fp.returning({
 									success: success,
 									message: message
 								}));
 							};
 							this.threw.nothing = function() {
-								scope($api.Function.returning({
+								scope($api.fp.returning({
 									success: false,
 									message: name + " threw " + e
 								}));
@@ -260,7 +260,7 @@
 
 							for (var x in delegate) {
 								this[x] = function() {
-									scope($api.Function.returning({
+									scope($api.fp.returning({
 										success: false,
 										message: name + " did not throw; returned " + returned
 									}));
@@ -268,14 +268,14 @@
 							}
 
 							this.nothing = function() {
-								scope($api.Function.returning({
+								scope($api.fp.returning({
 									success: true,
 									message: name + " did not error. (returned: " + returned + ")"
 								}));
 							};
 
 							this.type = function(type) {
-								scope($api.Function.returning({
+								scope($api.fp.returning({
 									success: false,
 									message: name + " did not throw expected error; returned " + returned
 								}))

--- a/loader/browser/test/server.js
+++ b/loader/browser/test/server.js
@@ -59,7 +59,7 @@
 													}
 												}
 											})()
-											: $api.Function.returning(void(0))
+											: $api.fp.returning(void(0))
 									),
 									(
 										(resultsPath)
@@ -78,7 +78,7 @@
 													url: resultsPath
 												})
 											})()
-											: $api.Function.returning(void(0))
+											: $api.fp.returning(void(0))
 									),
 									scope.httpd.Handler.Loader({
 										loader: new jsh.file.Loader({

--- a/loader/browser/test/suite.jsh.js
+++ b/loader/browser/test/suite.jsh.js
@@ -162,7 +162,7 @@
 												}
 											}
 										})()
-										: $api.Function.returning(void(0))
+										: $api.fp.returning(void(0))
 								),
 								(
 									(!parameters.options.interactive)
@@ -181,7 +181,7 @@
 												url: url
 											})
 										})()
-										: $api.Function.returning(void(0))
+										: $api.fp.returning(void(0))
 								),
 								scope.httpd.Handler.Loader({
 									loader: new jsh.file.Loader({
@@ -311,7 +311,7 @@
 			if (argument == "selenium:chrome") {
 				return jshUnitBrowserToBrowser(
 					"Chrome (Selenium)",
-					$api.Function.identity,
+					$api.fp.identity,
 					jsh.unit.browser.selenium.Chrome()
 				);
 			}
@@ -323,7 +323,7 @@
 				var instance = (parameters.options["chrome:instance"]) || jsh.shell.TMPDIR.createTemporary({ directory: true }).pathname;
 				return jshUnitBrowserToBrowser(
 					"Chrome",
-					$api.Function.identity,
+					$api.fp.identity,
 					jsh.unit.browser.local.Chrome({
 						program: jsh.shell.browser.installed.chrome.program,
 						user: instance.toString(),
@@ -335,7 +335,7 @@
 			if (argument == "firefox") {
 				return jshUnitBrowserToBrowser(
 					"Firefox",
-					$api.Function.identity,
+					$api.fp.identity,
 					jsh.unit.browser.local.Firefox({
 						//	TODO	push knowledge of these locations back into rhino/shell
 						program: "/Applications/Firefox.app/Contents/MacOS/firefox"

--- a/loader/document/module.fifty.ts
+++ b/loader/document/module.fifty.ts
@@ -166,18 +166,18 @@ namespace slime.runtime.document {
 
 			fifty.tests.Parent.one = function() {
 				var document = subject.Document.codec.string.decode("<root/>");
-				var nodes = $api.Function.result(
+				var nodes = $api.fp.result(
 					subject.Parent.nodes(document),
-					$api.Function.Stream.collect
+					$api.fp.Stream.collect
 				);
 				verify(nodes).length.is(2);
 			}
 
 			fifty.tests.Parent.two = function() {
 				var document = subject.Document.codec.string.decode("<root><a/><b><b2/></b></root>");
-				var nodes = $api.Function.result(
+				var nodes = $api.fp.result(
 					subject.Parent.nodes(document),
-					$api.Function.Stream.collect
+					$api.fp.Stream.collect
 				);
 
 				var isElement = function(name: string) {
@@ -194,11 +194,11 @@ namespace slime.runtime.document {
 				verify(nodes)[3].evaluate(isElement("b")).is(true);
 				verify(nodes)[4].evaluate(isElement("b2")).is(true);
 
-				var elements = $api.Function.result(
+				var elements = $api.fp.result(
 					subject.Parent.nodes(document),
-					$api.Function.pipe(
-						$api.Function.Stream.filter(subject.Node.isElement),
-						$api.Function.Stream.collect
+					$api.fp.pipe(
+						$api.fp.Stream.filter(subject.Node.isElement),
+						$api.fp.Stream.collect
 					)
 				);
 				verify(elements).length.is(4);

--- a/loader/document/module.js
+++ b/loader/document/module.js
@@ -112,7 +112,7 @@
 				})
 
 				Object.defineProperty(this, "children", {
-					get: $api.Function.memoized(function() {
+					get: $api.fp.memoized(function() {
 						return new NodeList(p.dom.childNodes);
 					}),
 					enumerable: true
@@ -161,7 +161,7 @@
 
 					var Parent = function(p) {
 						Object.defineProperty(this, "children", {
-							get: $api.Function.memoized(function() {
+							get: $api.fp.memoized(function() {
 								return new NodeList({ parent: p.jsoup });
 							}),
 							enumerable: true
@@ -170,7 +170,7 @@
 
 					var Doctype = function(p) {
 						Object.defineProperty(this, "name", {
-							get: noarg($api.Function.pipe(function() {
+							get: noarg($api.fp.pipe(function() {
 								return p.jsoup.attr("name");
 							}, $context.$slime.java.adapt.String)),
 							enumerable: true
@@ -265,8 +265,8 @@
 
 							var document = new (function(parent) {
 								Object.defineProperty(this, "element", {
-									get: noarg($api.Function.pipe(
-										$api.Function.returning(parent.children),
+									get: noarg($api.fp.pipe(
+										$api.fp.returning(parent.children),
 										function(array) {
 											return array.filter(filters.element);
 										},
@@ -338,7 +338,7 @@
 		 */
 		function NodesStream(root, cursor) {
 			/** @type { slime.js.Cast<slime.runtime.document.Parent> } */
-			var asParent = $api.Function.cast;
+			var asParent = $api.fp.cast;
 
 			/**
 			 *
@@ -379,8 +379,8 @@
 					next = checkParent(root, cursor);
 				}
 				return {
-					next: $api.Function.Maybe.value(position),
-					remaining: (next) ? NodesStream(root, next) : $api.Function.Stream.from.empty()
+					next: $api.fp.Maybe.value(position),
+					remaining: (next) ? NodesStream(root, next) : $api.fp.Stream.from.empty()
 				};
 			};
 		}
@@ -469,10 +469,10 @@
 							/** @type { slime.runtime.document.Node[] } */
 							var result = [];
 							copy.children = copy.children.reduce(function(rv,child,index,children) {
-								if (!hasOneTextChild) rv.push(text("\n" + $api.Function.string.repeat(depth+1)(p.indent)));
+								if (!hasOneTextChild) rv.push(text("\n" + $api.fp.string.repeat(depth+1)(p.indent)));
 								rv.push(convert(child,depth+1));
 								if (index+1 == children.length) {
-									if (!hasOneTextChild) rv.push(text("\n" + $api.Function.string.repeat(depth)(p.indent)));
+									if (!hasOneTextChild) rv.push(text("\n" + $api.fp.string.repeat(depth)(p.indent)));
 								}
 								return rv;
 							},result);

--- a/loader/document/source.js
+++ b/loader/document/source.js
@@ -84,49 +84,49 @@
 				 *
 				 * @param { slime.runtime.document.source.internal.State } state
 				 */
-				atXmlDeclaration: $api.Function.Predicate.and(
+				atXmlDeclaration: $api.fp.Predicate.and(
 					function(state) {
 						return state.position.offset == 0;
 					},
-					$api.Function.pipe(
+					$api.fp.pipe(
 						remaining,
 						startsWith("<?xml")
 					)
 				),
 
 				//	https://www.w3.org/TR/xml/#sec-cdata-sect
-				atCdata: $api.Function.pipe(
+				atCdata: $api.fp.pipe(
 					remaining,
 					startsWith(format.xml.cdata.start)
 				),
 
-				atComment: $api.Function.pipe(
+				atComment: $api.fp.pipe(
 					remaining,
 					startsWith("<!--")
 				),
 
-				atDoctype: $api.Function.pipe(
+				atDoctype: $api.fp.pipe(
 					remaining,
 					//	TODO	case-insensitive
 					startsWith("<!DOCTYPE")
 				),
 
-				atElement: $api.Function.pipe(
+				atElement: $api.fp.pipe(
 					remaining,
-					$api.Function.Predicate.and(
+					$api.fp.Predicate.and(
 						startsWith("<"),
-						$api.Function.Predicate.not(startsWith("</"))
+						$api.fp.Predicate.not(startsWith("</"))
 					)
 				),
 
-				atText: $api.Function.pipe(
+				atText: $api.fp.pipe(
 					remaining,
-					$api.Function.Predicate.not(startsWith("<"))
+					$api.fp.Predicate.not(startsWith("<"))
 				)
 			};
 		})();
 
-		var warnOnce = $api.Function.memoized(function() {
+		var warnOnce = $api.fp.memoized(function() {
 			debugger;
 		});
 
@@ -397,16 +397,16 @@
 				var after = recurse(
 					substate,
 					events,
-					$api.Function.pipe(
+					$api.fp.pipe(
 						State.remaining,
-						$api.Function.Predicate.or(
+						$api.fp.Predicate.or(
 							startsWithEndTag,
 							function(string) { return !Boolean(string.length) }
 						)
 					)
 				);
 
-				var endTag = $api.Function.pipe(
+				var endTag = $api.fp.pipe(
 					State.remaining,
 					startsWithEndTagFor(tagName),
 					function(closing) {

--- a/loader/document/test/manual/fidelity.jsh.js
+++ b/loader/document/test/manual/fidelity.jsh.js
@@ -12,7 +12,7 @@
 	 */
 	function($api,jsh) {
 		var invocation = jsh.script.cli.invocation(
-			$api.Function.pipe(
+			$api.fp.pipe(
 				jsh.script.cli.option.pathname({ longname: "markup" })
 			)
 		);

--- a/loader/expression.fifty.ts
+++ b/loader/expression.fifty.ts
@@ -482,7 +482,7 @@ namespace slime {
 			}
 			export namespace mime {
 				export interface Context {
-					Function: slime.$api.Global["Function"]
+					Function: slime.$api.Global["fp"]
 					deprecate: slime.$api.Global["deprecate"]
 				}
 			}

--- a/loader/jrunscript/expression.js
+++ b/loader/jrunscript/expression.js
@@ -381,7 +381,7 @@
 					}
 
 					/** @type { slime.js.Cast<slime.Resource["read"]> } */
-					var cast = slime.$api.Function.cast;
+					var cast = slime.$api.fp.cast;
 
 					this.read = cast(this.read);
 
@@ -460,7 +460,7 @@
 					// cache length and modified
 					if (isJrunscriptDescriptor(p) && Object.prototype.hasOwnProperty.call(p, "length")) {
 						Object.defineProperty(this,"length",{
-							get: slime.$api.Function.memoized(function() {
+							get: slime.$api.fp.memoized(function() {
 								if (typeof(p.length) == "number") {
 									return p.length;
 								} else if (typeof(p.length) == "undefined" && binary) {
@@ -491,7 +491,7 @@
 					if (isJrunscriptDescriptor(p) && Object.prototype.hasOwnProperty.call(p, "modified")) {
 						this.modified = void(0);
 						Object.defineProperty(this,"modified",{
-							get: slime.$api.Function.memoized(function() {
+							get: slime.$api.fp.memoized(function() {
 								return p.modified;
 							}),
 							enumerable: true
@@ -986,13 +986,13 @@
 							},
 							get: function(path) {
 								var _file = _loader.getFile(path.join("/"));
-								if (!_file) return slime.$api.Function.Maybe.nothing();
-								return slime.$api.Function.Maybe.value(_file)
+								if (!_file) return slime.$api.fp.Maybe.nothing();
+								return slime.$api.fp.Maybe.value(_file)
 							},
 							list: (_loader.getEnumerator()) ? function(path) {
 								var prefix = (path.length) ? path.join("/") : "";
 								var _list = _loader.getEnumerator().list(prefix);
-								if (!_list) return slime.$api.Function.Maybe.nothing();
+								if (!_list) return slime.$api.fp.Maybe.nothing();
 								var rv = Array.prototype.map.call(_list, function(x) { return String(x); }).map(function(string) {
 									var folder = (string.substring(string.length-1) == "/");
 									var name = (folder) ? string.substring(0,string.length-1) : string;
@@ -1003,7 +1003,7 @@
 									}
 									return item;
 								});
-								return slime.$api.Function.Maybe.value(rv);
+								return slime.$api.fp.Maybe.value(rv);
 							} : void(0),
 							code: function(_resource) {
 								var name = String(_resource.getSourceName());
@@ -1022,10 +1022,10 @@
 					}
 				},
 				entries: function(p) {
-					return slime.$api.Function.pipe(
-						slime.$api.Function.split({
+					return slime.$api.fp.pipe(
+						slime.$api.fp.split({
 							listing: slime.loader.synchronous.resources(p.filter),
-							loader: slime.$api.Function.identity
+							loader: slime.$api.fp.identity
 						}),
 						function(inputs) {
 							return inputs.listing.map(
@@ -1047,12 +1047,12 @@
 							},
 							length: function() {
 								var length = _resource.getLength();
-								if (length === null) return slime.$api.Function.Maybe.nothing();
-								return slime.$api.Function.Maybe.value(length.longValue());
+								if (length === null) return slime.$api.fp.Maybe.nothing();
+								return slime.$api.fp.Maybe.value(length.longValue());
 							},
 							modified: function() {
 								var _date = _resource.getLastModified();
-								return (_date) ? slime.$api.Function.Maybe.value(_date.getTime() / 1000) : slime.$api.Function.Maybe.nothing();
+								return (_date) ? slime.$api.fp.Maybe.value(_date.getTime() / 1000) : slime.$api.fp.Maybe.nothing();
 							}
 						}
 					}

--- a/loader/jrunscript/java.js
+++ b/loader/jrunscript/java.js
@@ -14,7 +14,7 @@
 	 */
 	function($api,$context,$exports) {
 		$exports.getClass = function(name) {
-			$api.Function.argument.isString({ index: 0, name: "name" }).apply(this,arguments);
+			$api.fp.argument.isString({ index: 0, name: "name" }).apply(this,arguments);
 			if ($context.classpath.getClass(name)) {
 				return $context.engine.getJavaClass(name);
 			}

--- a/loader/mime.fifty.ts
+++ b/loader/mime.fifty.ts
@@ -79,7 +79,7 @@ namespace slime.$api {
 		) {
 			fifty.tests.suite = function() {
 				var subject: slime.$api.mime.Export = fifty.$loader.module("mime.js", {
-					Function: fifty.global.$api.Function,
+					Function: fifty.global.$api.fp,
 					deprecate: function(f) {
 						return f;
 					}

--- a/loader/node/test/main.js
+++ b/loader/node/test/main.js
@@ -11,7 +11,7 @@
 		var base = __dirname + "/";
 		var loader = slime.fs.Loader({ base: base });
 		console.log(JSON.stringify({
-			identity: slime.runtime.$api.Function.identity(3),
+			identity: slime.runtime.$api.fp.identity(3),
 			base: base,
 			loader: {
 				type: typeof(loader),

--- a/loader/node/test/main.jsh.js
+++ b/loader/node/test/main.jsh.js
@@ -12,7 +12,7 @@
 	 */
 	function($api,jsh) {
 		jsh.shell.tools.rhino.require();
-		$api.Function.world.execute(jsh.shell.tools.node.require());
+		$api.fp.world.execute(jsh.shell.tools.node.require());
 		var node = jsh.shell.tools.node.installed;
 		//	TODO	this API could use better documentation, struggled to get this right
 		node.run({

--- a/rhino/file/file.js
+++ b/rhino/file/file.js
@@ -16,7 +16,7 @@
 	function (Packages, $api, $context, $export) {
 		if (!$context.Resource) throw new Error();
 
-		var constant = $api.Function.memoized;
+		var constant = $api.fp.memoized;
 
 		var fail = function(message) {
 			throw new Error(message);

--- a/rhino/file/java.js
+++ b/rhino/file/java.js
@@ -75,14 +75,14 @@
 				separator: {
 					file: "\\"
 				},
-				isAbsolute: $api.Function.pipe(fixWindowsForwardSlashes, function(string) {
+				isAbsolute: $api.fp.pipe(fixWindowsForwardSlashes, function(string) {
 					if (string[1] == ":" || string.substring(0,2) == "\\\\") {
 						return true;
 					} else {
 						return false;
 					}
 				}),
-				isRootPath: $api.Function.pipe(fixWindowsForwardSlashes, function(string) {
+				isRootPath: $api.fp.pipe(fixWindowsForwardSlashes, function(string) {
 					if (string.substring(1,2) == ":") {
 						return string.length == 3 && string[2] == "\\";
 					} else if (string.substring(0,2) == "\\\\") {
@@ -127,9 +127,9 @@
 			 * @param { string } path
 			 */
 			function removeTrailingSeparator(path) {
-				var matchTrailingSlash = $api.Function.result(
+				var matchTrailingSlash = $api.fp.result(
 					/(.*)/,
-					$api.Function.RegExp.modify(function(pattern) {
+					$api.fp.RegExp.modify(function(pattern) {
 						return pattern + "\\" + system.separator.file + "$";
 					})
 				);
@@ -140,8 +140,8 @@
 					return path;
 				}
 			}
-			var fixArgument = (system == systems.windows) ? fixWindowsForwardSlashes : $api.Function.identity;
-			return $api.Function.pipe(fixArgument, removeTrailingSeparator);
+			var fixArgument = (system == systems.windows) ? fixWindowsForwardSlashes : $api.fp.identity;
+			return $api.fp.pipe(fixArgument, removeTrailingSeparator);
 		}
 
 		/**
@@ -344,7 +344,7 @@
 				return function(events) {
 					var peer = java.newPeer(p.pathname);
 					var binary = peer.writeBinary(p.append || false);
-					return $api.Function.Maybe.value($context.api.io.Streams.java.adapt(binary));
+					return $api.fp.Maybe.value($context.api.io.Streams.java.adapt(binary));
 				}
 			}
 
@@ -358,9 +358,9 @@
 				var peer = java.newPeer(pathname);
 				if (!peer.exists()) {
 					events.fire("notFound");
-					return $api.Function.Maybe.nothing();
+					return $api.fp.Maybe.nothing();
 				}
-				return $api.Function.Maybe.value($context.api.io.Streams.java.adapt(peer.readBinary()));
+				return $api.fp.Maybe.value($context.api.io.Streams.java.adapt(peer.readBinary()));
 			}
 
 			var openWriter = function(pathname,events) {
@@ -384,7 +384,7 @@
 						read: {
 							stream: void(0),
 							string: function() {
-								return $api.Function.world.old.ask(function(events) {
+								return $api.fp.world.old.ask(function(events) {
 									var stream = openInputStream(pathname, events);
 									return (stream === null) ? null : stream.character().asString();
 								});
@@ -457,7 +457,7 @@
 					}
 					java.createDirectoryAt(peer);
 				}
-				return $api.Function.world.old.tell(function() {
+				return $api.fp.world.old.tell(function() {
 					var peer = java.newPeer(p.pathname);
 					var parent = java.getParent(peer);
 					if (!parent.exists()) {
@@ -471,7 +471,7 @@
 			}
 
 			function directory_remove_impure(p) {
-				return $api.Function.world.old.tell(function() {
+				return $api.fp.world.old.tell(function() {
 					var peer = java.newPeer(p.pathname);
 					peer.delete();
 				});
@@ -483,7 +483,7 @@
 			 */
 			function directory_exists_impure(pathname) {
 				return function() {
-					return $api.Function.world.old.ask(function(events) {
+					return $api.fp.world.old.ask(function(events) {
 						return directory_exists(pathname);
 					});
 				}
@@ -495,7 +495,7 @@
 			 */
 			function directory_list(pathname) {
 				return function() {
-					return $api.Function.world.old.ask(function(events) {
+					return $api.fp.world.old.ask(function(events) {
 						var peer = java.newPeer(pathname);
 						return peer.list(null).map(function(node) {
 							return pathname_create(String(node.getScriptPath()));
@@ -510,7 +510,7 @@
 			 */
 			function file_exists_impure(pathname) {
 				return function() {
-					return $api.Function.world.old.ask(function(events) {
+					return $api.fp.world.old.ask(function(events) {
 						var peer = java.newPeer(pathname);
 						return peer.exists() && !peer.isDirectory();
 					});
@@ -524,7 +524,7 @@
 			 * @returns { slime.$api.fp.world.old.Tell<void> }
 			 */
 			function copy_impure(file,destination) {
-				return $api.Function.world.old.tell(function(events) {
+				return $api.fp.world.old.tell(function(events) {
 					var from = java.newPeer(file);
 					var to = java.newPeer(destination);
 					$context.api.io.Streams.binary.copy(
@@ -598,12 +598,12 @@
 				openOutputStream: maybeOutputStream,
 				fileExists: function(p) {
 					return function(events) {
-						return $api.Function.Maybe.value(file_exists(p.pathname));
+						return $api.fp.Maybe.value(file_exists(p.pathname));
 					}
 				},
 				directoryExists: function(p) {
 					return function(events) {
-						return $api.Function.Maybe.value(directory_exists(p.pathname));
+						return $api.fp.Maybe.value(directory_exists(p.pathname));
 					}
 				},
 				createDirectory: function(p) {
@@ -643,7 +643,7 @@
 					read: {
 						stream: {
 							bytes: function(pathname) {
-								return $api.Function.world.old.ask(function(events) {
+								return $api.fp.world.old.ask(function(events) {
 									return openInputStream(pathname,events);
 								})
 							}
@@ -662,7 +662,7 @@
 				},
 				Directory: {
 					remove: function(p) {
-						return $api.Function.world.old.tell(function(e) {
+						return $api.fp.world.old.tell(function(e) {
 							var peer = java.newPeer(p.pathname);
 							if (!peer.exists()) e.fire("notFound");
 							if (peer.exists() && !peer.isDirectory()) throw new Error();

--- a/rhino/file/module-Loader.fifty.ts
+++ b/rhino/file/module-Loader.fifty.ts
@@ -66,9 +66,9 @@ namespace slime.jrunscript.file {
 					//	jsh.shell.echo(loader.list().map(function(item) { return item.path; }));
 					verify(map).java.evaluate(isLoaderEntry).is(true);
 					verify(map).java.evaluate(function() { return this.resource; }).is(void(0));
-					verify(map).java.evaluate($api.Function.property("resource")).is(void(0));
+					verify(map).java.evaluate($api.fp.property("resource")).is(void(0));
 					verify(map["java.js"]).evaluate(isResourceEntry).is(true);
-					verify(map["java.js"]).evaluate($api.Function.property("loader")).is(void(0));
+					verify(map["java.js"]).evaluate($api.fp.property("loader")).is(void(0));
 				});
 
 				run(function() {

--- a/rhino/file/module.js
+++ b/rhino/file/module.js
@@ -395,7 +395,7 @@
 		$exports.java = $context.api.io.java;
 
 		$export(
-			$api.Function.result(
+			$api.fp.result(
 				(
 					function() {
 						/** @type { slime.jrunscript.file.Exports } */

--- a/rhino/file/world.fifty.ts
+++ b/rhino/file/world.fifty.ts
@@ -84,23 +84,23 @@ namespace slime.jrunscript.file {
 					const { verify } = fifty;
 					const { $api, jsh } = fifty.global;
 
-					var writeText = $api.Function.world.action(
+					var writeText = $api.fp.world.action(
 						jsh.file.world.Location.file.write.string({ value: "tocopy" })
 					);
 
-					var readText = $api.Function.pipe(
-						$api.Function.world.question(
+					var readText = $api.fp.pipe(
+						$api.fp.world.question(
 							jsh.file.world.Location.file.read.string()
 						),
-						$api.Function.Maybe.map(function(s) { return s; }),
-						$api.Function.Maybe.else(function(): string { return null; })
+						$api.fp.Maybe.map(function(s) { return s; }),
+						$api.fp.Maybe.else(function(): string { return null; })
 					);
 
-					var exists = $api.Function.world.question(
+					var exists = $api.fp.world.question(
 						jsh.file.world.Location.file.exists()
 					);
 
-					var dExists = $api.Function.world.question(
+					var dExists = $api.fp.world.question(
 						jsh.file.world.Location.directory.exists()
 					)
 
@@ -116,7 +116,7 @@ namespace slime.jrunscript.file {
 							verify(exists(to)).is(false);
 							verify(readText(to)).is(null);
 
-							var copy = $api.Function.world.action(jsh.file.world.Location.file.copy({ to: to }));
+							var copy = $api.fp.world.action(jsh.file.world.Location.file.copy({ to: to }));
 							copy(from);
 
 							verify(exists(to)).is(true);
@@ -126,7 +126,7 @@ namespace slime.jrunscript.file {
 						fifty.run(function recursive() {
 							var from = fifty.jsh.file.temporary.location();
 							var parent = fifty.jsh.file.temporary.location();
-							var to = $api.Function.result(
+							var to = $api.fp.result(
 								parent,
 								jsh.file.world.Location.relative("foo")
 							);
@@ -144,7 +144,7 @@ namespace slime.jrunscript.file {
 							verify(exists(to)).is(false);
 							verify(readText(to)).is(null);
 
-							var copy = $api.Function.world.action(jsh.file.world.Location.file.copy({ to: to }), captor.handler);
+							var copy = $api.fp.world.action(jsh.file.world.Location.file.copy({ to: to }), captor.handler);
 							copy(from);
 
 							verify(dExists(parent)).is(true);
@@ -167,7 +167,7 @@ namespace slime.jrunscript.file {
 							verify(exists(to)).is(false);
 							verify(readText(to)).is(null);
 
-							var copy = $api.Function.world.action(jsh.file.world.Location.file.move({ to: to }));
+							var copy = $api.fp.world.action(jsh.file.world.Location.file.move({ to: to }));
 							copy(from);
 
 							verify(exists(from)).is(false);
@@ -178,7 +178,7 @@ namespace slime.jrunscript.file {
 						fifty.run(function recursive() {
 							var from = fifty.jsh.file.temporary.location();
 							var parent = fifty.jsh.file.temporary.location();
-							var to = $api.Function.result(
+							var to = $api.fp.result(
 								parent,
 								jsh.file.world.Location.relative("foo")
 							);
@@ -197,7 +197,7 @@ namespace slime.jrunscript.file {
 							verify(exists(to)).is(false);
 							verify(readText(to)).is(null);
 
-							var copy = $api.Function.world.action(jsh.file.world.Location.file.move({ to: to }), captor.handler);
+							var copy = $api.fp.world.action(jsh.file.world.Location.file.move({ to: to }), captor.handler);
 							copy(from);
 
 							verify(exists(from)).is(false);
@@ -254,13 +254,13 @@ namespace slime.jrunscript.file {
 						fifty.run(function exists() {
 							var at = fifty.jsh.file.temporary.location();
 
-							var exists = $api.Function.world.question(subject.Location.file.exists());
+							var exists = $api.fp.world.question(subject.Location.file.exists());
 
 							verify(exists(at)).is(false);
 
-							var writeA = $api.Function.world.action(subject.Location.file.write.string({ value: "a" }));
+							var writeA = $api.fp.world.action(subject.Location.file.write.string({ value: "a" }));
 
-							$api.Function.impure.now.output(at, writeA);
+							$api.fp.impure.now.output(at, writeA);
 
 							verify(exists(at)).is(true);
 						});
@@ -272,13 +272,13 @@ namespace slime.jrunscript.file {
 							buffer.writeText().write("text");
 							buffer.close();
 
-							var process = $api.Function.world.tell(
+							var process = $api.fp.world.tell(
 								subject.Location.file.write.stream({ input: buffer.readBinary() })(at)
 							);
 
 							process();
 
-							var getText = $api.Function.world.input(
+							var getText = $api.fp.world.input(
 								subject.Location.file.read.string()(at)
 							);
 
@@ -338,14 +338,14 @@ namespace slime.jrunscript.file {
 					fifty.tests.sandbox.locations.directory.exists = function() {
 						var at = fifty.jsh.file.temporary.location();
 
-						var exists = Object.assign($api.Function.world.question(subject.Location.directory.exists()), { toString: function() { return "exists()"; }});
+						var exists = Object.assign($api.fp.world.question(subject.Location.directory.exists()), { toString: function() { return "exists()"; }});
 
 						verify(at).evaluate(exists).is(false);
 
-						$api.Function.world.tell(subject.Location.directory.require()(at))();
+						$api.fp.world.tell(subject.Location.directory.require()(at))();
 						verify(at).evaluate(exists).is(true);
 
-						$api.Function.world.tell(subject.Location.directory.require()(at))();
+						$api.fp.world.tell(subject.Location.directory.require()(at))();
 						verify(at).evaluate(exists).is(true);
 					}
 				}
@@ -375,23 +375,23 @@ namespace slime.jrunscript.file {
 
 					fifty.tests.sandbox.locations.directory.move = function() {
 						const exists = {
-							file: $api.Function.world.question(jsh.file.world.Location.file.exists()),
-							directory: $api.Function.world.question(jsh.file.world.Location.directory.exists())
+							file: $api.fp.world.question(jsh.file.world.Location.file.exists()),
+							directory: $api.fp.world.question(jsh.file.world.Location.directory.exists())
 						};
 
 						const atFilepath = jsh.file.world.Location.relative("filepath");
 
-						const createDirectoryToMove = $api.Function.impure.Input.map(
+						const createDirectoryToMove = $api.fp.impure.Input.map(
 							fifty.jsh.file.temporary.location,
-							$api.Function.pipe(
+							$api.fp.pipe(
 								//	TODO	Output.compose?
-								$api.Function.impure.tap(
-									$api.Function.world.action(jsh.file.world.Location.directory.require())
+								$api.fp.impure.tap(
+									$api.fp.world.action(jsh.file.world.Location.directory.require())
 								),
-								$api.Function.impure.tap(
-									$api.Function.pipe(
+								$api.fp.impure.tap(
+									$api.fp.pipe(
 										atFilepath,
-										$api.Function.world.action(jsh.file.world.Location.file.write.string({ value: "contents" }))
+										$api.fp.world.action(jsh.file.world.Location.file.write.string({ value: "contents" }))
 									)
 								)
 							)
@@ -409,7 +409,7 @@ namespace slime.jrunscript.file {
 								verify(to).evaluate(atFilepath).evaluate(exists.file).is(false);
 							})();
 
-							var move = $api.Function.world.action(
+							var move = $api.fp.world.action(
 								jsh.file.world.Location.directory.move({ to: to })
 							);
 
@@ -428,7 +428,7 @@ namespace slime.jrunscript.file {
 
 							var parent = fifty.jsh.file.temporary.location();
 
-							var to = $api.Function.result(parent, jsh.file.world.Location.relative("child"));
+							var to = $api.fp.result(parent, jsh.file.world.Location.relative("child"));
 
 							var captor = fifty.$api.Events.Captor({
 								created: void(0)
@@ -442,7 +442,7 @@ namespace slime.jrunscript.file {
 								verify(captor).events.length.is(0);
 							})();
 
-							var move = $api.Function.world.action(
+							var move = $api.fp.world.action(
 								jsh.file.world.Location.directory.move({ to: to }),
 								captor.handler
 							);
@@ -508,12 +508,12 @@ namespace slime.jrunscript.file {
 					var result = parent.relative(relative);
 					verify(result).is.type("object");
 					verify(result).relative.is.type("function");
-					verify(result).pathname.evaluate($api.Function.string.endsWith("module.fifty.ts")).is(true);
+					verify(result).pathname.evaluate($api.fp.string.endsWith("module.fifty.ts")).is(true);
 					result = parent.relative("foo");
 					verify(result).is.type("object");
 					verify(result).relative.is.type("function");
-					verify(result).pathname.evaluate($api.Function.string.endsWith("module.fifty.ts")).is(false);
-					verify(result).pathname.evaluate($api.Function.string.endsWith("foo")).is(true);
+					verify(result).pathname.evaluate($api.fp.string.endsWith("module.fifty.ts")).is(false);
+					verify(result).pathname.evaluate($api.fp.string.endsWith("foo")).is(true);
 				}
 			}
 		//@ts-ignore
@@ -919,12 +919,12 @@ namespace slime.jrunscript.file {
 					fifty.tests.sandbox.filesystem.File.read = function() {
 						var me = filesystem.Pathname.relative(here, "module.fifty.ts");
 						var nothing = filesystem.Pathname.relative(here, "nonono");
-						var code = $api.Function.impure.now.input(
-							$api.Function.world.input(filesystem.File.read.string({ pathname: me }))
+						var code = $api.fp.impure.now.input(
+							$api.fp.world.input(filesystem.File.read.string({ pathname: me }))
 						);
 						verify(code,"code").is.type("string");
-						var no = $api.Function.impure.now.input(
-							$api.Function.world.input(filesystem.File.read.string({ pathname: nothing }))
+						var no = $api.fp.impure.now.input(
+							$api.fp.world.input(filesystem.File.read.string({ pathname: nothing }))
 						);
 						verify(no,"no").is.type("null");
 
@@ -932,13 +932,13 @@ namespace slime.jrunscript.file {
 							var pathname = function(relative: string) { return fifty.jsh.file.object.getRelativePath(relative).toString(); };
 							var thisFile = pathname("module.fifty.ts");
 							var doesNotExist = pathname("foo");
-							var thisFileContents = $api.Function.impure.now.input(
-								$api.Function.world.input(
+							var thisFileContents = $api.fp.impure.now.input(
+								$api.fp.world.input(
 									filesystem.File.read.string({ pathname: thisFile })
 								)
 							);
-							var doesNotExistContents = $api.Function.impure.now.input(
-								$api.Function.world.input(
+							var doesNotExistContents = $api.fp.impure.now.input(
+								$api.fp.world.input(
 									filesystem.File.read.string({ pathname: doesNotExist })
 								)
 							);
@@ -956,7 +956,7 @@ namespace slime.jrunscript.file {
 							return filesystem.Pathname.isDirectory(location);
 						}
 						verify(location).evaluate(exists).is(false);
-						$api.Function.world.now.action(filesystem.createDirectory, { pathname: location });
+						$api.fp.world.now.action(filesystem.createDirectory, { pathname: location });
 						verify(location).evaluate(exists).is(true);
 						filesystem.Directory.remove({
 							pathname: location
@@ -1001,29 +1001,29 @@ namespace slime.jrunscript.file {
 					//	exist. So going to test for that, and test for files and directories.
 
 					var exists = {
-						file: $api.Function.world.question(Location.file.exists()),
-						directory: $api.Function.world.question(Location.directory.exists())
+						file: $api.fp.world.question(Location.file.exists()),
+						directory: $api.fp.world.question(Location.directory.exists())
 					};
 
-					var tmpfile = $api.Function.world.input(jsh.file.world.filesystems.os.temporary({ directory: false }));
-					var tmpdir = $api.Function.world.input(jsh.file.world.filesystems.os.temporary({ directory: true }));
+					var tmpfile = $api.fp.world.input(jsh.file.world.filesystems.os.temporary({ directory: false }));
+					var tmpdir = $api.fp.world.input(jsh.file.world.filesystems.os.temporary({ directory: true }));
 
-					var file = $api.Function.impure.Input.process(
+					var file = $api.fp.impure.Input.process(
 						tmpfile,
 						function(location) {
 							verify(location).evaluate(exists.file).is(true);
 						}
 					);
 
-					var directory = $api.Function.impure.Input.process(
+					var directory = $api.fp.impure.Input.process(
 						tmpdir,
 						function(location) {
 							verify(location).evaluate(exists.directory).is(true);
 						}
 					);
 
-					$api.Function.impure.now.process(
-						$api.Function.impure.Process.compose([
+					$api.fp.impure.now.process(
+						$api.fp.impure.Process.compose([
 							file,
 							directory
 						])
@@ -1080,8 +1080,8 @@ namespace slime.jrunscript.file {
 
 			fifty.tests.world = function() {
 				var pathname = fifty.jsh.file.object.getRelativePath("module.fifty.ts").toString();
-				var contents = $api.Function.impure.now.input(
-					$api.Function.world.input(
+				var contents = $api.fp.impure.now.input(
+					$api.fp.world.input(
 						world.spi.filesystems.os.File.read.string({ pathname: pathname })
 					)
 				);

--- a/rhino/file/world.js
+++ b/rhino/file/world.js
@@ -50,11 +50,11 @@
 				pathname: location.pathname
 			});
 			var output = ask(events);
-			$api.Function.result(
+			$api.fp.result(
 				output,
-				$api.Function.pipe(
-					$api.Function.Maybe.map(write),
-					$api.Function.Maybe.else(function() {
+				$api.fp.pipe(
+					$api.fp.Maybe.map(write),
+					$api.fp.Maybe.else(function() {
 						throw new Error("Could not write to location " + location.pathname);
 					})
 				)
@@ -92,7 +92,7 @@
 				var exists = Location_directory_exists(parent)(events);
 				if (!exists) {
 					it(parent, events);
-					$api.Function.world.now.action(
+					$api.fp.world.now.action(
 						location.filesystem.createDirectory,
 						{ pathname: parent.pathname }
 					);
@@ -168,9 +168,9 @@
 										pathname: location.pathname
 									});
 									var maybe = ask(events);
-									return $api.Function.result(
+									return $api.fp.result(
 										maybe,
-										$api.Function.Maybe.map(
+										$api.fp.Maybe.map(
 											function(it) {
 												return it.character().asString()
 											}
@@ -219,9 +219,9 @@
 										var ask = location.filesystem.openOutputStream({
 											pathname: location.pathname
 										});
-										return $api.Function.result(
+										return $api.fp.result(
 											ask(events),
-											$api.Function.Maybe.map(function(stream) {
+											$api.fp.Maybe.map(function(stream) {
 												return stream.character();
 											})
 										);
@@ -236,7 +236,7 @@
 							return function(events) {
 								if (p.to.filesystem != location.filesystem) throw new Error("Must be same filesystem.");
 
-								$api.Function.world.now.action(
+								$api.fp.world.now.action(
 									ensureParent,
 									p.to,
 									{
@@ -260,7 +260,7 @@
 								//	TODO	insert existence check like there? Refactor?
 								if (p.to.filesystem != location.filesystem) throw new Error("Must be same filesystem.");
 
-								$api.Function.world.now.action(
+								$api.fp.world.now.action(
 									ensureParent,
 									p.to,
 									{
@@ -292,7 +292,7 @@
 								if (exists.present) {
 									if (!exists.value) {
 										if (p && p.recursive) {
-											$api.Function.world.now.action(
+											$api.fp.world.now.action(
 												ensureParent,
 												location,
 												{
@@ -305,7 +305,7 @@
 												}
 											);
 										}
-										$api.Function.world.now.action(
+										$api.fp.world.now.action(
 											location.filesystem.createDirectory,
 											{ pathname: location.pathname },
 											{
@@ -331,7 +331,7 @@
 					move: function(p) {
 						return function(location) {
 							return function(events) {
-								var exists = $api.Function.world.now.question(
+								var exists = $api.fp.world.now.question(
 									location.filesystem.directoryExists,
 									{ pathname: location.pathname }
 								);
@@ -340,7 +340,7 @@
 
 								if (p.to.filesystem != location.filesystem) throw new Error("Must be same filesystem.");
 
-								$api.Function.world.now.action(
+								$api.fp.world.now.action(
 									ensureParent,
 									p.to,
 									{
@@ -350,7 +350,7 @@
 									}
 								);
 
-								$api.Function.world.now.action(
+								$api.fp.world.now.action(
 									location.filesystem.move,
 									{
 										from: location.pathname,

--- a/rhino/http/client/curl.fifty.ts
+++ b/rhino/http/client/curl.fifty.ts
@@ -56,7 +56,7 @@ namespace slime.jrunscript.http.client.curl {
 				var implementation = api({
 					unixSocket: "/var/run/docker.sock"
 				});
-				var response = $api.Function.world.input(implementation({
+				var response = $api.fp.world.input(implementation({
 					request: {
 						method: "GET",
 						url: jsh.web.Url.codec.string.decode("http://docker.local.unix/info"),

--- a/rhino/http/client/curl.js
+++ b/rhino/http/client/curl.js
@@ -68,7 +68,7 @@
 							var lines = output.split("\n");
 
 							var noCarriageReturn = function(line) {
-								if ($api.Function.string.endsWith("\r")(line)) {
+								if ($api.fp.string.endsWith("\r")(line)) {
 									line = line.substring(0,line.length-1);
 								}
 								return line;

--- a/rhino/http/client/module.js
+++ b/rhino/http/client/module.js
@@ -363,16 +363,16 @@
 				return function(headers) {
 					var filtered = headers.filter(isHeaderName(name));
 					if (filtered.length > 1) throw new Error("Expected only one match for header " + name + ", but got more than one");
-					return $api.Function.result(
-						$api.Function.Maybe.from(filtered[0]),
-						$api.Function.Maybe.map($api.Function.property("value"))
+					return $api.fp.result(
+						$api.fp.Maybe.from(filtered[0]),
+						$api.fp.Maybe.map($api.fp.property("value"))
 					);
 				}
 			},
 			values: function(name) {
 				return function(headers) {
 					var filtered = headers.filter(isHeaderName(name));
-					return filtered.map($api.Function.property("value"));
+					return filtered.map($api.fp.property("value"));
 				}
 			}
 		}

--- a/rhino/http/client/objects.js
+++ b/rhino/http/client/objects.js
@@ -188,7 +188,7 @@
 			 */
 			function oldspi(p) {
 				var body = $context.interpretRequestBody(p.body);
-				return $api.Function.world.input(urlConnectionImplementation({
+				return $api.fp.world.input(urlConnectionImplementation({
 					request: {
 						method: p.method,
 						url: p.url,
@@ -222,7 +222,7 @@
 					}
 				})();
 
-				var spirequest = $api.Function.result(
+				var spirequest = $api.fp.result(
 					interpretRequest(p),
 					sessionRequest(cookies),
 					authorizedRequest(authorization),

--- a/rhino/http/client/spi.fifty.ts
+++ b/rhino/http/client/spi.fifty.ts
@@ -75,7 +75,7 @@ namespace slime.jrunscript.http.client.spi {
 					}
 				});
 				server.start();
-				var ask = $api.Function.world.input(subject({
+				var ask = $api.fp.world.input(subject({
 					request: {
 						method: "GET",
 						url: jsh.web.Url.codec.string.decode("http://127.0.0.1:" + server.port + "/foo"),

--- a/rhino/http/servlet/tools/serve.jsh.js
+++ b/rhino/http/servlet/tools/serve.jsh.js
@@ -14,7 +14,7 @@
 	function($api,jsh) {
 		jsh.shell.tools.tomcat.require();
 
-		$api.Function.result(
+		$api.fp.result(
 			{ options: { index: "index.html" }, arguments: jsh.script.arguments },
 			jsh.script.cli.option.pathname({ longname: "chrome:data" }),
 			jsh.script.cli.option.string({ longname: "index" }),

--- a/rhino/ip/module.fifty.ts
+++ b/rhino/ip/module.fifty.ts
@@ -253,14 +253,14 @@ namespace slime.jrunscript.ip {
 				var mocks = {
 					success: Mock(
 						function(p) {
-							return $api.Function.world.old.ask(function(events) {
+							return $api.fp.world.old.ask(function(events) {
 								return true;
 							})
 						}
 					),
 					error: Mock(
 						function(p) {
-							return $api.Function.world.old.ask(function(events) {
+							return $api.fp.world.old.ask(function(events) {
 								events.fire("error", new Error("mock error message"));
 								return false;
 							})
@@ -268,7 +268,7 @@ namespace slime.jrunscript.ip {
 					),
 					failure: Mock(
 						function(p) {
-							return $api.Function.world.old.ask(function(events) {
+							return $api.fp.world.old.ask(function(events) {
 								return false;
 							})
 						}
@@ -388,7 +388,7 @@ namespace slime.jrunscript.ip {
 				) => boolean
 			 ) {
 				var isAvailable: World["tcp"]["isAvailable"] = function(p) {
-					return $api.Function.world.old.ask(function(events) {
+					return $api.fp.world.old.ask(function(events) {
 						return implementation(p, events);
 					})
 				};

--- a/rhino/ip/module.js
+++ b/rhino/ip/module.js
@@ -28,7 +28,7 @@
 		 * @param { (t: T) => Error } failure
 		 */
 		var assert = function(test,failure) {
-			return $api.Function.conditional({
+			return $api.fp.conditional({
 				condition: test,
 				true: function(o) {
 					return o;
@@ -46,30 +46,30 @@
 		 */
 		var mustBeType = function(type) {
 			return assert(
-				$api.Function.pipe(
-					$api.Function.type,
-					$api.Function.Predicate.equals(type)
+				$api.fp.pipe(
+					$api.fp.type,
+					$api.fp.Predicate.equals(type)
 				),
 				function(v) {
-					throw new TypeError("Argument must be " + type + ", not " + $api.Function.type(v));
+					throw new TypeError("Argument must be " + type + ", not " + $api.fp.type(v));
 				}
 			);
 		};
 
 		/** @type { (v: any) => slime.jrunscript.ip.Host } */
-		var castToHost = $api.Function.identity;
+		var castToHost = $api.fp.identity;
 
-		var Host = $api.Function.pipe(
+		var Host = $api.fp.pipe(
 			castToHost,
 			mustBeType("object"),
 			assert(
-				$api.Function.pipe(
-					$api.Function.property("name"),
-					$api.Function.type,
-					$api.Function.Predicate.equals("string")
+				$api.fp.pipe(
+					$api.fp.property("name"),
+					$api.fp.type,
+					$api.fp.Predicate.equals("string")
 				),
 				function(v) {
-					return new TypeError("name property must be string, not " + $api.Function.type(v.name));
+					return new TypeError("name property must be string, not " + $api.fp.type(v.name));
 				}
 			),
 			function(o) {
@@ -144,7 +144,7 @@
 		var world = {
 			/** @type { slime.jrunscript.ip.World["isReachable"] } */
 			isReachable: function(p) {
-				return $api.Function.world.old.ask(function(events) {
+				return $api.fp.world.old.ask(function(events) {
 					try {
 						if (p.port) {
 							var _socket = new Packages.java.net.Socket();
@@ -165,7 +165,7 @@
 			/** @type { slime.jrunscript.ip.World["tcp"] } */
 			tcp: {
 				isAvailable: function(p) {
-					return $api.Function.world.old.ask(function(events) {
+					return $api.fp.world.old.ask(function(events) {
 						var number = p.port.number;
 
 						var debug = function(message) {

--- a/rhino/shell/invocation.js
+++ b/rhino/shell/invocation.js
@@ -183,7 +183,7 @@
 					if (typeof(argument) == "object") return argument;
 					if (typeof(argument) == "function") {
 						var rv = Object.assign({}, now);
-						return $api.Function.mutating(argument)(rv);
+						return $api.fp.mutating(argument)(rv);
 					}
 				})(parentEnvironment, p.environment),
 				directory: directoryForModuleRunArgument(p)

--- a/rhino/shell/jsh.js
+++ b/rhino/shell/jsh.js
@@ -249,7 +249,7 @@
 				if (!p.script) {
 					throw new TypeError("Required: script property indicating script to run.");
 				}
-				var argumentsFactory = $api.Function.mutating(p.arguments);
+				var argumentsFactory = $api.fp.mutating(p.arguments);
 				p.arguments = argumentsFactory([]);
 
 				if (p.script["file"] && !p.script.pathname) {
@@ -522,7 +522,7 @@
 		};
 		$exports.jsh.relaunch = $api.experimental(function(p) {
 			if (!p) p = {};
-			var environment = $api.Function.mutating(p.environment)($exports.environment);
+			var environment = $api.fp.mutating(p.environment)($exports.environment);
 			$exports.jsh({
 				fork: true,
 				script: $context.api.script.file,

--- a/rhino/shell/module.fifty.ts
+++ b/rhino/shell/module.fifty.ts
@@ -522,7 +522,7 @@ namespace slime.jrunscript.shell {
 				};
 
 				var exit = jsh.shell.Tell.exit();
-				var result = $api.Function.result(exit(tell), interpret);
+				var result = $api.fp.result(exit(tell), interpret);
 				verify(result).is("foobarfoobar");
 			}
 		}

--- a/rhino/shell/module.js
+++ b/rhino/shell/module.js
@@ -255,7 +255,7 @@
 			$exports,
 			"browser",
 			{
-				get: $api.Function.memoized(function() {
+				get: $api.fp.memoized(function() {
 					return $loader.module("browser/module.js", {
 						os: $exports.os,
 						HOME: $exports.HOME,
@@ -278,7 +278,7 @@
 			$exports.system,
 			"apple",
 			{
-				get: $api.Function.memoized(function() {
+				get: $api.fp.memoized(function() {
 					return $loader.file("apple.js", {
 						api: {
 							document: $context.api.document,
@@ -295,7 +295,7 @@
 			$exports.system,
 			"opendesktop",
 			{
-				get: $api.Function.memoized(function() {
+				get: $api.fp.memoized(function() {
 					return $loader.file("opendesktop.js", {
 						api: {
 							js: $context.api.js,
@@ -418,7 +418,7 @@
 			Object.defineProperty(
 				this, "launcher",
 				{
-					get: $api.Function.memoized(function() {
+					get: $api.fp.memoized(function() {
 						return $context.api.file.Searchpath([self.home.getRelativePath("bin")]).getCommand("java");
 					})
 				}
@@ -428,7 +428,7 @@
 			Object.defineProperty(
 				this, "jrunscript",
 				{
-					get: $api.Function.memoized(function() {
+					get: $api.fp.memoized(function() {
 						return $context.api.file.Searchpath([self.home.getRelativePath("bin"),self.home.getRelativePath("../bin")]).getCommand("jrunscript");
 					})
 				}
@@ -437,7 +437,7 @@
 			Object.defineProperty(
 				this, "keytool",
 				{
-					get: $api.Function.memoized(function() {
+					get: $api.fp.memoized(function() {
 						return $context.api.file.Searchpath([self.home.getRelativePath("bin")]).getCommand("keytool");
 					})
 				}

--- a/rhino/shell/os.fifty.ts
+++ b/rhino/shell/os.fifty.ts
@@ -65,7 +65,7 @@ namespace slime.jrunscript.shell.system {
 				var processes = ps();
 				jsh.shell.console(
 					processes.map(
-						$api.Function.pipe(
+						$api.fp.pipe(
 							function(process) {
 								return {
 									id: process.id,
@@ -74,7 +74,7 @@ namespace slime.jrunscript.shell.system {
 									children: process.children.map(function(child) { return child.id })
 								}
 							},
-							$api.Function.JSON.stringify({ space: 4 })
+							$api.fp.JSON.stringify({ space: 4 })
 						)
 					)
 				.join("\n"));

--- a/rhino/shell/plugin.jsh.fifty.ts
+++ b/rhino/shell/plugin.jsh.fifty.ts
@@ -103,7 +103,7 @@ namespace slime.jsh.shell {
 			)();
 
 			fifty.tests.stdio.close = function() {
-				var f = $api.Function.world.question(
+				var f = $api.fp.world.question(
 					jsh.shell.world.question
 				);
 				var result = f(

--- a/rhino/shell/run-old.js
+++ b/rhino/shell/run-old.js
@@ -127,7 +127,7 @@
 						})();
 					} else if (typeof(p.command) != "undefined") {
 						rv.result.command = p.command;
-						//	TODO	switch to $api.Function.mutating
+						//	TODO	switch to $api.fp.mutating
 						rv.result.arguments = p.arguments;
 						rv.result.as = p.as;
 						rv.configuration = toConfiguration(p.command, p.arguments);

--- a/rhino/shell/run.fifty.ts
+++ b/rhino/shell/run.fifty.ts
@@ -174,8 +174,8 @@ namespace slime.jrunscript.shell.internal.run {
 			const { verify } = fifty;
 			const { $api } = fifty.global;
 
-			fifty.tests.question = $api.Function.pipe(
-				$api.Function.world.input(
+			fifty.tests.question = $api.fp.pipe(
+				$api.fp.world.input(
 					test.subject.question(test.ls)
 				),
 				function(exit) {

--- a/rhino/shell/run.js
+++ b/rhino/shell/run.js
@@ -193,11 +193,11 @@
 							environment: context.environment
 						});
 					},
-					getStandardOutput: $api.Function.returning( (context.stdio.output) ? context.stdio.output.java.adapt() : Packages.inonit.script.runtime.io.Streams.Null.OUTPUT_STREAM ),
-					getStandardError: $api.Function.returning( (context.stdio.error) ? context.stdio.error.java.adapt() : Packages.inonit.script.runtime.io.Streams.Null.OUTPUT_STREAM ),
-					getStandardInput: $api.Function.returning( (context.stdio.input) ? context.stdio.input.java.adapt() : Packages.inonit.script.runtime.io.Streams.Null.INPUT_STREAM ),
-					getSubprocessEnvironment: $api.Function.returning( _environment ),
-					getWorkingDirectory: $api.Function.returning((context.directory) ? context.directory.pathname.java.adapt() : null)
+					getStandardOutput: $api.fp.returning( (context.stdio.output) ? context.stdio.output.java.adapt() : Packages.inonit.script.runtime.io.Streams.Null.OUTPUT_STREAM ),
+					getStandardError: $api.fp.returning( (context.stdio.error) ? context.stdio.error.java.adapt() : Packages.inonit.script.runtime.io.Streams.Null.OUTPUT_STREAM ),
+					getStandardInput: $api.fp.returning( (context.stdio.input) ? context.stdio.input.java.adapt() : Packages.inonit.script.runtime.io.Streams.Null.INPUT_STREAM ),
+					getSubprocessEnvironment: $api.fp.returning( _environment ),
+					getWorkingDirectory: $api.fp.returning((context.directory) ? context.directory.pathname.java.adapt() : null)
 				}
 			);
 		};
@@ -223,8 +223,8 @@
 						return "command: " + configuration.command + " arguments: " + configuration.arguments;
 					};
 
-					this.getCommand = $api.Function.returning(adapted.command);
-					this.getArguments = $api.Function.returning(adapted.arguments);
+					this.getCommand = $api.fp.returning(adapted.command);
+					this.getArguments = $api.fp.returning(adapted.arguments);
 				}
 			);
 		};
@@ -318,7 +318,7 @@
 		 * @returns { slime.$api.fp.world.old.Tell<slime.jrunscript.shell.run.TellEvents> }
 		 */
 		var impure = function(context,configuration) {
-			return $api.Function.world.old.tell(
+			return $api.fp.world.old.tell(
 				tell(context, configuration)
 			);
 		};
@@ -344,7 +344,7 @@
 		 */
 		var mockTell = function(stdio,result) {
 			var killed = false;
-			return $api.Function.world.old.tell(
+			return $api.fp.world.old.tell(
 				/**
 				 * @param { slime.$api.Events<slime.jrunscript.shell.run.TellEvents> } events
 				 */
@@ -479,8 +479,8 @@
 				return function(events) {
 					/** @type { slime.jrunscript.shell.run.Exit } */
 					var rv;
-					$api.Function.impure.now.process(
-						$api.Function.world.tell(
+					$api.fp.impure.now.process(
+						$api.fp.world.tell(
 							tell(invocation.context, invocation.configuration),
 							{
 								start: function(e) {
@@ -503,8 +503,8 @@
 			},
 			action: function(invocation) {
 				return function(events) {
-					$api.Function.impure.now.process(
-						$api.Function.world.tell(
+					$api.fp.impure.now.process(
+						$api.fp.world.tell(
 							tell(invocation.context, invocation.configuration),
 							{
 								start: function(e) {

--- a/rhino/tools/docker/kubectl.js
+++ b/rhino/tools/docker/kubectl.js
@@ -77,7 +77,7 @@
 				}
 			},
 			result: function(world,invocation) {
-				return $api.Function.world.old.ask(function(events) {
+				return $api.fp.world.old.ask(function(events) {
 					var tell = world.run(invocation);
 					var rv;
 					tell({

--- a/rhino/tools/docker/module.js
+++ b/rhino/tools/docker/module.js
@@ -133,7 +133,7 @@
 						})
 					);
 					return {
-						run: $api.Function.world.old.ask(function(events) {
+						run: $api.fp.world.old.ask(function(events) {
 							var rv;
 							tell({
 								stderr: function(e) {
@@ -312,11 +312,11 @@
 										url = url.replace("{" + x + "}", String(p.path[x]));
 									}
 								}
-								var query = $api.Function.result(
+								var query = $api.fp.result(
 									p.query,
-									$api.Function.pipe(
+									$api.fp.pipe(
 										Object.entries,
-										$api.Function.Array.map(function(entry) {
+										$api.fp.Array.map(function(entry) {
 											return { name: entry[0], value: String(entry[1]) }
 										}),
 										$context.library.web.Url.query,
@@ -325,7 +325,7 @@
 										}
 									)
 								)
-								var ask = $api.Function.world.input(spi({
+								var ask = $api.fp.world.input(spi({
 									request: {
 										method: (e.method) ? e.method : "GET",
 										url: $context.library.web.Url.codec.string.decode("http://docker.sock.unix" + url + query),
@@ -360,7 +360,7 @@
 							var toMethod = function(method, path) {
 								var defined = define({ method: method, url: path });
 								/** @type { slime.js.Cast<R> } */
-								var toR = $api.Function.cast;
+								var toR = $api.fp.cast;
 								return function(p) {
 									/** @type { R } */
 									var rv = toR(defined(implementation, p));
@@ -400,7 +400,7 @@
 						}
 					}
 				}
-				return $api.Function.world.old.tell(function(events) {
+				return $api.fp.world.old.tell(function(events) {
 					if (!p.destination.directory) {
 						if (p.library.shell.os.name == "Mac OS X") {
 							//	https://docs.docker.com/desktop/mac/release-notes/

--- a/rhino/tools/gcloud/module.fifty.ts
+++ b/rhino/tools/gcloud/module.fifty.ts
@@ -197,7 +197,7 @@ namespace slime.jrunscript.tools.gcloud {
 					}
 				});
 				var at = fifty.jsh.file.temporary.location();
-				$api.Function.world.now.action(
+				$api.fp.world.now.action(
 					module.cli.Installation.create,
 					at.pathname,
 					{

--- a/rhino/tools/gcloud/module.js
+++ b/rhino/tools/gcloud/module.js
@@ -28,9 +28,9 @@
 			var rv = function(command) {
 				return {
 					argument: function(argument) {
-						var toResult = command.result || $api.Function.identity;
+						var toResult = command.result || $api.fp.identity;
 						return {
-							run: $api.Function.world.old.ask(
+							run: $api.fp.world.old.ask(
 								function(events) {
 									var result;
 									var invocation = command.invocation(argument);
@@ -118,9 +118,9 @@
 					},
 					create: function create(pathname) {
 						return function(events) {
-							var url = $api.Function.result(INSTALLER, $api.Function.pipe(
-								$api.Function.optionalChain($context.library.shell.os.name),
-								$api.Function.optionalChain($context.library.shell.os.arch)
+							var url = $api.fp.result(INSTALLER, $api.fp.pipe(
+								$api.fp.optionalChain($context.library.shell.os.name),
+								$api.fp.optionalChain($context.library.shell.os.arch)
 							));
 							if (!url) {
 								throw new Error("Could not install.");

--- a/rhino/tools/gcloud/test/manual/run.jsh.js
+++ b/rhino/tools/gcloud/test/manual/run.jsh.js
@@ -12,7 +12,7 @@
 	 */
 	function($api,jsh) {
 		var invocation = jsh.script.cli.invocation(
-			$api.Function.pipe(
+			$api.fp.pipe(
 				jsh.script.cli.option.pathname({ longname: "installation" }),
 				jsh.script.cli.option.string({ longname: "account" }),
 				jsh.script.cli.option.string({ longname: "project" })

--- a/rhino/tools/git/api.html.js
+++ b/rhino/tools/git/api.html.js
@@ -80,10 +80,10 @@
 				repository: new function() {
 					var commit = function(repository,files,message) {
 						//	TODO	should use execute and forEach
-						$api.Function.result(
+						$api.fp.result(
 							files,
 							Object.entries,
-							$api.Function.Array.map(function(entry) {
+							$api.fp.Array.map(function(entry) {
 								repository.directory.getRelativePath(entry[0]).write(entry[1], { append: false, recursive: true });
 								repository.add({ path: entry[0] });
 							})

--- a/rhino/tools/git/commands.fifty.ts
+++ b/rhino/tools/git/commands.fifty.ts
@@ -127,8 +127,8 @@ namespace slime.jrunscript.tools.git {
 				}
 
 				var it = fixtures.empty();
-				fixtures.edit(it, "a", $api.Function.returning("a"));
-				fixtures.edit(it, "b", $api.Function.returning("b"));
+				fixtures.edit(it, "a", $api.fp.returning("a"));
+				fixtures.edit(it, "b", $api.fp.returning("b"));
 				it.api.command(add).argument("a").run();
 				verify(status(), "status", function(it) {
 					it.paths.a.is("A ");
@@ -136,8 +136,8 @@ namespace slime.jrunscript.tools.git {
 				});
 				it.api.command(add).argument("b").run();
 				it.api.command(commit).argument({ message: "1" }).run();
-				fixtures.edit(it, "a", $api.Function.returning("aa"));
-				fixtures.edit(it, "b", $api.Function.returning("bb"));
+				fixtures.edit(it, "a", $api.fp.returning("aa"));
+				fixtures.edit(it, "b", $api.fp.returning("bb"));
 				verify(status(), "status_after_edits", function(it) {
 					it.paths.a.is(" M");
 					it.paths.b.is(" M");

--- a/rhino/tools/git/commands.js
+++ b/rhino/tools/git/commands.js
@@ -37,7 +37,7 @@
 				};
 				output.split("\n").forEach(function(line) {
 					var NO_COMMITS_PREFIX = "## No commits yet on ";
-					if ($api.Function.string.startsWith(NO_COMMITS_PREFIX)(line)) {
+					if ($api.fp.string.startsWith(NO_COMMITS_PREFIX)(line)) {
 						rv.branch = line.substring(NO_COMMITS_PREFIX.length);
 					} else if (line.substring(0,2) == "##") {
 						var branchName = line.substring(3);

--- a/rhino/tools/git/fixtures.ts
+++ b/rhino/tools/git/fixtures.ts
@@ -47,16 +47,16 @@ namespace slime.jrunscript.tools.git.test.fixtures {
 				}
 
 				function edit(repository: Repository, path: string, change: (before: string) => string) {
-					var target = $api.Function.result(
+					var target = $api.fp.result(
 						repository.location,
 						jsh.file.world.Location.relative(path)
 					);
 
-					var before = $api.Function.result(
+					var before = $api.fp.result(
 						target,
-						$api.Function.pipe(
-							$api.Function.world.question(jsh.file.world.Location.file.read.string()),
-							$api.Function.Maybe.else(function() {
+						$api.fp.pipe(
+							$api.fp.world.question(jsh.file.world.Location.file.read.string()),
+							$api.fp.Maybe.else(function() {
 								return null as string;
 							})
 						)
@@ -64,9 +64,9 @@ namespace slime.jrunscript.tools.git.test.fixtures {
 
 					var edited = change(before);
 
-					var writeEdited = $api.Function.world.action(jsh.file.world.Location.file.write.string({ value: edited }));
+					var writeEdited = $api.fp.world.action(jsh.file.world.Location.file.write.string({ value: edited }));
 
-					$api.Function.impure.now.output(target, writeEdited);
+					$api.fp.impure.now.output(target, writeEdited);
 				}
 
 				return {

--- a/rhino/tools/git/module.fifty.ts
+++ b/rhino/tools/git/module.fifty.ts
@@ -382,14 +382,14 @@ namespace slime.jrunscript.tools.git {
 					var captor = fifty.$api.Events.Captor(events);
 
 					var isType = function(type: string): slime.$api.fp.Predicate<slime.$api.Event<any>> {
-						return $api.Function.pipe(
-							$api.Function.property("type"),
-							$api.Function.Predicate.is(type)
+						return $api.fp.pipe(
+							$api.fp.property("type"),
+							$api.fp.Predicate.is(type)
 						);
 					};
 
 					var ofType = function(type: string) {
-						return $api.Function.Array.filter(isType(type));
+						return $api.fp.Array.filter(isType(type));
 					}
 
 					var handler = captor.handler;
@@ -912,7 +912,7 @@ namespace slime.jrunscript.tools.git {
 						world: {
 							run: function(created: shell.run.Invocation) {
 								invocation = created;
-								return fifty.global.$api.Function.world.old.tell(function(events) {
+								return fifty.global.$api.fp.world.old.tell(function(events) {
 									events.fire("exit", {
 										status: 0,
 										stdio: {

--- a/rhino/tools/git/module.js
+++ b/rhino/tools/git/module.js
@@ -135,11 +135,11 @@
 							args.push("-c", "credential.helper=", "-c", "credential.helper=" + p.credentialHelper);
 						}
 						args.push(c.name);
-						if (o.arguments) args = $api.Function.object.revise(o.arguments(p))(args);
+						if (o.arguments) args = $api.fp.object.revise(o.arguments(p))(args);
 						//	TODO	this type should be in rhino/shell if it is not already
 						/** @type { slime.jrunscript.tools.git.internal.Environment } */
 						var environment = $api.Object.compose($context.environment);
-						if (o.environment) environment = $api.Function.object.revise(o.environment(p))(environment);
+						if (o.environment) environment = $api.fp.object.revise(o.environment(p))(environment);
 
 						var output = {
 							stdout: [],
@@ -167,7 +167,7 @@
 							directory: p.directory
 						});
 
-						var createReturnValue = (o.createReturnValue) ? o.createReturnValue(p) : $api.Function.returning(void(0));
+						var createReturnValue = (o.createReturnValue) ? o.createReturnValue(p) : $api.fp.returning(void(0));
 
 						return createReturnValue({ output: output, result: result });
 					}
@@ -950,7 +950,7 @@
 						});
 						/** @type { { name: string, value: string }[] } */
 						var settings = settingsCommand({});
-						return $api.Function.result(
+						return $api.fp.result(
 							settings,
 							function(settings) {
 								return settings.reduce(function(rv,setting) {
@@ -964,7 +964,7 @@
 								}, {});
 							},
 							Object.entries,
-							$api.Function.Array.map(function(entry) {
+							$api.fp.Array.map(function(entry) {
 								return $api.Object.compose({
 									name: entry[0]
 								}, entry[1])

--- a/rhino/tools/git/test/log.jsh.js
+++ b/rhino/tools/git/test/log.jsh.js
@@ -12,7 +12,7 @@
 	 * @param { slime.jsh.Global } jsh
 	 */
 	function($api,jsh) {
-		$api.Function.pipe(
+		$api.fp.pipe(
 			jsh.script.cli.option.string({ longname: "revisionRange" }),
 			function(p) {
 				var repository = jsh.tools.git.Repository({ directory: jsh.shell.PWD });

--- a/rhino/tools/github/module.js
+++ b/rhino/tools/github/module.js
@@ -20,10 +20,10 @@
 		 * @returns
 		 */
 		var parseLinkHeader = function(value) {
-			return $api.Function.result(
+			return $api.fp.result(
 				value,
-				$api.Function.string.split(", "),
-				$api.Function.Array.map(function(string) {
+				$api.fp.string.split(", "),
+				$api.fp.Array.map(function(string) {
 					var relationFormat = /^\<(.+?)\>\; rel\=\"(.+)\"/;
 					var parsed = relationFormat.exec(string);
 					return {
@@ -31,7 +31,7 @@
 						rel: parsed[2]
 					}
 				}),
-				$api.Function.Array.map(
+				$api.fp.Array.map(
 					/** @returns { [string, string] } */
 					function(relation) {
 						return [relation.rel, relation.url];
@@ -353,8 +353,8 @@
 										return {
 											run: function(run) {
 												var world = (run && run.world) ? run.world : $context.library.http.world;
-												return $api.Function.world.old.ask(function(events) {
-													var response = $api.Function.world.input(world.request(
+												return $api.fp.world.old.ask(function(events) {
+													var response = $api.fp.world.input(world.request(
 														toHttpArgument(
 															api,
 															authentication,
@@ -374,7 +374,7 @@
 										return {
 											run: function(run) {
 												var world = (run && run.world) ? run.world : $context.library.http.world;
-												return $api.Function.world.old.ask(function(events) {
+												return $api.fp.world.old.ask(function(events) {
 													var request = toHttpArgument(
 														api,
 														authentication,
@@ -382,7 +382,7 @@
 													);
 													var rv = [];
 													while(request) {
-														var response = $api.Function.world.input(world.request(request))();
+														var response = $api.fp.world.input(world.request(request))();
 														var page = operation.response(response);
 														rv = rv.concat(page);
 														var link = links(response);

--- a/rhino/tools/github/plugin.jsh.js
+++ b/rhino/tools/github/plugin.jsh.js
@@ -173,7 +173,7 @@
 											throw new Error();
 										}
 										/** @type { (file: slime.jrunscript.file.File) => slime.jrunscript.runtime.old.Resource } */
-										var toResource = $api.Function.cast;
+										var toResource = $api.fp.cast;
 										if (isFile(nodeEntry.resource)) {
 											return {
 												path: nodeEntry.path,

--- a/rhino/tools/github/test/manual/jsh.jsh.js
+++ b/rhino/tools/github/test/manual/jsh.jsh.js
@@ -46,7 +46,7 @@
 
 		jsh.script.cli.wrap({
 			commands: {
-				serve: $api.Function.pipe(
+				serve: $api.fp.pipe(
 					//	emit information about requests sent to GitHub
 					jsh.script.cli.option.boolean({ longname: "optimize" }),
 
@@ -74,7 +74,7 @@
 					});
 					emit(command);
 				},
-				test: $api.Function.pipe(
+				test: $api.fp.pipe(
 					//	turn on jsh launcher console-based debugging
 					jsh.script.cli.option.boolean({ longname: "debug" }),
 					function(p) {

--- a/rhino/tools/jenkins/module.js
+++ b/rhino/tools/jenkins/module.js
@@ -51,7 +51,7 @@
 		 * @returns { slime.jrunscript.http.client.spi.Response }
 		 */
 		function request(p) {
-			return $api.Function.world.now.question($context.library.http.world.request, toRequest(p));
+			return $api.fp.world.now.question($context.library.http.world.request, toRequest(p));
 		}
 
 		/**
@@ -256,7 +256,7 @@
 			api: {
 				JobSummary: {
 					isName: function(name) {
-						return $api.Function.pipe($api.Function.property("name"), $api.Function.is(name));
+						return $api.fp.pipe($api.fp.property("name"), $api.fp.is(name));
 					}
 				}
 			}

--- a/rhino/tools/module.fifty.ts
+++ b/rhino/tools/module.fifty.ts
@@ -24,7 +24,7 @@ namespace slime.jrunscript.java.tools {
 	export interface Exports {
 		javac: {
 			/**
-			 * @deprecated Use the form that returns the result and pipe that to another function using `$api.Function.pipe` for
+			 * @deprecated Use the form that returns the result and pipe that to another function using `$api.fp.pipe` for
 			 * this behavior.
 			 */
 			<R>(p: {

--- a/rhino/tools/node/module.fifty.ts
+++ b/rhino/tools/node/module.fifty.ts
@@ -95,24 +95,24 @@ namespace slime.jrunscript.node {
 			fifty.tests.sandbox.installation = function() {
 				var TMPDIR = fifty.jsh.file.temporary.location();
 				var installation = test.subject.world.Installation.from.location(TMPDIR);
-				var before = $api.Function.world.now.question(
+				var before = $api.fp.world.now.question(
 					test.subject.world.Installation.exists,
 					installation
 				);
 				verify(before).is(false);
-				$api.Function.world.now.action(
+				$api.fp.world.now.action(
 					test.subject.test.world.install,
 					{
 						location: TMPDIR.pathname,
 						version: test.subject.test.versions.current
 					}
 				);
-				var after = $api.Function.world.now.question(
+				var after = $api.fp.world.now.question(
 					test.subject.world.Installation.exists,
 					installation
 				);
 				verify(after).is(true);
-				var version = $api.Function.world.now.question(
+				var version = $api.fp.world.now.question(
 					test.subject.world.Installation.getVersion,
 					installation
 				)
@@ -145,7 +145,7 @@ namespace slime.jrunscript.node {
 
 				fifty.tests.sandbox.question = function() {
 					var TMPDIR = fifty.jsh.file.temporary.location();
-					$api.Function.world.now.action(
+					$api.fp.world.now.action(
 						test.subject.test.world.install,
 						{
 							location: TMPDIR.pathname,
@@ -154,7 +154,7 @@ namespace slime.jrunscript.node {
 					);
 					var installation = test.subject.world.Installation.from.location(TMPDIR);
 					debugger;
-					var result = $api.Function.world.now.question(
+					var result = $api.fp.world.now.question(
 						test.subject.world.Installation.question({
 							arguments: [fifty.jsh.file.object.getRelativePath("test/hello.js")],
 							stdio: {
@@ -196,7 +196,7 @@ namespace slime.jrunscript.node {
 
 			fifty.tests.wip = function() {
 				var TMPDIR = fifty.jsh.file.temporary.location();
-				$api.Function.world.now.action(
+				$api.fp.world.now.action(
 					test.subject.test.world.install,
 					{
 						location: TMPDIR.pathname,
@@ -205,7 +205,7 @@ namespace slime.jrunscript.node {
 				);
 				var installation = test.subject.world.Installation.from.location(TMPDIR);
 
-				var installedModule = $api.Function.world.question(
+				var installedModule = $api.fp.world.question(
 					test.subject.world.Installation.modules.installed("minimal-package"),
 				)
 
@@ -214,7 +214,7 @@ namespace slime.jrunscript.node {
 				verify(before).present.is(false);
 
 				var findInListing = function() {
-					var listing = $api.Function.world.now.question(
+					var listing = $api.fp.world.now.question(
 						test.subject.world.Installation.modules.list(),
 						installation
 					);
@@ -226,7 +226,7 @@ namespace slime.jrunscript.node {
 
 				verify(findInListing()).is(void(0));
 
-				$api.Function.world.now.action(
+				$api.fp.world.now.action(
 					test.subject.world.Installation.modules.install({ name: "minimal-package" }),
 					installation
 				);
@@ -366,7 +366,7 @@ namespace slime.jrunscript.node {
 				var tell = subject.install({
 					location: jsh.file.Pathname(TMPDIR.pathname)
 				});
-				$api.Function.world.execute(tell, {
+				$api.fp.world.execute(tell, {
 					installed: function(e) {
 						jsh.shell.console("Installed: Node " + e.detail.version + " at " + e.detail.location);
 					}
@@ -412,8 +412,8 @@ namespace slime.jsh.shell.tools {
 			const { verify } = fifty;
 			const { $api, jsh } = fifty.global;
 
-			$api.Function.impure.now.process(
-				$api.Function.world.action(jsh.shell.tools.node.require)
+			$api.fp.impure.now.process(
+				$api.fp.world.action(jsh.shell.tools.node.require)
 			)
 
 			const api = jsh.shell.tools.node.installed;
@@ -477,7 +477,7 @@ namespace slime.jsh.shell.tools {
 			fifty.tests.manual.jsh = function() {
 				jsh.shell.console("hello");
 				var installation = jsh.shell.tools.node.installation;
-				var modules = $api.Function.world.now.question(
+				var modules = $api.fp.world.now.question(
 					jsh.shell.tools.node.world.Installation.modules.list(),
 					installation
 				);

--- a/rhino/tools/node/module.js
+++ b/rhino/tools/node/module.js
@@ -82,7 +82,7 @@
 						output: "string"
 					}
 				});
-				var getExit = $api.Function.world.question(
+				var getExit = $api.fp.world.question(
 					$context.library.shell.world.question
 				);
 				var exit = getExit(invocation);
@@ -91,19 +91,19 @@
 		}
 
 		/** @type { (installation: slime.jrunscript.node.world.Installation) => string } */
-		var getInstallationPathEntry = $api.Function.pipe(
-			$api.Function.property("executable"),
+		var getInstallationPathEntry = $api.fp.pipe(
+			$api.fp.property("executable"),
 			//	TODO	should be Location.from.os
 			$context.library.file.world.Location.from.os,
 			$context.library.file.world.Location.parent(),
-			$api.Function.property("pathname")
+			$api.fp.property("pathname")
 		);
 
 		/** @type { (project: string) => string } */
-		var getProjectBin = $api.Function.pipe(
+		var getProjectBin = $api.fp.pipe(
 			$context.library.file.world.Location.from.os,
 			$context.library.file.world.Location.relative(".bin"),
-			$api.Function.property("pathname")
+			$api.fp.property("pathname")
 		)
 
 		/**
@@ -113,8 +113,8 @@
 		 */
 		var directoryContains = function(pathname,name) {
 			var directory = $context.library.file.world.Location.from.os(pathname);
-			var location = $api.Function.result(directory, $context.library.file.world.Location.relative(name));
-			return $api.Function.world.now.question(
+			var location = $api.fp.result(directory, $context.library.file.world.Location.relative(name));
+			return $api.fp.world.now.question(
 				$context.library.file.world.Location.file.exists(),
 				location
 			);
@@ -127,7 +127,7 @@
 		 */
 		var getRelativePath = function(parent, path) {
 			var base = $context.library.file.world.Location.from.os(parent);
-			var target = $api.Function.result(base, $context.library.file.world.Location.relative(path));
+			var target = $api.fp.result(base, $context.library.file.world.Location.relative(path));
 			return target.pathname;
 		}
 
@@ -162,12 +162,12 @@
 					}
 				)();
 
-				var PATH = $api.Function.result(
+				var PATH = $api.fp.result(
 					path,
-					$api.Function.pipe(
-						$api.Function.property("pathnames"),
-						$api.Function.Array.prepend([
-							$api.Function.result(getInstallationPathEntry(installation), $context.library.file.Pathname)
+					$api.fp.pipe(
+						$api.fp.property("pathnames"),
+						$api.fp.Array.prepend([
+							$api.fp.result(getInstallationPathEntry(installation), $context.library.file.Pathname)
 						]),
 						$context.library.file.Searchpath,
 						String
@@ -217,7 +217,7 @@
 						}
 					});
 
-					var result = $api.Function.world.now.question(
+					var result = $api.fp.world.now.question(
 						$context.library.shell.world.question,
 						$context.library.shell.Invocation.create(invocation)
 					);
@@ -225,12 +225,12 @@
 					/** @type { slime.jrunscript.node.internal.NpmLsOutput } */
 					var npmJson = JSON.parse(result.stdio.output);
 
-					return $api.Function.result(
+					return $api.fp.result(
 						npmJson,
-						$api.Function.pipe(
-							$api.Function.property("dependencies"),
+						$api.fp.pipe(
+							$api.fp.property("dependencies"),
 							Object.entries,
-							$api.Function.Array.map(function(entry) {
+							$api.fp.Array.map(function(entry) {
 								return { name: entry[0], version: entry[1].version }
 							})
 						)
@@ -248,7 +248,7 @@
 					var found = list.find(function(item) {
 						return item.name == p;
 					});
-					return $api.Function.Maybe.from(found);
+					return $api.fp.Maybe.from(found);
 				}
 			}
 		};
@@ -272,7 +272,7 @@
 						})
 					});
 
-					$api.Function.world.now.action(
+					$api.fp.world.now.action(
 						$context.library.shell.world.action,
 						$context.library.shell.Invocation.create(invocation)
 					);
@@ -373,7 +373,7 @@
 						//	TODO	check for other types besides object, function, falsy
 						//	TODO	can this be simplified further using mutator concept? Maybe; mutator could allow object and just return it
 						environment.PATH = PATH.toString();
-						var mutating = $api.Function.mutating(p.environment);
+						var mutating = $api.fp.mutating(p.environment);
 						var result = mutating(environment);
 						if (!result.PATH) result.PATH = PATH.toString();
 
@@ -430,7 +430,7 @@
 							if (p.global) {
 								list.push("--global");
 							}
-							var mutating = $api.Function.mutating(p.arguments);
+							var mutating = $api.fp.mutating(p.arguments);
 							var npmargs = mutating([]);
 							list.push.apply(list, npmargs);
 						})
@@ -548,18 +548,18 @@
 				from: {
 					location: function(location) {
 						return {
-							executable: $api.Function.result(location, $context.library.file.world.Location.relative("bin/node")).pathname
+							executable: $api.fp.result(location, $context.library.file.world.Location.relative("bin/node")).pathname
 						}
 					}
 				},
 				exists: function(installation) {
 					return function(events) {
-						return $api.Function.result(
+						return $api.fp.result(
 							installation,
-							$api.Function.pipe(
-								$api.Function.property("executable"),
+							$api.fp.pipe(
+								$api.fp.property("executable"),
 								$context.library.file.world.Location.from.os,
-								$api.Function.world.question($context.library.file.world.Location.file.exists())
+								$api.fp.world.question($context.library.file.world.Location.file.exists())
 							)
 						)
 					}

--- a/tools/code/module.fifty.ts
+++ b/tools/code/module.fifty.ts
@@ -76,7 +76,7 @@ namespace slime.tools.code {
 				var jxa = fifty.jsh.file.relative("../../jxa.bash");
 				var foo = fifty.jsh.file.relative("../../foo");
 
-				var hasShebang = $api.Function.world.question(test.subject.File.hasShebang());
+				var hasShebang = $api.fp.world.question(test.subject.File.hasShebang());
 
 				var wfHas = hasShebang({
 					path: "wf",

--- a/tools/code/module.js
+++ b/tools/code/module.js
@@ -14,7 +14,7 @@
 	 */
 	function($api,$context,$export) {
 		/** @type { slime.js.Cast<slime.jrunscript.file.File> } */
-		var castToFile = $api.Function.cast;
+		var castToFile = $api.fp.cast;
 
 		/** @type { (file: slime.jrunscript.file.File) => slime.jrunscript.file.world.Location } */
 		var toLocation = function(node) {
@@ -112,14 +112,14 @@
 
 		var defaults = {
 			exclude: {
-				file: $api.Function.pipe(
+				file: $api.fp.pipe(
 					function(file) { return file.pathname.basename; },
-					$api.Function.Predicate.or(
+					$api.fp.Predicate.or(
 						filename.isVcsGenerated,
 						filename.isIdeGenerated
 					)
 				),
-				directory: $api.Function.Predicate.or(
+				directory: $api.fp.Predicate.or(
 					directory.isLocal,
 					directory.isVcs,
 					directory.isBuildTool
@@ -133,13 +133,13 @@
 		 */
 		function getSourceFiles(p) {
 			if (!p.base) throw new Error("Required: base, specifying directory.");
-			return $api.Function.world.old.ask(function(on) {
+			return $api.fp.world.old.ask(function(on) {
 				return p.base.list({
 					filter: isAuthoredTextFile( (p.exclude && p.exclude.file) ? p.exclude.file : defaults.exclude.file ),
-					descendants: $api.Function.Predicate.not( (p.exclude && p.exclude.directory) ? p.exclude.directory : defaults.exclude.directory ),
+					descendants: $api.fp.Predicate.not( (p.exclude && p.exclude.directory) ? p.exclude.directory : defaults.exclude.directory ),
 					type: $context.library.file.list.ENTRY
 				}).map(toSourceFile).filter(
-					$api.Function.series(
+					$api.fp.series(
 						p.isText,
 						function(file) {
 							on.fire("unknownFileType", file);
@@ -205,8 +205,8 @@
 			throw new Error("Asserted Maybe that was Nothing.");
 		}
 
-		var readFileString = $api.Function.pipe(
-			$api.Function.world.question(
+		var readFileString = $api.fp.pipe(
+			$api.fp.world.question(
 				$context.library.file.world.Location.file.read.string()
 			),
 			Maybe_assert
@@ -218,7 +218,7 @@
 		 * @param { string } string
 		 */
 		var writeFileString = function(file,string) {
-			$api.Function.world.now.action(
+			$api.fp.world.now.action(
 				$context.library.file.world.Location.file.write.string({ value: string }),
 				file
 			);
@@ -239,7 +239,7 @@
 				if (!configuration) configuration = {
 					nowrite: false
 				};
-				return $api.Function.world.old.tell(function(events) {
+				return $api.fp.world.old.tell(function(events) {
 					var code = readFileString(entry.file);
 					var scan = findTrailingWhitespaceIn(code);
 					scan.instances.forEach(function(instance) {
@@ -268,7 +268,7 @@
 		 * @type { slime.tools.code.Exports["handleTrailingWhitespace"] }
 		 */
 		var trailingWhitespace = function(p) {
-			return $api.Function.world.old.tell(function(events) {
+			return $api.fp.world.old.tell(function(events) {
 				//	TODO	is there a simpler way to forward all those events below?
 				getSourceFiles({
 					base: p.base,
@@ -318,7 +318,7 @@
 
 		/** @type { slime.tools.code.Exports["handleFinalNewlines"] } */
 		function handleFinalNewlines(p) {
-			return $api.Function.world.old.tell(function(events) {
+			return $api.fp.world.old.tell(function(events) {
 				//	TODO	is there a simpler way to forward all those events below?
 				getSourceFiles({
 					base: p.base,
@@ -346,16 +346,16 @@
 		function hasShebang() {
 			return function(file) {
 				return function(events) {
-					var input = $api.Function.world.now.question(
+					var input = $api.fp.world.now.question(
 						$context.library.file.world.Location.file.read.stream(),
 						file.file
 					);
-					if (!input.present) return $api.Function.Maybe.nothing();
+					if (!input.present) return $api.fp.Maybe.nothing();
 					var _input = input.value.java.adapt();
 					var _1 = _input.read();
 					var _2 = _input.read();
 					_input.close();
-					return $api.Function.Maybe.value(_1 == 35 && _2 == 33);
+					return $api.fp.Maybe.value(_1 == 35 && _2 == 33);
 				}
 			}
 		}
@@ -368,12 +368,12 @@
 						return function(events) {
 							var basename = getBasename(file.file);
 							var byExtension = filename.isText(basename);
-							if (typeof(byExtension) == "boolean") return $api.Function.Maybe.value(byExtension);
+							if (typeof(byExtension) == "boolean") return $api.fp.Maybe.value(byExtension);
 							if (basename.indexOf(".") == -1) {
 								var rv = hasShebang()(file)(events);
 								if (rv.present) return rv;
 							}
-							return $api.Function.Maybe.nothing();
+							return $api.fp.Maybe.nothing();
 						}
 					}
 				}

--- a/tools/fifty.jsh.js
+++ b/tools/fifty.jsh.js
@@ -15,7 +15,7 @@
 
 		jsh.script.cli.wrap({
 			commands: {
-				view: $api.Function.pipe(
+				view: $api.fp.pipe(
 					jsh.script.cli.option.boolean({ longname: "debug:rhino" }),
 					function(p) {
 						jsh.shell.jsh({
@@ -32,7 +32,7 @@
 					}
 				),
 				test: {
-					jsh: $api.Function.pipe(
+					jsh: $api.fp.pipe(
 						jsh.script.cli.option.boolean({ longname: "debug:rhino" }),
 						jsh.script.cli.option.array({
 							longname: "property",
@@ -69,7 +69,7 @@
 							jsh.shell.exit(p.status);
 						}
 					),
-					browser: $api.Function.pipe(
+					browser: $api.fp.pipe(
 						function(p) {
 							return jsh.shell.jsh({
 								shell: SLIME,

--- a/tools/fifty/documentation.jsh.js
+++ b/tools/fifty/documentation.jsh.js
@@ -13,7 +13,7 @@
 	 * @param { slime.jsh.Global } jsh
 	 */
 	function(Packages,$api,jsh) {
-		$api.Function.result(
+		$api.fp.result(
 			{ options: {}, arguments: jsh.script.arguments.slice() },
 			jsh.script.cli.option.pathname({ longname: "base" }),
 			jsh.script.cli.option.string({ longname: "chrome:id" }),

--- a/tools/fifty/module.js
+++ b/tools/fifty/module.js
@@ -70,13 +70,13 @@
 				}
 			};
 
-			var isIdentifier = $api.Function.pipe(
-				$api.Function.property("object"),
-				$api.Function.property("kind"),
-				$api.Function.is("Identifier")
+			var isIdentifier = $api.fp.pipe(
+				$api.fp.property("object"),
+				$api.fp.property("kind"),
+				$api.fp.is("Identifier")
 			);
 
-			var isNotIdentifier = $api.Function.pipe(
+			var isNotIdentifier = $api.fp.pipe(
 				isIdentifier,
 				$ff.not()
 			)

--- a/tools/fifty/project.fifty.ts
+++ b/tools/fifty/project.fifty.ts
@@ -42,7 +42,7 @@ namespace slime.fifty.view {
 			fifty.tests.suite = function() {
 				var base = fifty.jsh.file.object.getRelativePath("../..").directory;
 				var server = library({ base: base });
-				var response = $api.Function.world.now.question(
+				var response = $api.fp.world.now.question(
 					jsh.http.world.request,
 					jsh.http.world.Argument.request({
 						url: "http://127.0.0.1:" + server.port + "/README.html"

--- a/tools/fifty/scope-jsh.ts
+++ b/tools/fifty/scope-jsh.ts
@@ -84,7 +84,7 @@ namespace slime.fifty.test.internal.scope.jsh {
 									]
 								})
 							);
-							var getBrowserResult = $api.Function.world.input(runBrowser);
+							var getBrowserResult = $api.fp.world.input(runBrowser);
 							var result = getBrowserResult();
 							fifty.verify(result, "browserResult").status.is(0);
 						}

--- a/tools/fifty/test-browser.js
+++ b/tools/fifty/test-browser.js
@@ -229,12 +229,12 @@
 				function(web) {
 					//	TODO	web module probably has easier way to parse query string
 					/** @type { slime.fifty.browser.test.internal.Query } */
-					var query = $api.Function.result(
+					var query = $api.fp.result(
 						void(0),
 						web.window.url,
-						$api.Function.property("query"),
+						$api.fp.property("query"),
 						web.Url.query.parse,
-						$api.Function.Array.map(
+						$api.fp.Array.map(
 							/** @returns { [string, string] } */
 							function(control) {
 								return [control.name, control.value];

--- a/tools/fifty/test-browser.jsh.js
+++ b/tools/fifty/test-browser.jsh.js
@@ -41,13 +41,13 @@
 			});
 		};
 
-		$api.Function.pipe(
+		$api.fp.pipe(
 			//	Keeps the browser open after running the tests so that they can be re-run by refreshing the page
 			jsh.script.cli.option.boolean({ longname: "interactive" }),
 
 			jsh.script.cli.option.string({ longname: "browser", default: "chrome" }),
 
-			$api.Function.pipe(
+			$api.fp.pipe(
 				//	Selects a location to use for Google Chrome configuration; if unspecified, a temporary directory will be used
 				jsh.script.cli.option.pathname({ longname: "chrome:data" }),
 
@@ -60,7 +60,7 @@
 
 			jsh.script.cli.option.pathname({ longname: "base" }),
 
-			$api.Function.pipe(
+			$api.fp.pipe(
 				//	See https://github.com/davidpcaldwell/slime/issues/317
 				jsh.script.cli.option.number({ longname: "debug:delay" }),
 				jsh.script.cli.option.boolean({ longname: "debug:devtools" })

--- a/tools/fifty/test.js
+++ b/tools/fifty/test.js
@@ -115,7 +115,7 @@
 			if (!code) throw new TypeError("Cannot run scope " + code);
 			/** @type { string } */
 			var name;
-			if (!name) name = $api.Function.result(
+			if (!name) name = $api.fp.result(
 				code,
 				getPropertyPathFrom(tests),
 				function(array) {
@@ -537,7 +537,7 @@
 						/** @type { any } */
 						var target = scope.tests;
 						part.split(".").forEach(function(token) {
-							target = $api.Function.result(target, $api.Function.optionalChain(token))
+							target = $api.fp.result(target, $api.fp.optionalChain(token))
 						});
 						if (typeof(target) == "function") {
 							/** @type { (argument: any) => void } */

--- a/tools/fifty/test.jsh.js
+++ b/tools/fifty/test.jsh.js
@@ -13,12 +13,12 @@
 	function($api,jsh) {
 		var isTypescriptInstalled = function() {
 			var installation = jsh.shell.tools.node.installation;
-			var nodeExists = $api.Function.world.input(
+			var nodeExists = $api.fp.world.input(
 				jsh.shell.tools.node.world.Installation.exists(installation)
 			)();
 			if (!nodeExists) return false;
 			var typescript = jsh.shell.tools.node.world.Installation.modules.installed("typescript");
-			var tsInstalled = $api.Function.world.now.question(
+			var tsInstalled = $api.fp.world.now.question(
 				typescript,
 				installation
 			);
@@ -36,7 +36,7 @@
 		});
 
 		/** @type { slime.jsh.script.cli.Processor<any, { definition: slime.jrunscript.file.File, list: boolean, part: string, view: string }> } */
-		var processor = $api.Function.pipe(
+		var processor = $api.fp.pipe(
 			function(p) {
 				var list = p.arguments[0];
 				if (list == "list") {

--- a/tools/fifty/tsdoc.jsh.js
+++ b/tools/fifty/tsdoc.jsh.js
@@ -21,7 +21,7 @@
 			}
 		})
 
-		$api.Function.world.execute(jsh.shell.tools.node.require());
+		$api.fp.world.execute(jsh.shell.tools.node.require());
 		jsh.shell.tools.node.installed.modules.require({ name: "typescript" });
 		jsh.shell.tools.node.installed.modules.require({ name: "@microsoft/tsdoc" });
 

--- a/tools/fifty/ui/main.jsh.js
+++ b/tools/fifty/ui/main.jsh.js
@@ -55,7 +55,7 @@
 			}
 		}
 
-		var invocation = $api.Function.result(
+		var invocation = $api.fp.result(
 			{ options: {}, arguments: p.arguments },
 			option.boolean({ longname: "nocache" }),
 			option.boolean({ longname: "harness" }),
@@ -109,7 +109,7 @@
 					}
 				});
 			};
-			if (!options.nocache) rv = $api.Function.memoized(rv);
+			if (!options.nocache) rv = $api.fp.memoized(rv);
 			return rv;
 		})(invocation.options);
 

--- a/tools/tsc.jsh.js
+++ b/tools/tsc.jsh.js
@@ -30,23 +30,23 @@
 			jsh.shell.exit(1);
 		}
 
-		$api.Function.world.execute(jsh.shell.tools.node.require());
-		var typescriptVersionInstalled = $api.Function.result(
+		$api.fp.world.execute(jsh.shell.tools.node.require());
+		var typescriptVersionInstalled = $api.fp.result(
 			jsh.shell.tools.node.installation,
-			$api.Function.pipe(
-				$api.Function.world.question(
+			$api.fp.pipe(
+				$api.fp.world.question(
 					jsh.shell.tools.node.world.Installation.modules.installed("typescript")
 				),
-				$api.Function.Maybe.map(function(module) {
+				$api.fp.Maybe.map(function(module) {
 					return module.version == parameters.options.version;
 				}),
-				$api.Function.Maybe.else(function() {
+				$api.fp.Maybe.else(function() {
 					return false;
 				})
 			)
 		);
 		if (!typescriptVersionInstalled) {
-			$api.Function.world.now.action(
+			$api.fp.world.now.action(
 				jsh.shell.tools.node.world.Installation.modules.install({ name: "typescript", version: parameters.options.version }),
 				jsh.shell.tools.node.installation
 			);

--- a/tools/wf.jsh.js
+++ b/tools/wf.jsh.js
@@ -25,9 +25,9 @@
 						return function(string) {
 							var match = p.pattern.exec(string);
 							if (match) {
-								return $api.Function.Maybe.value(p.match(match));
+								return $api.fp.Maybe.value(p.match(match));
 							} else {
-								return $api.Function.Maybe.nothing();
+								return $api.fp.Maybe.nothing();
 							}
 						}
 					}
@@ -47,7 +47,7 @@
 
 		/** @type { slime.jsh.script.cli.Descriptor<T> } */
 		var descriptor = {
-			options: $api.Function.cast,
+			options: $api.fp.cast,
 			commands: new jsh.file.Loader({ directory: jsh.wf.project.base }).module("wf.js", {
 				base: jsh.wf.project.base
 			})
@@ -59,7 +59,7 @@
 		var invocation = jsh.script.cli.invocation(descriptor.options);
 
 		/** @type { slime.js.Cast<T> } */
-		var toT = $api.Function.cast;
+		var toT = $api.fp.cast;
 
 		if (invocation.arguments[0] != "initialize" && project.initialize) {
 			project.initialize({

--- a/tools/wf/plugin-standard.jsh.fifty.ts
+++ b/tools/wf/plugin-standard.jsh.fifty.ts
@@ -491,7 +491,7 @@ namespace slime.jsh.wf {
 
 					jsh.shell.world.run(
 						jsh.shell.Invocation.create({
-							command: $api.Function.result(project.location, jsh.file.world.Location.relative("wf")).pathname,
+							command: $api.fp.result(project.location, jsh.file.world.Location.relative("wf")).pathname,
 							arguments: ["status"]
 						})
 					)({
@@ -502,7 +502,7 @@ namespace slime.jsh.wf {
 
 					jsh.shell.world.run(
 						jsh.shell.Invocation.create({
-							command: $api.Function.result(project.location, jsh.file.world.Location.relative("wf")).pathname,
+							command: $api.fp.result(project.location, jsh.file.world.Location.relative("wf")).pathname,
 							arguments: ["status"]
 						})
 					)({
@@ -511,7 +511,7 @@ namespace slime.jsh.wf {
 
 				fifty.tests.issue319 = function() {
 					var project = test.fixtures.adapt.repository(test.fixtures.project().clone);
-					$api.Function.world.now.action(
+					$api.fp.world.now.action(
 						jsh.shell.world.action,
 						jsh.shell.Invocation.create({
 							command: project.directory.getRelativePath("wf"),
@@ -530,7 +530,7 @@ namespace slime.jsh.wf {
 					fixtures.git.edit(repository, "wf.js", function(before) {
 						return before.replace("slime.jsh.Global", "slime.jjj.Global");
 					});
-					$api.Function.world.now.action(
+					$api.fp.world.now.action(
 						jsh.shell.world.action,
 						jsh.shell.Invocation.create({
 							command: project.directory.getRelativePath("wf"),

--- a/tools/wf/plugin-standard.jsh.js
+++ b/tools/wf/plugin-standard.jsh.js
@@ -32,7 +32,7 @@
 			var repository = jsh.tools.git.Repository({ directory: project });
 			var status = repository.status();
 			if (status.paths) {
-				var modified = $api.Function.result(
+				var modified = $api.fp.result(
 					status.paths,
 					Object.entries
 				);
@@ -175,7 +175,7 @@
 					);
 				}
 
-				$exports.tsc = $api.Function.pipe(
+				$exports.tsc = $api.fp.pipe(
 					jsh.script.cli.option.boolean({ longname: "vscode" }),
 					function(p) {
 						/**
@@ -193,8 +193,8 @@
 								return message;
 							}
 						}
-						var formatter = (p.options.vscode) ? formatForVscode : $api.Function.identity;
-						var result = $api.Function.world.now.question(
+						var formatter = (p.options.vscode) ? formatForVscode : $api.fp.identity;
+						var result = $api.fp.world.now.question(
 							jsh.wf.checks.tsc,
 							void(0),
 							{
@@ -261,12 +261,12 @@
 								arguments: ["list"]
 							}
 						},
-						result: $api.Function.pipe(
-							$api.Function.string.split("\n"),
-							$api.Function.Array.map($api.Function.RegExp.exec(/^([^\:]+)(?:.*)$/)),
-							$api.Function.Array.filter($api.Function.Maybe.present),
-							$api.Function.Array.map($api.Function.property("value")),
-							$api.Function.Array.map(function(p) {
+						result: $api.fp.pipe(
+							$api.fp.string.split("\n"),
+							$api.fp.Array.map($api.fp.RegExp.exec(/^([^\:]+)(?:.*)$/)),
+							$api.fp.Array.filter($api.fp.Maybe.present),
+							$api.fp.Array.map($api.fp.property("value")),
+							$api.fp.Array.map(function(p) {
 								return { stash: p[1] };
 							})
 						)
@@ -286,23 +286,23 @@
 					jsh.shell.console("Current branch: " + displayBranchName(status.branch));
 					if (vsRemote && vsRemote.ahead.length) jsh.shell.console("ahead of " + base + ": " + vsRemote.ahead.length);
 					if (vsRemote && vsRemote.behind.length) jsh.shell.console("behind " + base + ": " + vsRemote.behind.length);
-					var output = $api.Function.result(
+					var output = $api.fp.result(
 						status.entries,
-						$api.Function.conditional({
+						$api.fp.conditional({
 							condition: function(entries) {
 								return entries.length > 0;
 							},
-							true: $api.Function.pipe(
-								$api.Function.Array.map(function(entry) {
+							true: $api.fp.pipe(
+								$api.fp.Array.map(function(entry) {
 									if (entry.orig_path) {
 										return entry.code + " " + entry.path + " (was: " + entry.orig_path + ")";
 									} else {
 										return entry.code + " " + entry.path;
 									}
 								}),
-								$api.Function.Array.join("\n")
+								$api.fp.Array.join("\n")
 							),
-							false: $api.Function.returning(null)
+							false: $api.fp.returning(null)
 						})
 					);
 					if (output) jsh.shell.console(output);
@@ -580,7 +580,7 @@
 				}
 
 				$exports.submodule = {
-					update: (project.precommit) ? $api.Function.pipe(
+					update: (project.precommit) ? $api.fp.pipe(
 						/**
 						 *
 						 * @param { slime.jsh.script.cli.Invocation<slime.jsh.wf.standard.Options & { path: string }> } p
@@ -611,14 +611,14 @@
 							}
 						}
 					) : void(0),
-					remove: $api.Function.pipe(
+					remove: $api.fp.pipe(
 						jsh.script.cli.option.string({ longname: "path" }),
 						function(p) {
 							var path = p.options.path;
 							jsh.wf.project.submodule.remove({ path: path });
 						}
 					),
-					attach: $api.Function.pipe(
+					attach: $api.fp.pipe(
 						jsh.script.cli.option.string({ longname: "path" }),
 						function(p) {
 							var repository = jsh.tools.git.Repository({ directory: $context.base });
@@ -644,7 +644,7 @@
 							}
 						}
 					),
-					reset: $api.Function.pipe(
+					reset: $api.fp.pipe(
 						jsh.script.cli.option.string({ longname: "path" }),
 						function(p) {
 							var repository = jsh.tools.git.Repository({ directory: $context.base });
@@ -686,7 +686,7 @@
 					)
 				};
 
-				if (project.precommit) $exports.commit = $api.Function.pipe(
+				if (project.precommit) $exports.commit = $api.fp.pipe(
 					jsh.script.cli.option.string({ longname: "message" }),
 					jsh.script.cli.option.boolean({ longname: "notest" }),
 					function(p) {
@@ -726,7 +726,7 @@
 				);
 
 				var serveDocumentation = function(c) {
-					return $api.Function.pipe(
+					return $api.fp.pipe(
 						function(p) {
 							jsh.shell.run({
 								command: jsh.shell.jsh.src.getFile("fifty"),

--- a/tools/wf/plugin.jsh.js
+++ b/tools/wf/plugin.jsh.js
@@ -102,7 +102,7 @@
 					},
 					lint: {
 						eslint: function() {
-							$api.Function.world.execute(jsh.shell.tools.node.require());
+							$api.fp.world.execute(jsh.shell.tools.node.require());
 							jsh.shell.tools.node.installed.modules.require({ name: "eslint" });
 							return jsh.shell.jsh({
 								shell: jsh.shell.jsh.src,
@@ -301,7 +301,7 @@
 							}
 						},
 						invocation: function(f) {
-							return $api.Function.result(
+							return $api.fp.result(
 								{
 									options: {},
 									arguments: Array.prototype.slice.call(jsh.script.arguments)
@@ -326,7 +326,7 @@
 					}
 				};
 
-				var fetch = $api.Function.memoized(function() {
+				var fetch = $api.fp.memoized(function() {
 					var credentialHelper = jsh.shell.jsh.src.getFile("rhino/tools/github/git-credential-github-tokens-directory.bash").toString();
 
 					var repository = jsh.tools.git.Repository({ directory: base });
@@ -453,7 +453,7 @@
 					return {
 						require: function(p) {
 							var project = (p && p.project) ? p.project : base;
-							$api.Function.world.execute(jsh.shell.tools.node.require());
+							$api.fp.world.execute(jsh.shell.tools.node.require());
 							jsh.shell.tools.node.installed.modules.require({ name: "typescript", version: typescript.getVersion(project) });
 						},
 						tsc: function(p) {
@@ -478,7 +478,7 @@
 							jsh.shell.console("Compiling with TypeScript " + typescript.getVersion(project) + " ...");
 							jsh.shell.tools.rhino.require();
 							jsh.shell.tools.tomcat.require();
-							return $api.Function.world.now.question(
+							return $api.fp.world.now.question(
 								library.typescript.typedoc.run,
 								{
 									configuration: {
@@ -505,7 +505,7 @@
 
 				/** @type { slime.jsh.wf.exports.Checks["noUntrackedFiles"] } */
 				function noUntrackedFiles(p) {
-					return $api.Function.world.old.ask(function(events) {
+					return $api.fp.world.old.ask(function(events) {
 						events.fire("console", "Verifying no untracked files ...");
 						var status = p.repository.status();
 						var untracked = (status.paths) ? $api.Object.properties(status.paths).filter(function(property) {
@@ -528,7 +528,7 @@
 						return Boolean(config["user.name"] && config["user.email"]);
 					}
 
-					return $api.Function.world.old.ask(function(events) {
+					return $api.fp.world.old.ask(function(events) {
 						events.fire("debug", "Verifying git identity ...");
 						var config = p.repository.config({
 							arguments: ["--list"]
@@ -560,7 +560,7 @@
 
 				/** @type { slime.jsh.wf.exports.Checks["noModifiedSubmodules"] } */
 				function noModifiedSubmodules(p) {
-					return $api.Function.world.old.ask(function(events) {
+					return $api.fp.world.old.ask(function(events) {
 						events.fire("console", "Verifying submodules unmodified ...")
 						// var success = true;
 						// p.repository.submodule().forEach(function(sub) {
@@ -631,7 +631,7 @@
 
 				/** @type { slime.jsh.wf.exports.Checks["noDetachedHead"] } */
 				function noDetachedHead(p) {
-					return $api.Function.world.old.ask(function(events) {
+					return $api.fp.world.old.ask(function(events) {
 						events.fire("console", "Verifying not a detached HEAD ...");
 						var status = p.repository.status();
 						if (status.branch.name === null) {
@@ -658,7 +658,7 @@
 						return Boolean(allBranches.find(function(branch) { return branch == base; }));
 					}
 
-					return $api.Function.world.old.ask(function(events) {
+					return $api.fp.world.old.ask(function(events) {
 						events.fire("console", "Verifying up to date with origin ...");
 						var remote = "origin";
 						var origin = jsh.tools.git.program({ command: "git" })
@@ -703,7 +703,7 @@
 					var handleTrailingWhitespace = (typeof(p.trailingWhitespace) == "undefined") ? true : p.trailingWhitespace;
 					var handleFinalNewlines = (typeof(p.handleFinalNewlines) == "undefined") ? true : p.handleFinalNewlines;
 					return {
-						check: $api.Function.world.old.ask(function(events) {
+						check: $api.fp.world.old.ask(function(events) {
 							var success = true;
 
 							if (handleTrailingWhitespace) {
@@ -769,7 +769,7 @@
 
 							return success;
 						}),
-						fix: $api.Function.world.old.tell(function(events) {
+						fix: $api.fp.world.old.tell(function(events) {
 							if (handleTrailingWhitespace) {
 								events.fire("console", "Checking for trailing whitespace ...");
 								jsh.tools.code.handleTrailingWhitespace({
@@ -820,7 +820,7 @@
 						var version = typescript.getVersion(project);
 						events.fire("console", "Compiling with TypeScript " + version + " ...");
 						//	TODO	create standard jsh invocation to make the terser, commented-out form below this form possible
-						var result = $api.Function.world.now.question(
+						var result = $api.fp.world.now.question(
 							jsh.shell.world.question,
 							jsh.shell.Invocation.create({
 								command: jsh.shell.jsh.src.getFile("jsh.bash"),
@@ -862,7 +862,7 @@
 					tsc: tsc,
 					lint: lint,
 					precommit: function(p) {
-						return $api.Function.world.old.ask(function(events) {
+						return $api.fp.world.old.ask(function(events) {
 							var repository = fetch();
 
 							var success = true;
@@ -918,7 +918,7 @@
 								});
 							}
 
-							success = success && $api.Function.world.now.question(tsc, void(0), {
+							success = success && $api.fp.world.now.question(tsc, void(0), {
 								console: function(e) {
 									events.fire("console", e.detail);
 								},

--- a/tools/wf/typescript.js
+++ b/tools/wf/typescript.js
@@ -13,9 +13,9 @@
 	 * @param { slime.loader.Export<slime.jsh.wf.internal.typescript.Exports> } $export
 	 */
 	function($api,$context,$export) {
-		var parseTypedocVersion = $api.Function.pipe(
-			$api.Function.string.split("."),
-			$api.Function.Array.map(Number),
+		var parseTypedocVersion = $api.fp.pipe(
+			$api.fp.string.split("."),
+			$api.fp.Array.map(Number),
 			function(parsed) {
 				return {
 					major: parsed[0],
@@ -45,32 +45,32 @@
 		 * @returns
 		 */
 		function getRelativePath(pathname, relative) {
-			return $api.Function.result(
+			return $api.fp.result(
 				pathname,
-				$api.Function.pipe(
+				$api.fp.pipe(
 					$context.library.file.world.Location.from.os,
 					$context.library.file.world.Location.relative(relative),
-					$api.Function.property("pathname")
+					$api.fp.property("pathname")
 				)
 			)
 		}
 
 		/** @type { (project: slime.jrunscript.file.world.Location) => { [x: string]: any } } */
-		var getTypedocConfguration = $api.Function.pipe(
+		var getTypedocConfguration = $api.fp.pipe(
 			$context.library.file.world.Location.relative("typedoc.json"),
-			$api.Function.world.question($context.library.file.world.Location.file.read.string()),
-			$api.Function.Maybe.map(function removeComments(s) {
+			$api.fp.world.question($context.library.file.world.Location.file.read.string()),
+			$api.fp.Maybe.map(function removeComments(s) {
 				return s.split("\n").filter(function(line) {
 					if (!Boolean(line)) return false;
 					if (/^\s*\/\/(.*)/.test(line)) return false;
 					return true;
 				}).join("\n")
 			}),
-			$api.Function.Maybe.map(function(s) {
+			$api.fp.Maybe.map(function(s) {
 				//Packages.java.lang.System.err.println(s);
 				return JSON.parse(s);
 			}),
-			$api.Function.Maybe.else(
+			$api.fp.Maybe.else(
 				/** @type { () => { [x: string]: any } } */
 				function() { return {}; }
 			)
@@ -89,32 +89,32 @@
 		var invocation = function(p) {
 			if (!p.configuration || !p.configuration.typescript || !p.configuration.typescript.version) throw new TypeError("Required: p.configuration.typescript.version");
 
-			$api.Function.world.now.action($context.library.node.require);
+			$api.fp.world.now.action($context.library.node.require);
 
-			$api.Function.world.now.action(
+			$api.fp.world.now.action(
 				$context.library.node.world.Installation.modules.require({ name: "typescript", version: p.configuration.typescript.version }),
 				$context.library.node.installation
 			);
 
-			var typedocVersion = $api.Function.result(
+			var typedocVersion = $api.fp.result(
 				p.configuration.typescript.version,
-				$api.Function.pipe(
+				$api.fp.pipe(
 					typedocVersionForTypescript,
 					parseTypedocVersion
 				)
 			);
 
-			$api.Function.world.now.action(
+			$api.fp.world.now.action(
 				$context.library.node.world.Installation.modules.require({
 					name: "typedoc",
-					version: $api.Function.result(p.configuration.typescript.version, typedocVersionForTypescript)
+					version: $api.fp.result(p.configuration.typescript.version, typedocVersionForTypescript)
 				}),
 				$context.library.node.installation
 			);
 
 			var project = $context.library.file.world.Location.from.os(p.project);
 
-			var configuration = $api.Function.result(
+			var configuration = $api.fp.result(
 				project,
 				getTypedocConfguration
 			);
@@ -140,11 +140,11 @@
 
 					if (!configuration.readme) {
 						var readme = (function(project) {
-							var typedocIndexLocation = $api.Function.result(
+							var typedocIndexLocation = $api.fp.result(
 								project,
 								$context.library.file.world.Location.relative("typedoc-index.md")
 							);
-							var exists = $api.Function.world.now.question(
+							var exists = $api.fp.world.now.question(
 								$context.library.file.world.Location.file.exists(),
 								typedocIndexLocation
 							);
@@ -154,8 +154,8 @@
 					}
 
 					if (!configuration.entryPoints && typedocVersionUsesEntryPoints(typedocVersion)) {
-						var entryPointLocation = $api.Function.result(project, $context.library.file.world.Location.relative("README.fifty.ts"));
-						var exists = $api.Function.world.now.question(
+						var entryPointLocation = $api.fp.result(project, $context.library.file.world.Location.relative("README.fifty.ts"));
+						var exists = $api.fp.world.now.question(
 							$context.library.file.world.Location.file.exists(),
 							entryPointLocation
 						);
@@ -176,7 +176,7 @@
 			return function(events) {
 				var argument = invocation(p);
 
-				var exit = $api.Function.world.now.question(
+				var exit = $api.fp.world.now.question(
 					$context.library.node.world.Installation.question(argument),
 					$context.library.node.installation
 				);

--- a/wf.js
+++ b/wf.js
@@ -149,7 +149,7 @@
 			}
 		}
 
-		$exports.initialize = $api.Function.pipe(
+		$exports.initialize = $api.fp.pipe(
 			function initialize(p) {
 				jsh.wf.project.git.installHooks();
 				//	TODO	could consider whether we can wire our commit process into the git hooks mechanism:
@@ -195,7 +195,7 @@
 					function node() {
 						(
 							function core() {
-								$api.Function.world.execute(jsh.shell.tools.node.require());
+								$api.fp.world.execute(jsh.shell.tools.node.require());
 							}
 						)();
 						(
@@ -261,7 +261,7 @@
 		}
 
 		/** @type { slime.jsh.wf.Lint["check"] } */
-		var lint = $api.Function.world.old.ask(function(events) {
+		var lint = $api.fp.world.old.ask(function(events) {
 			var success = true;
 
 			success = success && jsh.wf.checks.lint().check({
@@ -428,7 +428,7 @@
 				};
 
 				/** @type { slime.jsh.wf.Precommit } */
-				var precommit = $api.Function.world.old.ask(function(events) {
+				var precommit = $api.fp.world.old.ask(function(events) {
 					var success = true;
 
 					var trunk = getTrunk();
@@ -467,7 +467,7 @@
 			$exports
 		);
 
-		$exports.check = $api.Function.pipe(
+		$exports.check = $api.fp.pipe(
 			jsh.script.cli.option.boolean({ longname: "docker" }),
 			function(p) {
 				jsh.shell.console("Linting ...");
@@ -494,7 +494,7 @@
 		if (jsh.tools.git.Repository) {
 			(
 				function() {
-					$exports.git.branch = $api.Function.pipe(
+					$exports.git.branch = $api.fp.pipe(
 						function(p) {
 							var name = p.arguments[0];
 							git.repository.command(git.command.fetch).argument().run();
@@ -503,15 +503,15 @@
 						}
 					);
 
-					$exports.git.trunk = $api.Function.pipe(
+					$exports.git.trunk = $api.fp.pipe(
 						function(p) {
 							git.repository.command(git.command.checkout).argument({ branch: getTrunk() }).run();
-							$api.Function.world.now.action(cleanGitBranches);
+							$api.fp.world.now.action(cleanGitBranches);
 						}
 					)
 
 					$exports.git.branches = (jsh.tools.git.Repository) ? {
-						list: $api.Function.pipe(
+						list: $api.fp.pipe(
 							function(p) {
 								repository.fetch({ all: true, prune: true, recurseSubmodules: true, stdio: { output: null } });
 								/** @type { slime.jrunscript.tools.git.Branch[] } */
@@ -540,14 +540,14 @@
 							}
 						),
 						prune: function(p) {
-							$api.Function.world.now.action(cleanGitBranches);
+							$api.fp.world.now.action(cleanGitBranches);
 						}
 					} : void(0)
 				}
 			)();
 		}
 
-		$exports.merge = $api.Function.pipe(
+		$exports.merge = $api.fp.pipe(
 			/**
 			 *
 			 * @param { slime.jsh.script.cli.Invocation<slime.jsh.wf.standard.Options & { branch: string }> } p
@@ -674,7 +674,7 @@
 		//	TODO	implement generation of git hooks so that we can get rid of separate pre-commit implementation
 
 		//	TODO	figure out whether there is anything to be harvested from the below or whether it can simply be removed
-		if (false) $exports.commit = $api.Function.pipe(
+		if (false) $exports.commit = $api.fp.pipe(
 			/**
 			 *
 			 * @param { slime.jsh.script.cli.Invocation<slime.jsh.wf.standard.Options & { message: string }> } p
@@ -800,14 +800,14 @@
 		)
 
 		/** @type { (p: slime.jrunscript.file.Directory) => void } */
-		var deleteContents = $api.Function.pipe(
+		var deleteContents = $api.fp.pipe(
 			function(dir) { return dir.pathname.toString() },
 			jsh.file.state.list,
 			function(f) {
 				return f();
 			},
-			$api.Function.Array.map($api.Function.property("absolute")),
-			$api.Function.Array.map(jsh.file.action.delete),
+			$api.fp.Array.map($api.fp.property("absolute")),
+			$api.fp.Array.map(jsh.file.action.delete),
 			function(p) {
 				p.forEach(function(deletion) {
 					deletion({
@@ -830,7 +830,7 @@
 				}
 			},
 			{
-				case: $api.Function.returning(true),
+				case: $api.fp.returning(true),
 				use: function(p) {
 					jsh.shell.console("Not found: " + $context.base.getRelativePath(p));
 				}


### PR DESCRIPTION
Very old constructs (not used in type-checking) may still be available as $api.Function and its properties

Also:
* Add type checking to js/debug/plugin.jsh.js