### PR TITLE
#896: Add diagnostics

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,6 +8,21 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
+			"label": "Documentation: Show",
+			"detail": "Serves the project documentation and opens a browser to view it",
+			"type": "shell",
+			"command": "./wf documentation",
+			"problemMatcher": [],
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": false,
+				"panel": "dedicated",
+				"showReuseMessage": true,
+				"clear": true
+			}
+		},
+		{
 			"label": "Java: Install JDK",
 			"detail": "Installs the default JDK into this shell",
 			"type": "shell",
@@ -90,27 +105,6 @@
 			}
 		},
 		{
-			"label": "Documentation: Show",
-			"detail": "Serves the project documentation and opens a browser to view it",
-			"type": "shell",
-			"command": "./wf documentation",
-			"problemMatcher": [],
-			"presentation": {
-				"echo": true,
-				"reveal": "always",
-				"focus": false,
-				"panel": "dedicated",
-				"showReuseMessage": true,
-				"clear": true
-			}
-		},
-		{
-			"label": "Project: Update MPL headers",
-			"type": "shell",
-			"command": "./jsh.bash contributor/code/license.jsh.js --fix",
-			"problemMatcher": []
-		},
-		{
 			"label": "jsh: Run Current File",
 			"type": "shell",
 			"command": "./jsh.bash ${file}",
@@ -163,6 +157,18 @@
 			"label": "Fifty: list tests",
 			"type": "shell",
 			"command": "./fifty test.jsh list ${file}",
+			"problemMatcher": []
+		},
+		{
+			"label": "Project: Update MPL headers",
+			"type": "shell",
+			"command": "./jsh.bash contributor/code/license.jsh.js --fix",
+			"problemMatcher": []
+		},
+		{
+			"label": "Project: Run tests in Docker",
+			"type": "shell",
+			"command": "./wf test",
 			"problemMatcher": []
 		}
 	],

--- a/contributor/suite.jsh.js
+++ b/contributor/suite.jsh.js
@@ -41,6 +41,32 @@
 			unhandled: jsh.script.getopts.UNEXPECTED_OPTION_PARSER.SKIP
 		});
 
