### PR TITLE
#289: Get initial manual test running jsh working

### DIFF
--- a/.devcontainer/docker-compose.extend.yaml
+++ b/.devcontainer/docker-compose.extend.yaml
@@ -4,16 +4,4 @@
 #
 #	END LICENSE
 
-services:
-  test:
-    volumes:
-      - type: bind
-        source: ..
-        target: /slime
-      - type: volume
-        source: local
-        target: /slime/local
-    command: sleep infinity
-
-volumes:
-  local:
+version: '3.9'

--- a/.devcontainer/post-create-command.bash
+++ b/.devcontainer/post-create-command.bash
@@ -4,6 +4,4 @@
 #
 #	END LICENSE
 
-./wf initialize
 ./jsh.bash --add-jdk-17
-apt --yes install git

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -102,9 +102,6 @@
 				"panel": "dedicated",
 				"showReuseMessage": true,
 				"clear": true
-			},
-			"runOptions": {
-				"runOn": "folderOpen"
 			}
 		},
 		{

--- a/contributor/docker-compose.yaml
+++ b/contributor/docker-compose.yaml
@@ -31,6 +31,13 @@ services:
 
   devbox:
     <<: *box
+    volumes:
+      - type: bind
+        source: ..
+        target: /slime
+      - type: volume
+        source: local
+        target: /slime/local
     command: sleep infinity
 
   chrome:
@@ -42,3 +49,6 @@ services:
     image: seleniarm/standalone-firefox
     ports:
       - 7901:7900
+
+volumes:
+  local:

--- a/contributor/jdk11-test.bash
+++ b/contributor/jdk11-test.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+#	LICENSE
+#	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+#	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#	END LICENSE
+
+SLIME=$(dirname $0)/..
+rm -R ${SLIME}/local/jdk/8
+rm -R ${SLIME}/local/jdk/default
+rm -R ${SLIME}/local/git
+rm -R ${SLIME}/local/jsh
+rm -R ${SLIME}/local/wiki
+${SLIME}/jsh.bash --install-jdk-11
+${SLIME}/jsh.bash ${SLIME}/jsh/test/jsh-data.jsh.js


### PR DESCRIPTION
Also:
* Add devbox service for empty SLIME installation
* Do not wf initialize in devcontainer
* Do not automatically run wf documentation on VSCode open