### PR TITLE
Update curl remote shell example to use main

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following script runs the `master` version of the shell remotely and runs th
 ### Using `curl` (installed on macOS)
 
 ```bash
-curl -v -L https://raw.githubusercontent.com/davidpcaldwell/slime/master/jsh.bash | bash -s https://raw.githubusercontent.com/davidpcaldwell/slime/master/jsh/test/jsh-data.jsh.js
+curl -v -L https://raw.githubusercontent.com/davidpcaldwell/slime/main/jsh.bash | bash -s https://raw.githubusercontent.com/davidpcaldwell/slime/main/jsh/test/jsh-data.jsh.js
 ```
 
 ### Using `wget` (installed on many Linux distributions lacking `curl`)


### PR DESCRIPTION
Was using master; still using master on wget.

Anomalies remain, will open another ticket:
* Script claims to be searching for source files under master URLs
* Script prints "branch = master," appearing to use code that is disabled on main