### PR TITLE
Make it possible to destroy documentation updater

### DIFF
--- a/tools/fifty/documentation-handler.fifty.ts
+++ b/tools/fifty/documentation-handler.fifty.ts
@@ -14,7 +14,10 @@ namespace slime.tools.documentation {
 	 * The application-level export of the documentation handler. Using a configuration, creates a function capable of creating a
 	 * servlet handler that can serve project TypeDoc documentation from standard SLIME TypeDoc URLs given the httpd API.
 	 */
-	export type Export = (configuration: Configuration) => (p: slime.servlet.httpd) => slime.servlet.handler
+	export type Export = (configuration: Configuration) => {
+		handler: (p: slime.servlet.httpd) => slime.servlet.handler
+		stop: () => void
+	}
 
 	export type Script = slime.loader.Script<void,Export>
 }

--- a/tools/fifty/documentation-updater.fifty.ts
+++ b/tools/fifty/documentation-updater.fifty.ts
@@ -49,6 +49,7 @@ namespace slime.tools.documentation.updater {
 	export interface Updater {
 		run: () => void
 		update: () => void
+		stop: () => void
 	}
 
 	export interface Exports {
@@ -84,6 +85,8 @@ namespace slime.tools.documentation.updater {
 				errored: {
 					out: string
 				}
+				destroying: void
+				destroyed: void
 			}>
 		}) => Updater
 	}
@@ -141,8 +144,8 @@ namespace slime.tools.documentation.updater {
 				})();
 			}
 
-			fifty.tests.manual.run = function() {
-				var updater = subject.Updater({
+			var createUpdater = function() {
+				return subject.Updater({
 					project: project.pathname,
 					events: {
 						initialized: function(e) {
@@ -174,9 +177,28 @@ namespace slime.tools.documentation.updater {
 						},
 						errored: function(e) {
 							jsh.shell.console("Errored; was to write to " + e.detail.out);
+						},
+						destroying: function(e) {
+							jsh.shell.console("Destroying ...");
+						},
+						destroyed: function(e) {
+							jsh.shell.console("Destroyed.");
 						}
 					}
 				});
+			}
+
+			fifty.tests.manual.run = function() {
+				var updater = createUpdater();
+				updater.run();
+			};
+
+			fifty.tests.manual.stop = function() {
+				var updater = createUpdater();
+				jsh.java.Thread.start(function() {
+					jsh.java.Thread.sleep(45000);
+					updater.stop();
+				})
 				updater.run();
 			}
 		}

--- a/tools/fifty/documentation-updater.js
+++ b/tools/fifty/documentation-updater.js
@@ -308,6 +308,7 @@
 							timeout: function() { return state.codeCheckInterval; }
 						})();
 					}
+					events.fire("destroyed");
 				},
 				update: function() {
 					lock.wait({
@@ -315,10 +316,16 @@
 							setInterval(10000);
 						}
 					})();
-				}//,
-				// stop: function() {
-				// 	//	TODO	detach listener, stop threads
-				// }
+				},
+				stop: function() {
+					events.fire("destroying");
+					lock.wait({
+						then: function() {
+							eventsListener.detach();
+							state.stopped = true;
+						}
+					})();
+				}
 			};
 		};
 

--- a/tools/fifty/project.js
+++ b/tools/fifty/project.js
@@ -48,12 +48,15 @@
 								base: p.base.getSubdirectory("local/wiki")
 							});
 							scope.$exports.handle = scope.httpd.Handler.series(
-								documentationFactory(scope.httpd),
+								documentationFactory.handler(scope.httpd),
 								wikiHandler,
 								asTextHandler({
 									loader: new $context.library.file.Loader({ directory: p.base })
 								})
-							)
+							);
+							scope.$exports.destroy = function() {
+								documentationFactory.stop();
+							}
 						}
 					}
 				}


### PR DESCRIPTION
This helps in scenarios like a reloaded server, so that we don't start multiple copies