### PR TITLE
#289: Move toward JDK 11

### DIFF
--- a/jsh/launcher/javac.js
+++ b/jsh/launcher/javac.js
@@ -464,6 +464,8 @@
 			} catch (e) {
 				if (e.rhinoException) {
 					e.rhinoException.printStackTrace();
+				} else if (e.printStackTrace) {
+					e.printStackTrace();
 				}
 				throw e;
 			}

--- a/loader/$api-Function.fifty.ts
+++ b/loader/$api-Function.fifty.ts
@@ -609,7 +609,7 @@ namespace slime.$api.fp {
 			 */
 			modify: (modifier: (pattern: string) => string) => (original: RegExp) => RegExp
 
-			exec: (regexp: RegExp) => (string: string) => Maybe<RegExpExecArray>
+			exec: (regexp: RegExp) => Partial<string,RegExpExecArray>
 		}
 	}
 


### PR DESCRIPTION
* Add ability to download Rhino
* Improve exception reporting from javac.js (which currently fails under JDK 11).

Also:
* Clarify definition of $api.fp.RegExp.exec