### PR TITLE
script context should not always be optional

### DIFF
--- a/jrunscript/security/module.fifty.ts
+++ b/jrunscript/security/module.fifty.ts
@@ -5,8 +5,7 @@
 //	END LICENSE
 
 namespace slime.jrunscript.security {
-	export interface Context {
-	}
+	export type Context = void
 
 	export interface Certificate {
 		alias: string

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -71,7 +71,7 @@ namespace slime.time {
 	export namespace test {
 		export const { subject, load } = (function(fifty: slime.fifty.test.Kit) {
 			var script: Script = fifty.$loader.script("module.js");
-			var jcontext: slime.loader.Script<context.Java,Context> = fifty.$loader.script("context.java.js");
+			var jcontext: slime.loader.Script<context.Java|void,Context> = fifty.$loader.script("context.java.js");
 			return {
 				subject: (fifty.global.jsh) ? script(jcontext()) : script(),
 				load: function(context: Context) {
@@ -230,5 +230,5 @@ namespace slime.time {
 	//@ts-ignore
 	)(fifty);
 
-	export type Script = slime.loader.Script<Context,Exports>
+	export type Script = slime.loader.Script<Context|void,Exports>
 }

--- a/js/time/old.fifty.ts
+++ b/js/time/old.fifty.ts
@@ -17,7 +17,7 @@ namespace slime.time {
 		export namespace test {
 			export const { subject, old, load } = (function(fifty: slime.fifty.test.Kit) {
 				var script: Script = fifty.$loader.script("module.js");
-				var jcontext: slime.loader.Script<context.Java,Context> = fifty.$loader.script("context.java.js");
+				var jcontext: slime.loader.Script<context.Java | void,Context> = fifty.$loader.script("context.java.js");
 				return {
 					subject: (fifty.global.jsh) ? script(jcontext()) : script(),
 					old: script({

--- a/loader/Loader.fifty.ts
+++ b/loader/Loader.fifty.ts
@@ -178,8 +178,8 @@ namespace slime {
 
 	export namespace loader {
 		export interface Script<C,E> {
-			(c?: C): E
-			thread: (c?: C) => PromiseLike<E>
+			(c: C): E
+			thread: (c: C) => PromiseLike<E>
 		}
 
 		export type Export<T> = (value: T) => void

--- a/loader/browser/test/events.fifty.ts
+++ b/loader/browser/test/events.fifty.ts
@@ -5,8 +5,7 @@
 //	END LICENSE
 
 namespace slime.runtime.browser.test.events {
-	export interface Context {
-	}
+	export type Context = void
 
 	export namespace test {
 		export const subject = (function(fifty: slime.fifty.test.Kit) {

--- a/rhino/file/mock.fifty.ts
+++ b/rhino/file/mock.fifty.ts
@@ -18,7 +18,11 @@ namespace slime.jrunscript.file.internal.mock {
 			fifty: slime.fifty.test.Kit
 		) {
 			var script: Script = fifty.$loader.script("mock.js");
-			var module = script();
+			var module = script({
+				library: {
+					io: fifty.global.jsh.io
+				}
+			});
 
 			fifty.tests.suite = function() {
 				fifty.load("world.fifty.ts", "spi.filesystem.relative", module.filesystem());

--- a/rhino/jrunscript/embed.fifty.ts
+++ b/rhino/jrunscript/embed.fifty.ts
@@ -21,7 +21,10 @@ namespace slime.jrunscript.bootstrap {
 
 			fifty.tests.suite = function() {
 				var code: Script = fifty.$loader.script("embed.js");
-				var bootstrap = code();
+				var bootstrap = code({
+					debug: void(0),
+					script: void(0)
+				});
 				jsh.shell.console(Object.keys(bootstrap).toString());
 				var rhino = bootstrap.rhino.running();
 				jsh.shell.console("Rhino context: " + String(rhino));

--- a/rhino/shell/fixtures.ts
+++ b/rhino/shell/fixtures.ts
@@ -5,8 +5,7 @@
 //	END LICENSE
 
 namespace slime.jrunscript.shell.test {
-	export interface Context {
-	}
+	export type Context = void
 
 	export namespace run {
 		export type Delegate = (invocation: slime.jrunscript.shell.run.old.Invocation) => slime.jrunscript.shell.run.Mock

--- a/rhino/tools/docker/kubectl.fifty.ts
+++ b/rhino/tools/docker/kubectl.fifty.ts
@@ -130,8 +130,7 @@ namespace slime.jrunscript.tools.kubernetes.cli {
 }
 
 namespace slime.jrunscript.tools.docker.internal.kubectl {
-	export interface Context {
-	}
+	export type Context = void
 
 	export type Script = slime.loader.Script<Context,slime.jrunscript.tools.kubernetes.cli.Exports>
 }

--- a/rhino/tools/git/commands.fifty.ts
+++ b/rhino/tools/git/commands.fifty.ts
@@ -210,8 +210,7 @@ namespace slime.jrunscript.tools.git {
 }
 
 namespace slime.jrunscript.tools.git.internal.commands {
-	export interface Context {
-	}
+	export type Context = void
 
 	export interface Exports extends slime.jrunscript.tools.git.Commands {
 	}

--- a/rhino/tools/git/fixtures.ts
+++ b/rhino/tools/git/fixtures.ts
@@ -5,8 +5,7 @@
 //	END LICENSE
 
 namespace slime.jrunscript.tools.git.test.fixtures {
-	export interface Context {
-	}
+	export type Context = void
 
 	/**
 	 * A local git repository, with a `location` indicating the repository's world-oriented location and an `api` that allows


### PR DESCRIPTION
Rather, we specify a context type or allow void; optional uses Type | void. Type checking now captures context requirements more correctly.