### PR TITLE
Get tests passing on aarch64 Docker

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
 		"*.json": "jsonc"
 	},
 	"git.branchProtection": [
-		"master"
+		"main"
 	],
 	"java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m",
 	//	See	https://github.com/redhat-developer/vscode-java/issues/2551 for why the below is currently needed; should be considered

--- a/README.fifty.ts
+++ b/README.fifty.ts
@@ -30,7 +30,8 @@
  * ##### JDK
  *
  * Current goal is to be compatible with version used by most Java developers per most recent [JetBrains
- * survey](https://www.jetbrains.com/lp/devecosystem-2021/java/), which is currently **Java 8**.
+ * survey](https://www.jetbrains.com/lp/devecosystem-2021/java/), which (as of 2021; 2022 survey is not out as of 2022 Nov 13) is
+ * currently **Java 8**.
  *
  * ##### JVM JavaScript engine
  *

--- a/contributor/docker-compose.yaml
+++ b/contributor/docker-compose.yaml
@@ -4,6 +4,7 @@
 #
 #	END LICENSE
 
+version: '2.4'
 services:
   test:
     build: ..
@@ -12,17 +13,17 @@ services:
       # - ..:/slime
       # - /slime/local
     environment:
-      - SLIME_WF_SKIP_GIT_IDENTITY_REEQUIREMENT=1
+      - SLIME_WF_SKIP_GIT_IDENTITY_REQUIREMENT=1
     working_dir: /slime
     command: /bin/bash /slime/wf check --docker
     depends_on:
       - chrome
       - firefox
   chrome:
-    image: selenium/standalone-chrome:4.1.3-20220405
+    image: seleniarm/standalone-chromium
     ports:
       - 7900:7900
   firefox:
-    image: selenium/standalone-firefox:4.1.3-20220405
+    image: seleniarm/standalone-firefox
     ports:
       - 7901:7900

--- a/contributor/macos/linuxvm/profile.bashrc
+++ b/contributor/macos/linuxvm/profile.bashrc
@@ -11,4 +11,3 @@ if [ ! -d "${LOCAL}" ]; then
 fi
 export JSH_LOCAL_JDKS="${LOCAL}/jdk"
 export JSH_SHELL_LIB="${LOCAL}/jsh/lib"
-export SLIME_WF_JDK_8=${JSH_LOCAL_JDKS}/default

--- a/jsh.bash
+++ b/jsh.bash
@@ -146,8 +146,13 @@ install_jdk_corretto() {
 		fi
 		JDK_TARBALL_PATH="amazon-corretto-${MAJOR_VERSION}.jdk/Contents/Home"
 	elif [ "${UNAME}" == "Linux" ]; then
-		JDK_TARBALL_BASENAME="amazon-corretto-${VERSION}-linux-x64.tar.gz"
-		JDK_TARBALL_PATH="amazon-corretto-${VERSION}-linux-x64"
+		if [ "${ARCH}" == "aarch64" ]; then
+			JDK_TARBALL_BASENAME="amazon-corretto-${VERSION}-linux-aarch64.tar.gz"
+			JDK_TARBALL_PATH="amazon-corretto-${VERSION}-linux-aarch64"
+		else
+			JDK_TARBALL_BASENAME="amazon-corretto-${VERSION}-linux-x64.tar.gz"
+			JDK_TARBALL_PATH="amazon-corretto-${VERSION}-linux-x64"
+		fi
 	fi
 	JDK_TARBALL_URL="https://corretto.aws/downloads/resources/${VERSION}/${JDK_TARBALL_BASENAME}"
 	if [ ! -d "${HOME}/Downloads" ]; then

--- a/rhino/tools/node/module.js
+++ b/rhino/tools/node/module.js
@@ -40,10 +40,16 @@
 		};
 
 		var getDownload = function(version, os, arch) {
-			if (arch == "aarch64") {
+			if (os == "Mac OS X" && arch == "aarch64") {
 				if (version == "16.17.1") {
 					return {
 						url: "https://nodejs.org/dist/v16.17.1/node-v16.17.1-darwin-arm64.tar.gz"
+					}
+				}
+			} else if (os == "Linux" && arch == "aarch64") {
+				if (version == "16.17.1") {
+					return {
+						url: "https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-arm64.tar.gz"
 					}
 				}
 			}

--- a/tools/wf/plugin.jsh.fifty.ts
+++ b/tools/wf/plugin.jsh.fifty.ts
@@ -96,7 +96,7 @@ namespace slime.jsh.wf {
 			require: (p?: { project: slime.jrunscript.file.Directory }) => void
 
 			/**
-			 * @deprecated Replaced by {@link slime.jsh.wf.exports.Checks["tsc"]}.
+			 * @deprecated Replaced by {@link slime.jsh.wf.exports.Checks | jsh.wf.checks.tsc()}.
 			 */
 			tsc: (p?: { project: slime.jrunscript.file.Directory }) => boolean
 

--- a/wf
+++ b/wf
@@ -9,11 +9,17 @@ export PROJECT="$(dirname $0)"
 
 SLIME="${PROJECT}"
 
+JSH_LOCAL_JDKS="${SLIME}/local/jdk"
+JSH_SHELL_LIB="${SLIME}/local/jsh/lib"
+
+#	If this is a VMWare Linux guest, mount the source directory inside the VM at ${HOME}/src
 if [ "$(uname)" == "Linux" ]; then
 	#	We know (?) realpath is present because this is Linux
 	if [ "$(realpath $0)" == "/mnt/hgfs/slime/wf" ]; then
 		#	VMWare Linux guest with host source directory mounted
 		if [ -z "${JSH_LOCAL_JDKS}" ]; then
+			#	Set up profile which specifies "local" assets (ordinarily in the local/ subdirectory) should go under the home
+			#	directory
 			echo "source $(realpath ${SLIME}/contributor/macos/linuxvm/profile.bashrc)" >>"${HOME}/.bashrc"
 			source ${SLIME}/contributor/macos/linuxvm/profile.bashrc
 		fi
@@ -23,19 +29,36 @@ if [ "$(uname)" == "Linux" ]; then
 	fi
 fi
 
+SLIME_WF_JDK_VERSION="${SLIME_WF_JDK_VERSION:-8}"
+
 #	For now, run all SLIME wf commands under JDK 8 with Rhino
+if [ "${SLIME_WF_JDK_VERSION}" = "8" ]; then
+	SLIME_WF_JDK_8="${JSH_LOCAL_JDKS}/8"
 
-if [ -z "${SLIME_WF_JDK_8}" ]; then
-	SLIME_WF_JDK_8="${SLIME}/local/jdk/8"
-fi
+	if [ ! -d "${SLIME_WF_JDK_8}" ]; then
+		${SLIME}/jsh.bash --add-jdk-8
+	fi
 
-if [ ! -d "${SLIME_WF_JDK_8}" ]; then
-	${SLIME}/jsh.bash --add-jdk-8
+	if [ ! -f "${JSH_SHELL_LIB}/js.jar" ]; then
+		${SLIME}/jsh.bash ${SLIME}/jsh/tools/install/rhino.jsh.js
+	fi
+
+	export JSH_LAUNCHER_JDK_HOME="${SLIME_WF_JDK_8}"
+elif [ "${SLIME_WF_JDK_VERSION}" = "11" ]; then
+	SLIME_WF_JDK_11="${JSH_LOCAL_JDKS}/11"
+
+	if [ ! -d "${SLIME_WF_JDK_8}" ]; then
+		${SLIME}/jsh.bash --add-jdk-11
+	fi
+
+	if [ ! -f "${JSH_SHELL_LIB}/js.jar" ]; then
+		${SLIME}/jsh.bash ${SLIME}/jsh/tools/install/rhino.jsh.js
+	fi
+
+	export JSH_LAUNCHER_JDK_HOME="${SLIME_WF_JDK_11}"
+else
+	>&2 echo "Unsupported JDK version ${SLIME_WF_JDK_VERSION}; exiting."
+	exit 1
 fi
-LIB="${JSH_SHELL_LIB:-${SLIME}/local/jsh/lib}"
-if [ ! -f "${LIB}/js.jar" ]; then
-	${SLIME}/jsh.bash ${SLIME}/jsh/tools/install/rhino.jsh.js
-fi
-export JSH_LAUNCHER_JDK_HOME="${SLIME_WF_JDK_8}"
 
 ${PROJECT}/tools/wf.bash "$@"

--- a/wf.js
+++ b/wf.js
@@ -160,7 +160,7 @@
 				//	Currently used by plugin-standard.jsh.fifty.ts to install TypeScript types so tsc passes in parent project
 				var skipGitIdentityRequirement =
 					(p && p.arguments[0] == "--test-skip-git-identity-requirement")
-					|| jsh.shell.environment.SLIME_WF_SKIP_GIT_IDENTITY_REEQUIREMENT
+					|| jsh.shell.environment.SLIME_WF_SKIP_GIT_IDENTITY_REQUIREMENT
 				;
 
 				if (!skipGitIdentityRequirement) {
@@ -481,7 +481,7 @@
 					return 1;
 				}
 				jsh.shell.console("Running TypeScript compiler ...");
-				jsh.wf.typescript.tsc();
+				jsh.wf.checks.tsc();
 				jsh.shell.console("Running tests ...");
 				var testsPassed = test({
 					docker: p.options.docker,


### PR DESCRIPTION
* Download correct JDK build
* Download correct Node.js build
* Switch to seleniarm Docker images

Also:
* #289: Begin working toward JDK 11 test case
* Refactor wf JDK version/installation management
* Update JDK compatibility information
* Fix spelling error in identity requirement setting
* Fix broken TypeDoc link to tsc check
* VSCode: update branch protection to main from master