### PR TITLE
Functional programming improvements

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -114,9 +114,46 @@
 			"problemMatcher": []
 		},
 		{
-			"label": "Fifty: run wip test under jsh",
+			"label": "jsh: Run Current File",
+			"type": "shell",
+			"command": "./jsh.bash ${file}",
+			"problemMatcher": [],
+			"runOptions": {
+				"reevaluateOnRerun": false
+			}
+		},
+		{
+			"label": "jsh: Debug Current File",
+			"type": "shell",
+			"command": "./jsh.bash ${file}",
+			"problemMatcher": [],
+			"options": {
+				"env": {
+					"JSH_DEBUG_SCRIPT": "rhino"
+				}
+			},
+			"runOptions": {
+				"reevaluateOnRerun": false
+			}
+		},
+		{
+			"label": "Fifty (jsh): Run wip() Test in Current File",
 			"type": "shell",
 			"command": "./fifty test.jsh ${file} --part wip",
+			"problemMatcher": []
+		},
+		{
+			"label": "Fifty (browser): Run wip() Test in Current File",
+			"type": "shell",
+			"command": "./fifty",
+			"args": [
+				"test.browser",
+				"--chrome:data", "local/chrome/fifty",
+				"'${relativeFile}'",
+				"--part", "wip",
+				"--interactive",
+				"--chrome:debug:vscode"
+			],
 			"problemMatcher": []
 		},
 		{

--- a/contributor/code/module.js
+++ b/contributor/code/module.js
@@ -103,7 +103,7 @@
 						if (entry.path == "wf") return true;
 					},
 					$api.fp.pipe(
-						$api.fp.world.question(
+						$api.fp.world.mapping(
 							$context.library.code.File.isText()
 						),
 						function(maybe) {

--- a/jrunscript/tools/install/module.js
+++ b/jrunscript/tools/install/module.js
@@ -379,7 +379,7 @@
 					 * @returns
 					 */
 					var createFetcher = function(events) {
-						return $api.fp.world.question(
+						return $api.fp.world.mapping(
 							$context.api.http.world.Client.withFollowRedirects($context.api.http.world.request),
 							{
 								request: function(e) {

--- a/jsh/launcher/test/suite.js
+++ b/jsh/launcher/test/suite.js
@@ -164,7 +164,7 @@
 		};
 
 		/** @type { (invocation: slime.jsh.internal.launcher.test.ShellInvocation) => slime.jsh.internal.launcher.test.Result } */
-		var getShellResultFor = $api.fp.world.question(shellResultQuestion, {
+		var getShellResultFor = $api.fp.world.mapping(shellResultQuestion, {
 			invocation: function(e) {
 				//	TODO	can we use console for this and the next call?
 				$context.console("Command: " + e.detail.command + " " + e.detail.arguments.join(" "));

--- a/loader/$api-Function.fifty.ts
+++ b/loader/$api-Function.fifty.ts
@@ -86,48 +86,7 @@ namespace slime.$api.fp {
 	)(fifty);
 
 	export interface Exports {
-		pipe: {
-			<T,U,V,W,X,Y,Z,R>(
-				f: (t: T) => U,
-				g: (u: U) => V,
-				h: (v: V) => W,
-				i: (w: W) => X,
-				j: (x: X) => Y,
-				k: (y: Y) => Z,
-				l: (z: Z) => R
-			): (t: T) => R
-			<T,U,V,W,X,Y,R>(
-				f: (t: T) => U,
-				g: (u: U) => V,
-				h: (v: V) => W,
-				i: (w: W) => X,
-				j: (x: X) => Y,
-				k: (y: Y) => R
-			): (t: T) => R
-			<T,U,V,W,X,R>(
-				f: (t: T) => U,
-				g: (u: U) => V,
-				h: (v: V) => W,
-				i: (w: W) => X,
-				j: (x: X) => R
-			): (t: T) => R
-			<T,U,V,W,R>(
-				f: (t: T) => U,
-				g: (u: U) => V,
-				h: (v: V) => W,
-				i: (w: W) => R
-			): (t: T) => R
-			<T,U,V,R>(
-				f: (t: T) => U,
-				g: (u: U) => V,
-				h: (v: V) => R
-			): (t: T) => R
-			<T,U,R>(
-				f: (t: T) => U,
-				g: (u: U) => R
-			): (t: T) => R
-			<T,R>(f: (t: T) => R): (t: T) => R
-		}
+		pipe: Pipe
 	}
 
 	export interface Exports {
@@ -135,79 +94,48 @@ namespace slime.$api.fp {
 	}
 
 	export interface Exports {
-		/**
-		 * Returns the result of invoking a function. `result(input, f)` is syntactic sugar for `f(input)` in situations where
-		 * writing the input before the function lends clarity (for example, if the function is a pipeline created by `pipe`).
-		 */
-		result: {
-			/** @deprecated Use the two-argument version of `result`, and `pipe` to compose the functions. */
-			<P,T,U,V,W,X,Y,Z,R>(
-				p: P,
-				f: (p: P) => T,
-				g: (t: T) => U,
-				h: (u: U) => V,
-				i: (v: V) => W,
-				j: (w: W) => X,
-				k: (x: X) => Y,
-				l: (y: Y) => Z,
-				m: (z: Z) => R
-			): R
-			/** @deprecated Use the two-argument version of `result`, and `pipe` to compose the functions. */
-			<P,T,U,V,W,X,Y,R>(
-				p: P,
-				f: (p: P) => T,
-				g: (t: T) => U,
-				h: (u: U) => V,
-				i: (v: V) => W,
-				j: (w: W) => X,
-				k: (x: X) => Y,
-				l: (y: Y) => R
-			): R
-			/** @deprecated Use the two-argument version of `result`, and `pipe` to compose the functions. */
-			<P,T,U,V,W,X,R>(
-				p: P,
-				f: (p: P) => T,
-				g: (t: T) => U,
-				h: (u: U) => V,
-				i: (v: V) => W,
-				j: (w: W) => X,
-				k: (x: X) => R
-			): R
-			/** @deprecated Use the two-argument version of `result`, and `pipe` to compose the functions. */
-			<P,T,U,V,W,R>(
-				p: P,
-				f: (p: P) => T,
-				g: (t: T) => U,
-				h: (u: U) => V,
-				i: (v: V) => W,
-				j: (w: W) => R
-			): R
-			/** @deprecated Use the two-argument version of `result`, and `pipe` to compose the functions. */
-			<P,T,U,V,R>(
-				p: P,
-				f: (p: P) => T,
-				g: (t: T) => U,
-				h: (u: U) => V,
-				i: (v: V) => R
-			): R
-			/** @deprecated Use the two-argument version of `result`, and `pipe` to compose the functions. */
-			<P,T,U,R>(
-				p: P,
-				f: (p: P) => T,
-				g: (t: T) => U,
-				h: (u: U) => R
-			): R
-			/** @deprecated Use the two-argument version of `result`, and `pipe` to compose the functions. */
-			<P,T,R>(
-				p: P,
-				f: (p: P) => T,
-				g: (t: T) => R
-			): R
-			<P,R>(
-				p: P,
-				f: (i: P) => R
-			): R
+		now: {
+			/**
+			 * Returns the result of invoking a function. `invoke(input, f)` is syntactic sugar for `f(input)` in situations where
+			 * writing the input before the function lends clarity (for example, if the function is a pipeline created by `pipe`).
+			 */
+			invoke: Invoke
 		}
+	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			const { verify } = fifty;
+			const { $api } = fifty.global;
+
+			fifty.tests.exports.now = function() {
+				var f = function(i: number): string {
+					return String(i);
+				};
+
+				var g = function(s: string): string {
+					return "g" + s;
+				};
+
+				var result = $api.fp.now.invoke(2, f);
+				verify(result).is("2");
+
+				var result2 = $api.fp.now.invoke(2, f, g);
+				verify(result2).is("g2");
+			};
+
+			fifty.tests.wip = fifty.tests.exports.now;
+		}
+	//@ts-ignore
+	)(fifty);
+
+	export interface Exports {
+		/**
+		 * @deprecated Use `$api.Function.now.invoke`.
+		 */
+		result: Invoke
 	}
 
 	(

--- a/loader/$api-Function.js
+++ b/loader/$api-Function.js
@@ -485,6 +485,17 @@
 					}
 				}
 			},
+			now: {
+				invoke: function(p) {
+					var functions = Array.prototype.slice.call(arguments).slice(1);
+					if (functions.length == 0) throw new TypeError();
+					var rv = p;
+					functions.forEach(function(f) {
+						rv = f(rv);
+					});
+					return rv;
+				}
+			},
 			impure: impure.impure,
 			world: impure.world,
 			object: {

--- a/loader/$api-fp-generated.fifty.ts
+++ b/loader/$api-fp-generated.fifty.ts
@@ -1,0 +1,211 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+namespace slime.$api.fp {
+	export type Pipe = {
+		<A,B,C,D,E,F,G,H,I>(
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E,
+			j: (e: E) => F,
+			k: (f: F) => G,
+			l: (g: G) => H,
+			m: (h: H) => I
+		): (a: A) => I
+
+		<A,B,C,D,E,F,G,H>(
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E,
+			j: (e: E) => F,
+			k: (f: F) => G,
+			l: (g: G) => H
+		): (a: A) => H
+
+		<A,B,C,D,E,F,G>(
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E,
+			j: (e: E) => F,
+			k: (f: F) => G
+		): (a: A) => G
+
+		<A,B,C,D,E,F>(
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E,
+			j: (e: E) => F
+		): (a: A) => F
+
+		<A,B,C,D,E>(
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E
+		): (a: A) => E
+
+		<A,B,C,D>(
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D
+		): (a: A) => D
+
+		<A,B,C>(
+			f: (a: A) => B,
+			g: (b: B) => C
+		): (a: A) => C
+
+		<A,B>(
+			f: (a: A) => B
+		): (a: A) => B
+	}
+
+	export type Invoke = {
+		<A,B,C,D,E,F,G,H,I>(
+			a: A,
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E,
+			j: (e: E) => F,
+			k: (f: F) => G,
+			l: (g: G) => H,
+			m: (h: H) => I
+		): I
+
+		<A,B,C,D,E,F,G,H>(
+			a: A,
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E,
+			j: (e: E) => F,
+			k: (f: F) => G,
+			l: (g: G) => H
+		): H
+
+		<A,B,C,D,E,F,G>(
+			a: A,
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E,
+			j: (e: E) => F,
+			k: (f: F) => G
+		): G
+
+		<A,B,C,D,E,F>(
+			a: A,
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E,
+			j: (e: E) => F
+		): F
+
+		<A,B,C,D,E>(
+			a: A,
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E
+		): E
+
+		<A,B,C,D>(
+			a: A,
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D
+		): D
+
+		<A,B,C>(
+			a: A,
+			f: (a: A) => B,
+			g: (b: B) => C
+		): C
+
+		<A,B>(
+			a: A,
+			f: (a: A) => B
+		): B
+	}
+}
+
+namespace slime.$api.fp.impure {
+	export type Input_map = {
+		<A,B,C,D,E,F,G,H,I>(
+			a: Input<A>,
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E,
+			j: (e: E) => F,
+			k: (f: F) => G,
+			l: (g: G) => H,
+			m: (h: H) => I
+		): Input<I>
+
+		<A,B,C,D,E,F,G,H>(
+			a: Input<A>,
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E,
+			j: (e: E) => F,
+			k: (f: F) => G,
+			l: (g: G) => H
+		): Input<H>
+
+		<A,B,C,D,E,F,G>(
+			a: Input<A>,
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E,
+			j: (e: E) => F,
+			k: (f: F) => G
+		): Input<G>
+
+		<A,B,C,D,E,F>(
+			a: Input<A>,
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E,
+			j: (e: E) => F
+		): Input<F>
+
+		<A,B,C,D,E>(
+			a: Input<A>,
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D,
+			i: (d: D) => E
+		): Input<E>
+
+		<A,B,C,D>(
+			a: Input<A>,
+			f: (a: A) => B,
+			g: (b: B) => C,
+			h: (c: C) => D
+		): Input<D>
+
+		<A,B,C>(
+			a: Input<A>,
+			f: (a: A) => B,
+			g: (b: B) => C
+		): Input<C>
+
+		<A,B>(
+			a: Input<A>,
+			f: (a: A) => B
+		): Input<B>
+	}
+}

--- a/loader/$api-fp-impure.js
+++ b/loader/$api-fp-impure.js
@@ -31,14 +31,30 @@
 						return v;
 					}
 				},
-				map: function(input, map) {
+				map: function(input) {
+					var functions = Array.prototype.slice.call(arguments,1);
 					return function() {
-						return map(input());
+						var rv = input();
+						functions.forEach(function(f) {
+							rv = f(rv);
+						});
+						return rv;
 					}
 				},
 				process: function(input, output) {
 					return function() {
 						output(input());
+					}
+				},
+				//@ts-ignore
+				compose: function(p) {
+					return function() {
+						var rv = Object.fromEntries(
+							Object.entries(p).map(function(entry) {
+								return [entry[0], entry[1]()];
+							})
+						);
+						return rv;
 					}
 				}
 			},
@@ -53,6 +69,12 @@
 				output: function(p,f) {
 					return function() {
 						f(p);
+					}
+				},
+				/** @type { slime.$api.fp.impure.Exports["Process"]["create"]} */
+				create: function(p) {
+					return function() {
+						p.output(p.input());
 					}
 				}
 			},
@@ -94,14 +116,14 @@
 					);
 				}
 			},
-			question: function(question, handler) {
+			mapping: function(question, handler) {
 				return function(p) {
 					var ask = question(p);
 					var adapted = $context.events.ask(ask);
 					return adapted(handler);
 				}
 			},
-			action: function(action, handler) {
+			output: function(action, handler) {
 				return function(p) {
 					var tell = action(p);
 					var adapted = $context.events.tell(tell);

--- a/loader/tools/generate-fp-types.jsh.js
+++ b/loader/tools/generate-fp-types.jsh.js
@@ -1,0 +1,216 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+//@ts-check
+(
+	/**
+	 * @param { slime.$api.Global } $api
+	 * @param { slime.jsh.Global } jsh
+	 * @param { slime.jsh.script.cli.main } main
+	 */
+	function($api,jsh,main) {
+		var inputs = {
+			counts: $api.fp.impure.Input.value({
+				pipe: 8,
+				invoke: 8,
+				input_map: 8
+			}),
+			destination: $api.fp.impure.Input.map(
+				$api.fp.impure.Input.value(jsh.script.world.file),
+				$api.fp.pipe(
+					jsh.file.world.Location.relative("../../$api-fp-generated.fifty.ts")
+				)
+			)
+		};
+
+		var output = function(location) {
+			return function(string) {
+				$api.fp.impure.now.output(
+					location,
+					$api.fp.world.output(jsh.file.world.Location.file.write.string({ value: string }))
+				);
+			}
+		};
+
+		var offset = function(n) {
+			return function(string) {
+				for (var i=0; i<n; i++) {
+					string = "\t" + string;
+				}
+				return string;
+			}
+		};
+
+		var indent = offset(1);
+
+		var indexes = function(n) {
+			//	https://stackoverflow.com/questions/3746725/how-to-create-an-array-containing-1-n
+			return Array.apply(
+				null,
+				{
+					length: n
+				}
+			).map(Number.call, Number);
+		}
+
+		/**
+		 *
+		 * @param { number } number
+		 * @return { string[] }
+		 */
+		var getGenericTypeList = function(number) {
+			var array = [];
+			for (var i=0; i<number; i++) {
+				array.push(String.fromCharCode("A".charCodeAt(0) + i));
+			}
+			return array;
+		}
+
+		var getFunctionName = function(index) {
+			return String.fromCharCode("f".charCodeAt(0) + index);
+		}
+
+		var getParameterNameOfType = function(type) {
+			return type.toLowerCase();
+		}
+
+		/**
+		 *
+		 * @param { number } size
+		 * @returns { string[] }
+		 */
+		var pipeDefinition = function(size) {
+			var rv = [];
+			var types = getGenericTypeList(size+1);
+			rv.push("<" + types.join(",") + ">(");
+			for (var i=0; i<size; i++) {
+				var last = i+1 == size;
+				var f = getFunctionName(i);
+				var p = getParameterNameOfType(types[i]);
+				var r = types[i+1];
+				rv.push(indent(f + ": (" + p + ": " + types[i] + ") => " + r + ( last ? "" : "," )));
+			}
+			var t = types[0];
+			var p = getParameterNameOfType(t);
+			var x = types[types.length-1];
+			rv.push("): (" + p + ": " + t + ") => " + x);
+			return rv;
+		};
+
+		var invokeDefinition = function(size) {
+			var rv = [];
+			var types = getGenericTypeList(size+1);
+			rv.push("<" + types.join(",") + ">(");
+			rv.push(indent("a: A,"));
+			for (var i=0; i<size; i++) {
+				var last = i+1 == size;
+				var f = getFunctionName(i);
+				var p = getParameterNameOfType(types[i]);
+				var r = types[i+1]
+				rv.push(indent(f + ": (" + p + ": " + types[i] + ") => " + r + ( last ? "" : "," )));
+			}
+			rv.push("): " + types[types.length-1]);
+			return rv;
+		}
+
+		var inputMapDefinition = function(size) {
+			var rv = [];
+			var types = getGenericTypeList(size+1);
+			rv.push("<" + types.join(",") + ">(");
+			rv.push(indent("a: Input<A>,"));
+			for (var i=0; i<size; i++) {
+				var last = i+1 == size;
+				var f = getFunctionName(i);
+				var p = getParameterNameOfType(types[i]);
+				var r = types[i+1]
+				rv.push(indent(f + ": (" + p + ": " + types[i] + ") => " + r + ( last ? "" : "," )));
+			}
+			rv.push("): " + "Input<" + types[types.length-1] + ">");
+			return rv;
+		}
+
+		/**
+		 *
+		 * @param { (name: string) => string } open
+		 */
+		var definition = function(open) {
+			/**
+			 * @param { string } name
+			 * @param { string[][] } nested
+			 * @returns { string[] }
+			 */
+			return function(name, nested) {
+				return $api.fp.Arrays.join([
+					[open(name)],
+					$api.fp.Arrays.join(
+						nested.map(function(definition,index,array) {
+							var last = (index+1) == array.length;
+							return (last) ? definition : definition.concat([""]);
+						})
+					).map(offset(1)),
+					["}"]
+				]);
+			}
+		};
+
+		var typeDefinition = definition(function(name) {
+			return "export type " + name + " = {";
+		});
+
+		var namespaceDefinition = definition(function(name) {
+			return "namespace " + name + " {";
+		});
+
+		main(
+			function(p) {
+				$api.fp.impure.now.process(
+					$api.fp.impure.Process.create({
+						input: $api.fp.impure.Input.map(
+							$api.fp.impure.Input.compose(inputs),
+							$api.fp.pipe(
+								function(inputs) {
+									var impure = namespaceDefinition(
+										"slime.$api.fp.impure",
+										[
+											typeDefinition(
+												"Input_map",
+												indexes(inputs.counts.input_map).map(function(n,index,array) {
+													return inputMapDefinition(array.length-n);
+												})
+											)
+										]
+									);
+									return [
+										namespaceDefinition(
+											"slime.$api.fp",
+											[
+												typeDefinition(
+													"Pipe",
+													indexes(inputs.counts.pipe).map(function(n,index,array) {
+														return pipeDefinition(array.length-n);
+													})
+												),
+												typeDefinition(
+													"Invoke",
+													indexes(inputs.counts.invoke).map(function(n,index,array) {
+														return invokeDefinition(array.length-n);
+													})
+												)
+											]
+										).join("\n"),
+										impure.join("\n")
+									].join("\n\n");
+								}
+							)
+						),
+						output: output(inputs.destination())
+					})
+				)
+			}
+		);
+	}
+//@ts-ignore
+)($api,jsh,main);

--- a/rhino/file/world.fifty.ts
+++ b/rhino/file/world.fifty.ts
@@ -84,23 +84,23 @@ namespace slime.jrunscript.file {
 					const { verify } = fifty;
 					const { $api, jsh } = fifty.global;
 
-					var writeText = $api.fp.world.action(
+					var writeText = $api.fp.world.output(
 						jsh.file.world.Location.file.write.string({ value: "tocopy" })
 					);
 
 					var readText = $api.fp.pipe(
-						$api.fp.world.question(
+						$api.fp.world.mapping(
 							jsh.file.world.Location.file.read.string()
 						),
 						$api.fp.Maybe.map(function(s) { return s; }),
 						$api.fp.Maybe.else(function(): string { return null; })
 					);
 
-					var exists = $api.fp.world.question(
+					var exists = $api.fp.world.mapping(
 						jsh.file.world.Location.file.exists()
 					);
 
-					var dExists = $api.fp.world.question(
+					var dExists = $api.fp.world.mapping(
 						jsh.file.world.Location.directory.exists()
 					)
 
@@ -116,7 +116,7 @@ namespace slime.jrunscript.file {
 							verify(exists(to)).is(false);
 							verify(readText(to)).is(null);
 
-							var copy = $api.fp.world.action(jsh.file.world.Location.file.copy({ to: to }));
+							var copy = $api.fp.world.output(jsh.file.world.Location.file.copy({ to: to }));
 							copy(from);
 
 							verify(exists(to)).is(true);
@@ -144,7 +144,7 @@ namespace slime.jrunscript.file {
 							verify(exists(to)).is(false);
 							verify(readText(to)).is(null);
 
-							var copy = $api.fp.world.action(jsh.file.world.Location.file.copy({ to: to }), captor.handler);
+							var copy = $api.fp.world.output(jsh.file.world.Location.file.copy({ to: to }), captor.handler);
 							copy(from);
 
 							verify(dExists(parent)).is(true);
@@ -167,7 +167,7 @@ namespace slime.jrunscript.file {
 							verify(exists(to)).is(false);
 							verify(readText(to)).is(null);
 
-							var copy = $api.fp.world.action(jsh.file.world.Location.file.move({ to: to }));
+							var copy = $api.fp.world.output(jsh.file.world.Location.file.move({ to: to }));
 							copy(from);
 
 							verify(exists(from)).is(false);
@@ -197,7 +197,7 @@ namespace slime.jrunscript.file {
 							verify(exists(to)).is(false);
 							verify(readText(to)).is(null);
 
-							var copy = $api.fp.world.action(jsh.file.world.Location.file.move({ to: to }), captor.handler);
+							var copy = $api.fp.world.output(jsh.file.world.Location.file.move({ to: to }), captor.handler);
 							copy(from);
 
 							verify(exists(from)).is(false);
@@ -254,11 +254,11 @@ namespace slime.jrunscript.file {
 						fifty.run(function exists() {
 							var at = fifty.jsh.file.temporary.location();
 
-							var exists = $api.fp.world.question(subject.Location.file.exists());
+							var exists = $api.fp.world.mapping(subject.Location.file.exists());
 
 							verify(exists(at)).is(false);
 
-							var writeA = $api.fp.world.action(subject.Location.file.write.string({ value: "a" }));
+							var writeA = $api.fp.world.output(subject.Location.file.write.string({ value: "a" }));
 
 							$api.fp.impure.now.output(at, writeA);
 
@@ -338,7 +338,7 @@ namespace slime.jrunscript.file {
 					fifty.tests.sandbox.locations.directory.exists = function() {
 						var at = fifty.jsh.file.temporary.location();
 
-						var exists = Object.assign($api.fp.world.question(subject.Location.directory.exists()), { toString: function() { return "exists()"; }});
+						var exists = Object.assign($api.fp.world.mapping(subject.Location.directory.exists()), { toString: function() { return "exists()"; }});
 
 						verify(at).evaluate(exists).is(false);
 
@@ -375,8 +375,8 @@ namespace slime.jrunscript.file {
 
 					fifty.tests.sandbox.locations.directory.move = function() {
 						const exists = {
-							file: $api.fp.world.question(jsh.file.world.Location.file.exists()),
-							directory: $api.fp.world.question(jsh.file.world.Location.directory.exists())
+							file: $api.fp.world.mapping(jsh.file.world.Location.file.exists()),
+							directory: $api.fp.world.mapping(jsh.file.world.Location.directory.exists())
 						};
 
 						const atFilepath = jsh.file.world.Location.relative("filepath");
@@ -386,12 +386,12 @@ namespace slime.jrunscript.file {
 							$api.fp.pipe(
 								//	TODO	Output.compose?
 								$api.fp.impure.tap(
-									$api.fp.world.action(jsh.file.world.Location.directory.require())
+									$api.fp.world.output(jsh.file.world.Location.directory.require())
 								),
 								$api.fp.impure.tap(
 									$api.fp.pipe(
 										atFilepath,
-										$api.fp.world.action(jsh.file.world.Location.file.write.string({ value: "contents" }))
+										$api.fp.world.output(jsh.file.world.Location.file.write.string({ value: "contents" }))
 									)
 								)
 							)
@@ -409,7 +409,7 @@ namespace slime.jrunscript.file {
 								verify(to).evaluate(atFilepath).evaluate(exists.file).is(false);
 							})();
 
-							var move = $api.fp.world.action(
+							var move = $api.fp.world.output(
 								jsh.file.world.Location.directory.move({ to: to })
 							);
 
@@ -442,7 +442,7 @@ namespace slime.jrunscript.file {
 								verify(captor).events.length.is(0);
 							})();
 
-							var move = $api.fp.world.action(
+							var move = $api.fp.world.output(
 								jsh.file.world.Location.directory.move({ to: to }),
 								captor.handler
 							);
@@ -1001,8 +1001,8 @@ namespace slime.jrunscript.file {
 					//	exist. So going to test for that, and test for files and directories.
 
 					var exists = {
-						file: $api.fp.world.question(Location.file.exists()),
-						directory: $api.fp.world.question(Location.directory.exists())
+						file: $api.fp.world.mapping(Location.file.exists()),
+						directory: $api.fp.world.mapping(Location.directory.exists())
 					};
 
 					var tmpfile = $api.fp.world.input(jsh.file.world.filesystems.os.temporary({ directory: false }));

--- a/rhino/shell/plugin.jsh.fifty.ts
+++ b/rhino/shell/plugin.jsh.fifty.ts
@@ -103,7 +103,7 @@ namespace slime.jsh.shell {
 			)();
 
 			fifty.tests.stdio.close = function() {
-				var f = $api.fp.world.question(
+				var f = $api.fp.world.mapping(
 					jsh.shell.world.question
 				);
 				var result = f(

--- a/rhino/tools/git/fixtures.ts
+++ b/rhino/tools/git/fixtures.ts
@@ -55,7 +55,7 @@ namespace slime.jrunscript.tools.git.test.fixtures {
 					var before = $api.fp.result(
 						target,
 						$api.fp.pipe(
-							$api.fp.world.question(jsh.file.world.Location.file.read.string()),
+							$api.fp.world.mapping(jsh.file.world.Location.file.read.string()),
 							$api.fp.Maybe.else(function() {
 								return null as string;
 							})
@@ -64,7 +64,7 @@ namespace slime.jrunscript.tools.git.test.fixtures {
 
 					var edited = change(before);
 
-					var writeEdited = $api.fp.world.action(jsh.file.world.Location.file.write.string({ value: edited }));
+					var writeEdited = $api.fp.world.output(jsh.file.world.Location.file.write.string({ value: edited }));
 
 					$api.fp.impure.now.output(target, writeEdited);
 				}

--- a/rhino/tools/node/module.fifty.ts
+++ b/rhino/tools/node/module.fifty.ts
@@ -205,7 +205,7 @@ namespace slime.jrunscript.node {
 				);
 				var installation = test.subject.world.Installation.from.location(TMPDIR);
 
-				var installedModule = $api.fp.world.question(
+				var installedModule = $api.fp.world.mapping(
 					test.subject.world.Installation.modules.installed("minimal-package"),
 				)
 
@@ -413,7 +413,7 @@ namespace slime.jsh.shell.tools {
 			const { $api, jsh } = fifty.global;
 
 			$api.fp.impure.now.process(
-				$api.fp.world.action(jsh.shell.tools.node.require)
+				$api.fp.world.output(jsh.shell.tools.node.require)
 			)
 
 			const api = jsh.shell.tools.node.installed;

--- a/rhino/tools/node/module.js
+++ b/rhino/tools/node/module.js
@@ -82,7 +82,7 @@
 						output: "string"
 					}
 				});
-				var getExit = $api.fp.world.question(
+				var getExit = $api.fp.world.mapping(
 					$context.library.shell.world.question
 				);
 				var exit = getExit(invocation);
@@ -559,7 +559,7 @@
 							$api.fp.pipe(
 								$api.fp.property("executable"),
 								$context.library.file.world.Location.from.os,
-								$api.fp.world.question($context.library.file.world.Location.file.exists())
+								$api.fp.world.mapping($context.library.file.world.Location.file.exists())
 							)
 						)
 					}

--- a/tools/code/module.fifty.ts
+++ b/tools/code/module.fifty.ts
@@ -76,7 +76,7 @@ namespace slime.tools.code {
 				var jxa = fifty.jsh.file.relative("../../jxa.bash");
 				var foo = fifty.jsh.file.relative("../../foo");
 
-				var hasShebang = $api.fp.world.question(test.subject.File.hasShebang());
+				var hasShebang = $api.fp.world.mapping(test.subject.File.hasShebang());
 
 				var wfHas = hasShebang({
 					path: "wf",

--- a/tools/code/module.js
+++ b/tools/code/module.js
@@ -206,7 +206,7 @@
 		}
 
 		var readFileString = $api.fp.pipe(
-			$api.fp.world.question(
+			$api.fp.world.mapping(
 				$context.library.file.world.Location.file.read.string()
 			),
 			Maybe_assert

--- a/tools/tsc.jsh.js
+++ b/tools/tsc.jsh.js
@@ -34,7 +34,7 @@
 		var typescriptVersionInstalled = $api.fp.result(
 			jsh.shell.tools.node.installation,
 			$api.fp.pipe(
-				$api.fp.world.question(
+				$api.fp.world.mapping(
 					jsh.shell.tools.node.world.Installation.modules.installed("typescript")
 				),
 				$api.fp.Maybe.map(function(module) {

--- a/tools/wf/typescript.js
+++ b/tools/wf/typescript.js
@@ -58,7 +58,7 @@
 		/** @type { (project: slime.jrunscript.file.world.Location) => { [x: string]: any } } */
 		var getTypedocConfguration = $api.fp.pipe(
 			$context.library.file.world.Location.relative("typedoc.json"),
-			$api.fp.world.question($context.library.file.world.Location.file.read.string()),
+			$api.fp.world.mapping($context.library.file.world.Location.file.read.string()),
 			$api.fp.Maybe.map(function removeComments(s) {
 				return s.split("\n").filter(function(line) {
 					if (!Boolean(line)) return false;


### PR DESCRIPTION
* Add VSCode tasks to run and debug current file in jsh
* Add VSCode task to run current Fifty wip test in browser
* Add $api.fp.impure.Input.compose to allow an object with Input properties to be a single Input
* Rename $api.fp.world.question to $api.fp.world.mapping
* Add $api.fp.now.invoke to invoke functions imperatively
* Rename $api.fp.world.action to $api.fp.world.output
* Add tool for generating FP types to make them easier to refactor
* Improve $api.fp.impure.Input.map to allow pipelining
* Add $api.fp.impure.Process.create to convert Input/Output to Process