### PR TITLE
Require TypeScript for Fifty browser tests

### DIFF
--- a/jsh.fifty.ts
+++ b/jsh.fifty.ts
@@ -41,7 +41,9 @@ namespace slime.jsh {
 		}
 
 		tools: Tools & {
-			//	deprecated
+			/**
+			 * @deprecated See {@link slime.jsh.shell.tools.Exports | slime.jsh.shell.tools.Exports.rhino }
+			 */
 			rhino: {}
 			tomcat: {}
 			ncdbg: {}

--- a/jsh/tools/install/tomcat.js
+++ b/jsh/tools/install/tomcat.js
@@ -209,6 +209,7 @@
 					var majorVersion = Number(version.split(".")[0]);
 					var mirror = (p.version) ? "https://archive.apache.org/dist/" : void(0);
 					//	TODO	this does not seem to fail on 404
+					//	TODO	logging console messages for findApache is not ideal, should fire event instead
 					var local = $api.fp.world.now.question(
 						findApache,
 						{

--- a/tools/fifty/test-browser.jsh.js
+++ b/tools/fifty/test-browser.jsh.js
@@ -13,6 +13,8 @@
 	 * @param { slime.jsh.Global } jsh
 	 */
 	function(Packages,$api,jsh) {
+		jsh.wf.typescript.require();
+
 		jsh.shell.tools.tomcat.old.require();
 
 		/**

--- a/tools/fifty/test.jsh.js
+++ b/tools/fifty/test.jsh.js
@@ -35,6 +35,7 @@
 		//	the Fifty tests. May want to provide this as an API somewhere (currently there is one in jsh.wf, but it functions
 		//	slightly differently; a `jsh` script requiring TypeScript is very foreseeable, though). Could generalize to require a
 		//	specific TypeScript version, etc.
+		//	TODO	test-browser.jsh.js uses a much simpler method; is the above comment out of date? Is the other script wrong?
 		jsh.shell.jsh.require({
 			satisfied: $api.fp.impure.Input.map(
 				$api.fp.impure.Input.value(void(0)),


### PR DESCRIPTION
Also:
* Deprecate jsh.tools.rhino
* Various inline comments