### PR TITLE
#289: Get jrunscript tests passing

### DIFF
--- a/jsh.bash
+++ b/jsh.bash
@@ -300,11 +300,6 @@ if [ -z "${JRUNSCRIPT}" ]; then
 	JRUNSCRIPT="${JSH_LOCAL_JDKS}/default/bin/jrunscript"
 fi
 
-#	TODO	Because jsh shells invoke jrunscript by name currently, we put jrunscript in the PATH. Could be removed by having
-#			shells execute subshells using the launcher program (e.g., this bash script), or by having it locate jrunscript
-#			dynamically, possibly using an environment variable provided here
-export PATH="$(dirname ${JRUNSCRIPT}):${PATH}"
-
 javaSystemPropertyArgument() {
 	if [ -n "$2" ]; then
 		echo "-D$1=$2"

--- a/jsh/launcher/api.html
+++ b/jsh/launcher/api.html
@@ -80,7 +80,7 @@ END LICENSE
 	<script>
 		window.addEventListener('load', function() {
 			var settings = document.getElementById("settings");
-			Array.prototype.slice.call(settings.tBodies[0].rows).slice(1).forEach(function(row) {
+			Array.prototype.slice.call(settings.tBodies[0].rows).slice(2).forEach(function(row) {
 				var propertyElement = row.cells[0].getElementsByTagName("code")[0];
 				propertyElement.className = "name";
 				var cell = document.createElement("td");
@@ -230,6 +230,16 @@ END LICENSE
 				</tr>
 			</thead>
 			<tbody>
+				<!--
+					Note that the markup below is modified by script above.
+				-->
+				<tr>
+					<td>(none)</td>
+					<td><code>JSH_LAUNCHER_BASH_DEBUG</code></td>
+					<td>
+						Enables debugging within the <code>jsh.bash</code> launcher.
+					</td>
+				</tr>
 				<tr>
 					<td>(none)</td>
 					<td><code>JSH_LAUNCHER_JDK_HOME</code></td>

--- a/jsh/launcher/jsh.bash
+++ b/jsh/launcher/jsh.bash
@@ -13,7 +13,7 @@ if [ -z "$JSH_JAVA_HOME" ]; then
 	if [ "0" = "$?" ]; then
 		true
 	else
-		echo "JSH_JAVA_HOME not defined; should point to Java 2 SDK."
+		echo "JSH_JAVA_HOME not defined; should point to Java Development Kit."
 		exit 1
 	fi
 else

--- a/jsh/launcher/test/suite.js
+++ b/jsh/launcher/test/suite.js
@@ -141,7 +141,10 @@
 				var script = (p.script) ? p.script : $context.script;
 				var environment = $api.Object.compose(
 					p.environment,
-					{ JSH_JAVA_HOME: $context.library.shell.java.home.toString() },
+					//	TODO	considered passing the location of jrunscript directly but it might affect native launcher, which
+					//			currently contains its own logic for locating jrunscript. So for now we pass this (somewhat
+					//			inaccurately-named, since it might not really be JAVA_HOME) value
+					{ JSH_JAVA_HOME: $context.library.shell.java.jrunscript.parent.parent.pathname.toString() },
 					$api.Object.compose(
 						(p.bash && p.logging) ? { JSH_LOG_JAVA_PROPERTIES: p.logging } : {},
 						($context.library.shell.environment.JSH_SHELL_LIB) ? { JSH_SHELL_LIB: $context.library.shell.environment.JSH_SHELL_LIB } : {}

--- a/jsh/test/remote.fifty.ts
+++ b/jsh/test/remote.fifty.ts
@@ -77,7 +77,6 @@ namespace slime.jsh.test.remote {
 					toInvocation(download),
 					getOutput
 				);
-				jsh.shell.console("bash = " + launcherBashScript);
 				jsh.shell.console("invoke = " + invoke);
 				var scriptOutput = $api.fp.now.invoke(
 					toInvocation(invoke, launcherBashScript),
@@ -86,6 +85,7 @@ namespace slime.jsh.test.remote {
 				if (!scriptOutput) throw new Error("No script output.");
 				var output = JSON.parse(scriptOutput);
 				verify(output).evaluate.property("engines").is.type("object");
+				jsh.shell.console(JSON.stringify(output,void(0),4));
 			}
 		}
 	//@ts-ignore

--- a/rhino/tools/github/test/module.js
+++ b/rhino/tools/github/test/module.js
@@ -98,6 +98,7 @@
 				command.push("JSH_GITHUB_API_PROTOCOL=http");
 				command.push("JSH_DISABLE_HTTPS_SECURITY=true");
 				if (p && p.optimize) command.push("JSH_OPTIMIZE_REMOTE_SHELL=true");
+				if (p && p.debug) command.push("JSH_LAUNCHER_BASH_DEBUG=true");
 				if (p && p.debug) command.push("JSH_LAUNCHER_DEBUG=true");
 				PROTOCOL = "http";
 			} else if (p && p.debug) {


### PR DESCRIPTION
* Correctly specify Java location to old launcher in tests

Also:
* Remove old method of finding jrunscript in subshells by altering subshell PATH in jsh.bash
* Document JSH_LAUNCHER_BASH_DEBUG variable