### PR TITLE
Respect GitHub protocol when downloading Rhino

### DIFF
--- a/jsh/test/remote.fifty.ts
+++ b/jsh/test/remote.fifty.ts
@@ -17,7 +17,7 @@ namespace slime.jsh.test.remote {
 			var loader = jsh.file.world.Location.directory.loader.synchronous({ root: slime });
 
 			var code: {
-				testing: slime.jsh.unit.mock.github.test.Script
+				testing: slime.jrunscript.tools.github.internal.test.Script
 			} = {
 				testing: jsh.loader.synchronous.script("rhino/tools/github/test/module.js")(loader)
 			};
@@ -50,6 +50,11 @@ namespace slime.jsh.test.remote {
 				}),
 				$api.fp.world.mapping(jsh.shell.world.question),
 				$api.fp.impure.tap(function(t) {
+					if (t.status != 0) {
+						jsh.shell.console("Status: " + t.status);
+						jsh.shell.console("stderr:");
+						jsh.shell.console(t.stdio.error);
+					}
 					debugger;
 				}),
 				$api.fp.property("stdio"),
@@ -57,7 +62,7 @@ namespace slime.jsh.test.remote {
 			)
 
 			fifty.tests.suite = function() {
-				var settings: slime.jsh.unit.mock.github.test.Settings = {
+				var settings: slime.jsh.unit.mock.github.Settings = {
 					mock: server,
 					branch: "local"
 				};
@@ -73,10 +78,12 @@ namespace slime.jsh.test.remote {
 					getOutput
 				);
 				jsh.shell.console("bash = " + launcherBashScript);
+				jsh.shell.console("invoke = " + invoke);
 				var scriptOutput = $api.fp.now.invoke(
 					toInvocation(invoke, launcherBashScript),
 					getOutput
 				);
+				if (!scriptOutput) throw new Error("No script output.");
 				var output = JSON.parse(scriptOutput);
 				verify(output).evaluate.property("engines").is.type("object");
 			}

--- a/jsh/unit/plugin.jsh.web.fifty.ts
+++ b/jsh/unit/plugin.jsh.web.fifty.ts
@@ -24,7 +24,7 @@ namespace slime.jsh.unit {
 
 			export type Constructor = constructor.Function & {
 				bitbucket: (o: {}) => handler
-				github: (o: { src: slime.jsh.unit.mock.github.src, private?: boolean }) => handler
+				github: slime.jsh.unit.mock.web.Github
 			}
 		}
 

--- a/rhino/jrunscript/api.js
+++ b/rhino/jrunscript/api.js
@@ -1232,6 +1232,10 @@
 				}
 			};
 			var source = sources[version];
+			//	TODO	possibly not the right variable to use, but band-aiding to pass tests
+			if (/^https\:\/\/github\.com/.test(source.url) && $api.shell.environment.JSH_GITHUB_API_PROTOCOL == "http") {
+				source.url = source.url.replace("https://", "http://");
+			}
 			if (!source) throw new Error("No known way to retrieve Rhino version " + version);
 			var tmpdir = Packages.java.io.File.createTempFile("jsh-install",null);
 			tmpdir["delete"]();
@@ -1243,6 +1247,7 @@
 			var _url = new Packages.java.net.URL(source.url);
 			Packages.java.lang.System.err.println("Downloading Rhino from " + _url);
 			var _connection = _url.openConnection();
+			$api.console("Rhino download: opened connection " + _connection);
 			if (source.format == "dist") {
 				var _zipstream = new Packages.java.util.zip.ZipInputStream(_connection.getInputStream());
 				var _entry;
@@ -1257,6 +1262,8 @@
 				Packages.java.lang.System.err.println("Downloaded Rhino to " + tmprhino);
 				return tmprhino;
 			} else if (source.format == "jar") {
+				$api.console("Rhino download: getting response code ...");
+				$api.console("Rhino download status: " + _connection.getResponseCode());
 				$api.io.copy(_connection.getInputStream(), new Packages.java.io.FileOutputStream(tmprhino));
 				return tmprhino;
 			} else {

--- a/rhino/tools/github/plugin.jsh.fifty.ts
+++ b/rhino/tools/github/plugin.jsh.fifty.ts
@@ -1,0 +1,23 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+namespace slime.jsh.unit.mock.web {
+	export type Github = (p: {
+		src: slime.jsh.unit.mock.github.src
+		private?: boolean
+	}) => slime.jsh.unit.mock.handler;
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			fifty.tests.suite = function() {
+
+			}
+		}
+	//@ts-ignore
+	)(fifty);
+}