+		jsh.java.Thread.start(
+			function addDiagnosticForTscDisappearing() {
+				/** @type { boolean } */
+				var found;
+
+				/** @type { boolean } */
+				var now;
+
+				while(true) {
+					now = jsh.shell.jsh.src.getRelativePath("local/jsh/lib/node/bin/tsc").java.adapt().exists();
+					if (typeof(found) == "undefined") {
+						jsh.shell.console("Initial check: tsc found = " + now);
+					} else if (found && !now) {
+						jsh.shell.console("tsc change: removed");
+						jsh.shell.console("node present? " + jsh.shell.jsh.src.getRelativePath("local/jsh/lib/node").java.adapt().exists());
+					} else if (!found && now) {
+						jsh.shell.console("tsc change: added");
+					} else {
+						//jsh.shell.console("tsc still " + now);
+					}
+					found = now;
+					jsh.java.Thread.sleep(25);
+				}
+			}
+		);
+
 		// TODO: force CoffeeScript for verification?
 
 		if (!parameters.options.java.length) {

--- a/jsh/loader/java/inonit/script/jsh/Shell.java
+++ b/jsh/loader/java/inonit/script/jsh/Shell.java
@@ -175,7 +175,8 @@ public class Shell {
 										try {
 											File file = getTscPath();
 											if (file == null) throw new RuntimeException(
-												"tsc file is null, even though tsc resource is " + tsc
+												"tsc file is null, even though tsc resource was " + tsc
+												+ "\nand is " + configuration.getInstallation().getLibraries().getFile("node/bin/tsc")
 												+ "\nlibraries = " + configuration.getInstallation().getLibraries()
 											);
 											return file.getCanonicalPath();

--- a/jsh/tools/install/plugin.jsh.js
+++ b/jsh/tools/install/plugin.jsh.js
@@ -686,7 +686,7 @@
 
 					var location = jsh.shell.jsh.lib.getRelativePath("node");
 
-					/** @type { slime.jsh.shell.tools.Managed } */
+					/** @type { slime.jsh.shell.tools.node.Managed } */
 					var managed = {
 						installation: node.world.Installation.from.location({
 							filesystem: jsh.file.world.spi.filesystems.os,

--- a/rhino/tools/node/module.fifty.ts
+++ b/rhino/tools/node/module.fifty.ts
@@ -387,111 +387,6 @@ namespace slime.jrunscript.node {
 	}
 }
 
-namespace slime.jsh.shell.tools {
-	export interface Managed {
-		installation: slime.jrunscript.node.world.Installation
-
-		installed: slime.jrunscript.node.object.Installation
-		require: slime.$api.fp.world.Action<void,slime.jrunscript.node.object.install.Events & {
-			removed: slime.jrunscript.node.object.Installation
-			found: slime.jrunscript.node.object.Installation
-		}>
-	}
-
-	export namespace node {
-		export interface Exports extends slime.jrunscript.node.Exports, slime.jsh.shell.tools.Managed {
-		}
-	}
-
-	export interface Exports {
-		node: node.Exports
-	}
-
-	(
-		function(
-			fifty: slime.fifty.test.Kit
-		) {
-			const { verify } = fifty;
-			const { $api, jsh } = fifty.global;
-
-			$api.fp.impure.now.process(
-				$api.fp.world.output(jsh.shell.tools.node.require)
-			)
-
-			const api = jsh.shell.tools.node.installed;
-
-			fifty.tests.jsapi = fifty.test.Parent();
-
-			fifty.tests.jsapi.a = function() {
-				var result = api.run({
-					arguments: [fifty.jsh.file.object.getRelativePath("test/hello.js")],
-					stdio: {
-						output: String
-					}
-				});
-				verify(result).stdio.output.is("Hello, World (Node.js)\n");
-			}
-
-			fifty.tests.jsapi.b = function() {
-				//	TODO	should not be messing with global installation in tests
-				if (api.modules["minimal-package"]) {
-					api.run({
-						command: "npm",
-						arguments: ["uninstall", "-g", "minimal-package"]
-					});
-					api.modules["refresh"]();
-				}
-				verify(api).modules.installed.evaluate.property("minimal-package").is(void(0));
-				var result = api.run({
-					command: "npm",
-					arguments: ["install", "-g", "minimal-package"]
-				});
-				api.modules["refresh"]();
-				verify(api).modules.installed["minimal-package"].is.type("object");
-
-				api.run({
-					command: "npm",
-					arguments: ["uninstall", "-g", "minimal-package"]
-				});
-				api.modules["refresh"]();
-				verify(api).modules.installed.evaluate.property("minimal-package").is(void(0));
-			}
-
-			fifty.tests.jsapi.c = function() {
-				if (api.modules["minimal-package"]) {
-					api.modules.uninstall({
-						name: "minimal-package"
-					});
-				}
-				verify(api).modules.installed.evaluate.property("minimal-package").is(void(0));
-				api.modules.install({
-					name: "minimal-package"
-				});
-				verify(api).modules.installed["minimal-package"].is.type("object");
-
-				api.modules.uninstall({
-					name: "minimal-package"
-				});
-				verify(api).modules.installed.evaluate.property("minimal-package").is(void(0));
-			}
-
-			fifty.tests.manual = {};
-			fifty.tests.manual.jsh = function() {
-				jsh.shell.console("hello");
-				var installation = jsh.shell.tools.node.installation;
-				var modules = $api.fp.world.now.question(
-					jsh.shell.tools.node.world.Installation.modules.list(),
-					installation
-				);
-				modules.forEach(function(module) {
-					jsh.shell.console(module.name + " " + module.version);
-				});
-			}
-		}
-	//@ts-ignore
-	)(fifty);
-}
-
 namespace slime.jrunscript.node.internal {
 	//	TODO	this probably has a richer structure when --depth is not 0
 	export interface NpmLsOutput {
@@ -514,7 +409,6 @@ namespace slime.jrunscript.node.internal {
 				jsh.shell.console("version: " + api.version);
 				fifty.run(fifty.tests.sandbox);
 				fifty.run(fifty.tests.object.installation);
-				fifty.run(fifty.tests.jsapi);
 			}
 		}
 	//@ts-ignore

--- a/tools/fifty/test.jsh.js
+++ b/tools/fifty/test.jsh.js
@@ -31,7 +31,16 @@
 		//	slightly differently; a `jsh` script requiring TypeScript is very foreseeable, though). Could generalize to require a
 		//	specific TypeScript version, etc.
 		jsh.shell.jsh.require({
-			satisfied: isTypescriptInstalled,
+			satisfied: $api.fp.impure.Input.map(
+				$api.fp.impure.Input.value(void(0)),
+				$api.fp.impure.tap(function() {
+					jsh.shell.console("[fifty tsc check] Checking for TypeScript ...")
+				}),
+				isTypescriptInstalled,
+				$api.fp.impure.tap(function(installed) {
+					jsh.shell.console("[fifty tsc check] TypeScript installed? " + installed);
+				})
+			),
 			install: function() { jsh.wf.typescript.require(); }
 		});
 

--- a/tools/wf/plugin.jsh.js
+++ b/tools/wf/plugin.jsh.js
@@ -1055,19 +1055,26 @@
 					}
 				});
 
-				var jsh_wf_prohibitModifiedSubmodules = $api.events.Function(function(p,events) {
-					p.repository.submodule().forEach(function(sub) {
-						var submodule = jsh.tools.git.Repository({ directory: p.repository.directory.getSubdirectory(sub.path) });
-						var status = submodule.status();
-						if (status.paths) {
-							throw new jsh.wf.error.Failure(
-								"Submodule " + sub.path + " " + submodule + " "
-								+ "is modified in " + p.repository
-								+ " paths=" + JSON.stringify(status.paths)
-							);
-						}
-					});
-				});
+				var jsh_wf_prohibitModifiedSubmodules = $api.events.Function(
+					/**
+					 *
+					 * @param { { repository: slime.jrunscript.tools.git.repository.Local } } p
+					 * @param {*} events
+					 */
+					function(p,events) {
+						p.repository.submodule().forEach(function(sub) {
+							var submodule = jsh.tools.git.Repository({ directory: p.repository.directory.getSubdirectory(sub.path) });
+							var status = submodule.status();
+							if (status.paths) {
+								throw new jsh.wf.error.Failure(
+									"Submodule " + sub.path + " " + submodule + " "
+									+ "is modified in " + p.repository
+									+ " paths=" + JSON.stringify(status.paths)
+								);
+							}
+						});
+					}
+				);
 
 				/** @type { slime.jsh.wf.Exports["Project"] } */
 				var Project = {


### PR DESCRIPTION
* Add thread to monitor tsc existence
* Improve error message when tsc disappears from shell
* Add diagnostic to Fifty jsh test tsc require()
* Add diagnostics to prohibitModifiedSubmodules test

Also:
* Rearrange VSCode tasks.json
* Move Node jsh plugin definition to jsh/tools/install from rhino/tools/node and rename namespace to jsh.shell.tools.node from jsh.shell.tools