### PR TITLE
In TypeDoc monitor, notice modified submodules

### DIFF
--- a/contributor/code/module.js
+++ b/contributor/code/module.js
@@ -235,17 +235,18 @@
 		)();
 
 		/** @type { slime.jrunscript.tools.git.Command<void, string[]> } */
-		var lsFiles = {
+		var lsFilesRecurseSubmodules = {
 			invocation: function() {
 				return {
-					command: "ls-files"
-				}
+					command: "ls-files",
+					arguments: ["--recurse-submodules"]
+				};
 			},
 			result: function(output) {
 				//	TODO	platform line ending or \n?
 				return output.split("\n");
 			}
-		}
+		};
 
 		$export({
 			files: files,
@@ -282,7 +283,8 @@
 			},
 			git: {
 				lastModified: function(p) {
-					var files = $context.library.git.program({ command: "git" }).repository(p.base).command(lsFiles).argument().run();
+					//	TODO	would this notice untracked files? Should it?
+					var files = $context.library.git.program({ command: "git" }).repository(p.base).command(lsFilesRecurseSubmodules).argument().run();
 					var loader = $context.library.file.world.Location.directory.loader.synchronous({
 						root: $context.library.file.world.Location.from.os(p.base)
 					});

--- a/jsh/script/plugin.jsh.fifty.ts
+++ b/jsh/script/plugin.jsh.fifty.ts
@@ -17,6 +17,17 @@ namespace slime.jsh.script {
 		})(fifty);
 	}
 
+	/**
+	 * Provides APIs supporting command-line `jsh` applications.
+	 *
+	 * ## CLI applications with commands
+	 *
+	 * The simplest way to define a CLI application with commands - in other words, applications invoked using the main script and
+	 * a command name, where each command defines its own arguments - is using the
+	 * {@link slime.jsh.script.cli.Exports#program | jsh.script.cli.program()} method, providing a
+	 * {@link slime.jsh.script.cli.Commands} object as the `commands` property; the function produced is a
+	 * {@link slime.jsh.script.cli.main | `main` implementation}.
+	 */
 	export namespace cli {
 		export interface Invocation<T> {
 			options: T

--- a/rhino/tools/git/api.html.js
+++ b/rhino/tools/git/api.html.js
@@ -42,7 +42,7 @@
 
 			scope.module = module;
 
-			var fixtures = $loader.file("fixtures.js", { module: module });
+			var fixtures = $loader.file("fixtures-old.js", { module: module });
 
 			scope.init = fixtures.init;
 

--- a/rhino/tools/git/commands.fifty.ts
+++ b/rhino/tools/git/commands.fifty.ts
@@ -11,6 +11,7 @@ namespace slime.jrunscript.tools.git.internal.commands {
 		) {
 			fifty.tests.exports = fifty.test.Parent();
 			fifty.tests.world = {};
+			fifty.tests.manual = {};
 		}
 	//@ts-ignore
 	)(fifty);
@@ -168,8 +169,28 @@ namespace slime.jrunscript.tools.git {
 	export interface Commands {
 		submodule: {
 			update: Command<void,void>
+			status: Command<{ cached?: boolean, recursive?: boolean }, { sha1: string, path: string }[]>
 		}
 	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			const { jsh } = fifty.global;
+			const subject = jsh.tools.git.commands;
+
+			fifty.tests.manual.submodule = {};
+			fifty.tests.manual.submodule.status = function() {
+				var repository = jsh.tools.git.program({ command: "git" }).repository(jsh.shell.PWD.toString());
+				var submodules = repository.command(subject.submodule.status).argument({}).run();
+				submodules.forEach(function(submodule) {
+					jsh.shell.console("Path: " + submodule.path + " commit: " + submodule.sha1);
+				});
+			}
+		}
+	//@ts-ignore
+	)(fifty);
 
 	export interface Commands {
 		remote: {

--- a/rhino/tools/git/commands.js
+++ b/rhino/tools/git/commands.js
@@ -105,6 +105,30 @@
 
 		/** @type { slime.jrunscript.tools.git.Commands["submodule"] } */
 		var submodule = {
+			status: {
+				invocation: function(p) {
+					return {
+						command: "submodule",
+						arguments: $api.Array.build(function(rv) {
+							rv.push("status");
+							if (p.cached) rv.push("--cached");
+							if (p.recursive) rv.push("--recursive");
+						})
+					};
+				},
+				result: function(output) {
+					return output.split("\n").filter(Boolean).map(function(line) {
+						return line.trim();
+					}).map(function(line) {
+						return line.split(/\s/);
+					}).map(function(tokens) {
+						return {
+							sha1: tokens[0],
+							path: tokens[1]
+						};
+					});
+				}
+			},
 			update: {
 				invocation: function() {
 					return {

--- a/rhino/tools/git/fixtures-old.js
+++ b/rhino/tools/git/fixtures-old.js
@@ -8,7 +8,7 @@
 (
 	/**
 	 * @param { { module: slime.jrunscript.tools.git.Exports }} $context
-	 * @param { slime.loader.Export<slime.jrunscript.tools.git.internal.Fixtures> } $export
+	 * @param { slime.loader.Export<slime.jrunscript.tools.git.internal.old.Fixtures> } $export
 	 */
 	function($context,$export) {
 		var module = $context.module;

--- a/rhino/tools/git/module.fifty.ts
+++ b/rhino/tools/git/module.fifty.ts
@@ -289,23 +289,25 @@ namespace slime.jrunscript.tools.git {
 		//@ts-ignore
 		)(fifty);
 
-		export interface Fixtures {
-			init: slime.jrunscript.tools.git.Exports["init"]
-			write: (p: {
-				repository?: repository.Local
-				directory?: slime.jrunscript.file.Directory
-				files: {
-					[path: string]: string
-				}
-			}) => void
-		}
-
-		export const fixtures: Fixtures = (
-			function(fifty: slime.fifty.test.Kit) {
-				return fifty.$loader.file("fixtures.js", { module: subject });
+		export namespace old {
+			export interface Fixtures {
+				init: slime.jrunscript.tools.git.Exports["init"]
+				write: (p: {
+					repository?: repository.Local
+					directory?: slime.jrunscript.file.Directory
+					files: {
+						[path: string]: string
+					}
+				}) => void
 			}
-		//@ts-ignore
-		)(fifty);
+
+			export const fixtures: Fixtures = (
+				function(fifty: slime.fifty.test.Kit) {
+					return fifty.$loader.file("fixtures-old.js", { module: subject });
+				}
+			//@ts-ignore
+			)(fifty);
+		}
 	}
 
 
@@ -564,11 +566,11 @@ namespace slime.jrunscript.tools.git {
 
 				fifty.tests.types.Repository.Local.status = function() {
 					var at = fifty.jsh.file.object.temporary.location();
-					var repository = internal.fixtures.init({ pathname: at });
+					var repository = internal.old.fixtures.init({ pathname: at });
 					debugger;
 					var status = repository.status();
 					verify(repository).status().evaluate.property("paths").is(void(0));
-					internal.fixtures.write({
+					internal.old.fixtures.write({
 						repository: repository,
 						files: {
 							a: "a"

--- a/tools/fifty/documentation-handler.js
+++ b/tools/fifty/documentation-handler.js
@@ -85,7 +85,7 @@
 							jsh.shell.console(
 								"Checked; unchanged -"
 								+ " code = " + new Date(e.detail.code)
-								+ " documentation = " + e.detail.documentation
+								+ " documentation = " + new Date(e.detail.documentation)
 							);
 						},
 						updating: function(e) {

--- a/tools/fifty/documentation-handler.js
+++ b/tools/fifty/documentation-handler.js
@@ -82,7 +82,11 @@
 							jsh.shell.console("Set interval to " + e.detail + " milliseconds.");
 						},
 						unchanged: function(e) {
-							jsh.shell.console("Checked; no change.");
+							jsh.shell.console(
+								"Checked; unchanged -"
+								+ " code = " + new Date(e.detail.code)
+								+ " documentation = " + e.detail.documentation
+							);
 						},
 						updating: function(e) {
 							jsh.shell.console("Updating: out=" + e.detail.out);

--- a/tools/fifty/documentation-updater.fifty.ts
+++ b/tools/fifty/documentation-updater.fifty.ts
@@ -59,7 +59,10 @@ namespace slime.tools.documentation.updater {
 					project: string
 				}
 				creating: void
-				unchanged: void
+				unchanged: {
+					code: number
+					documentation: number
+				}
 				setInterval: number
 				updating: {
 					out: string

--- a/tools/fifty/documentation-updater.js
+++ b/tools/fifty/documentation-updater.js
@@ -283,7 +283,10 @@
 									if (timestamps.code.value > timestamps.documentation.value) {
 										run();
 									} else {
-										events.fire("unchanged");
+										events.fire("unchanged", {
+											code: timestamps.code.value,
+											documentation: timestamps.documentation.value
+										});
 									}
 								}
 							}


### PR DESCRIPTION
Also:
* When emitting message that files are unchanged, include dates
* Add slime.jsh.script.cli namespace comment
* Rename rhino/tools/git/fixtures.js to allow type checking (was shadowed by fixtures.ts) and put in 'old' namespace
* Add git submodule.status command