--- a/rhino/tools/github/plugin.jsh.js
+++ b/rhino/tools/github/plugin.jsh.js
@@ -19,8 +19,7 @@
 			},
 			load: function() {
 				/**
-				 * @param { { src: slime.jsh.unit.mock.github.src, private: boolean } } o
-				 * @returns { slime.jsh.unit.mock.handler }
+				 * @type { slime.jsh.unit.mock.web.Github }
 				 */
 				var MockGithubApi = function(o) {
 					var authorize = function(request) {
@@ -37,6 +36,7 @@
 					}
 					return function(request) {
 						var host = request.headers.value("host");
+						Packages.java.lang.System.err.println("Received request: " + request.method + " " + host + " " + request.path)
 
 						//	TODO	relaxing branch/ref requirements so that we always pretend that the requested branch was also
 						//			the current branch and can just serve from the filesystem. We could probably write a more

--- a/rhino/tools/github/test/manual/jsh.jsh.js
+++ b/rhino/tools/github/test/manual/jsh.jsh.js
@@ -21,7 +21,7 @@
 		jsh.loader.plugins(api);
 
 		var code = {
-			/** @type { slime.jsh.unit.mock.github.test.Script } */
+			/** @type { slime.jrunscript.tools.github.internal.test.Script } */
 			testing: loader.script("test/module.js")
 		};
 

--- a/rhino/tools/github/test/module.fifty.ts
+++ b/rhino/tools/github/test/module.fifty.ts
@@ -4,11 +4,7 @@
 //
 //	END LICENSE
 
-namespace slime.jsh.unit.mock.github.test {
-	export interface Context {
-		slime: slime.jrunscript.file.Directory
-	}
-
+namespace slime.jsh.unit.mock.github {
 	export interface Settings {
 		mock?: slime.jsh.unit.mock.Web
 		branch?: string
@@ -20,15 +16,21 @@ namespace slime.jsh.unit.mock.github.test {
 	export interface Exports {
 		startMock: (jsh: slime.jsh.Global) => slime.jsh.unit.mock.Web
 
-		getDownloadJshBashCommand: (PATH: slime.jrunscript.file.Searchpath, options: Pick<slime.jsh.unit.mock.github.test.Settings,"mock" | "token" | "branch">) => string[]
+		getDownloadJshBashCommand: (PATH: slime.jrunscript.file.Searchpath, options: Pick<slime.jsh.unit.mock.github.Settings,"mock" | "token" | "branch">) => string[]
 
-		getBashInvocationCommand: (options: slime.jsh.unit.mock.github.test.Settings) => string[]
+		getBashInvocationCommand: (options: slime.jsh.unit.mock.github.Settings) => string[]
 
 		/**
 		 * Outputs a single string, suitable for use at the shell command line, that will invoke a shell with the given settings
 		 * using tools (`curl` or `wget`) found on the given search path.
 		 */
-		getCommandLine: (PATH: slime.jrunscript.file.Searchpath, settings: Settings) => string
+		getCommandLine: (PATH: slime.jrunscript.file.Searchpath, settings: slime.jsh.unit.mock.github.Settings) => string
+	}
+}
+
+namespace slime.jrunscript.tools.github.internal.test {
+	export interface Context {
+		slime: slime.jrunscript.file.Directory
 	}
 
 	(
@@ -42,5 +44,5 @@ namespace slime.jsh.unit.mock.github.test {
 	//@ts-ignore
 	)(fifty);
 
-	export type Script = slime.loader.synchronous.Script<Context,Exports>
+	export type Script = slime.loader.synchronous.Script<Context,slime.jsh.unit.mock.github.Exports>
 }

--- a/rhino/tools/github/test/module.js
+++ b/rhino/tools/github/test/module.js
@@ -9,8 +9,8 @@
 	/**
 	 *
 	 * @param { slime.$api.Global } $api
-	 * @param { slime.jsh.unit.mock.github.test.Context } $context
-	 * @param { slime.loader.Export<slime.jsh.unit.mock.github.test.Exports> } $export
+	 * @param { slime.jrunscript.tools.github.internal.test.Context } $context
+	 * @param { slime.loader.Export<slime.jsh.unit.mock.github.Exports> } $export
 	 */
 	function($api,$context,$export) {
 		/**
@@ -42,7 +42,7 @@
 
 		/**
 		 * @param { slime.jrunscript.file.Searchpath } PATH
-		 * @param { Pick<slime.jsh.unit.mock.github.test.Settings,"mock" | "token" | "branch"> } p
+		 * @param { Pick<slime.jsh.unit.mock.github.Settings,"mock" | "token" | "branch"> } p
 		 * @returns
 		 */
 		var getDownloadJshBashCommand = function(PATH,p) {
@@ -82,7 +82,7 @@
 
 		/**
 		 *
-		 * @param { slime.jsh.unit.mock.github.test.Settings } p
+		 * @param { slime.jsh.unit.mock.github.Settings } p
 		 * @returns
 		 */
 		var getBashInvocationCommand = function(p) {
@@ -120,7 +120,7 @@
 
 		/**
 		 *
-		 * @param { slime.jsh.unit.mock.github.test.Settings } p
+		 * @param { slime.jsh.unit.mock.github.Settings } p
 		 * @returns
 		 */
 		var getCommand = function(PATH,p) {


### PR DESCRIPTION
Also:
* Reoganize mock GitHub usage
* When doing remote shell testing, add output to improve diagnosis
* Move mock GitHub API definition to appropriate script