### PR TITLE
Add jrunscript.file fixture to create mock filesystem

### DIFF
--- a/loader/$api-fp-impure.fifty.ts
+++ b/loader/$api-fp-impure.fifty.ts
@@ -357,7 +357,7 @@ namespace slime.$api.fp.world {
 
 	export interface Exports {
 		now: {
-			question: <P,E,A>(question: world.Question<P,E,A>, argument?: P, handler?: slime.$api.event.Handlers<E>) => A
+			question: <P,E,A>(question: world.Question<P,E,A>, argument: P, handler?: slime.$api.event.Handlers<E>) => A
 			action: <P,E>(action: world.Action<P,E>, argument?: P, handler?: slime.$api.event.Handlers<E>) => void
 
 			ask: <E,A>(ask: world.Ask<E,A>, handler?: slime.$api.event.Handlers<E>) => A

--- a/loader/jrunscript/native.fifty.ts
+++ b/loader/jrunscript/native.fifty.ts
@@ -242,18 +242,6 @@ namespace slime.jrunscript {
 		}
 
 		export namespace inonit.script {
-			export namespace runtime.io {
-				export interface Streams {
-					split: any
-					readBytes: any
-					copy: {
-						(i: slime.jrunscript.native.java.io.InputStream, o: slime.jrunscript.native.java.io.OutputStream, closeInputStream?: boolean): void
-						(r: slime.jrunscript.native.java.io.Reader, w: slime.jrunscript.native.java.io.Writer): void
-					}
-					readLine: any
-				}
-			}
-
 			export namespace engine {
 				export namespace Code {
 					export interface Loader extends java.lang.Object {

--- a/rhino/file/mock.js
+++ b/rhino/file/mock.js
@@ -15,12 +15,13 @@
 	 */
 	function(Packages,$api,$context,$export) {
 		/**
+		 * @type { slime.jrunscript.file.Exports["mock"]["filesystem"] }
 		 *
 		 * @returns { slime.jrunscript.file.world.spi.Filesystem }
 		 */
 		var Mock = function(p) {
-			var SLASH = (p && p.separators && p.separators.pathname) ? p.separators.pathname : "/";
-			var COLON = (p && p.separators && p.separators.searchpath) ? p.separators.searchpath : ":";
+			var SLASH = (p && p.separator && p.separator.pathname) ? p.separator.pathname : "/";
+			var COLON = (p && p.separator && p.separator.searchpath) ? p.separator.searchpath : ":";
 
 			/** @typedef { { type: "file", data: slime.jrunscript.Array<number> } } File */
 			/** @typedef { { type: "directory" } } Directory */

--- a/rhino/file/module.fifty.ts
+++ b/rhino/file/module.fifty.ts
@@ -185,16 +185,6 @@ namespace slime.jrunscript.file {
 		}
 	}
 
-	export interface Exports {
-		mock: {
-			filesystem: (p?: {
-				separator?: {
-					pathname?: string
-				}
-			}) => slime.jrunscript.file.world.spi.Filesystem
-		}
-	}
-
 	(
 		function(
 			fifty: slime.fifty.test.Kit

--- a/rhino/file/world.js
+++ b/rhino/file/world.js
@@ -469,10 +469,11 @@
 							/**
 							 *
 							 * @param { slime.jrunscript.file.world.Location } location
+							 * @param { slime.$api.fp.Predicate<slime.jrunscript.file.world.Location> } descend
 							 * @param { slime.$api.Events<slime.jrunscript.file.world.location.directory.list.Events> } events
 							 * @returns { slime.jrunscript.file.world.Location[] }
 							 */
-							var process = function(location,events) {
+							var process = function(location,descend,events) {
 								var listed = $api.fp.world.now.ask(
 									location.filesystem.listDirectory({ pathname: location.pathname })
 								);
@@ -488,8 +489,10 @@
 										var isDirectory = $api.fp.world.now.question(location.filesystem.directoryExists, { pathname: it.pathname });
 										if (isDirectory.present) {
 											if (isDirectory.value) {
-												var contents = process(it,events);
-												rv = rv.concat(contents);
+												if (descend(it)) {
+													var contents = process(it,descend,events);
+													rv = rv.concat(contents);
+												}
 											} else {
 												//	ordinary file, nothing to do
 											}
@@ -506,7 +509,7 @@
 
 							return function(location) {
 								return function(events) {
-									var array = process(location,events);
+									var array = process(location,p.descend,events);
 									return $api.fp.Stream.from.array(array);
 								}
 							}

--- a/rhino/file/world.js
+++ b/rhino/file/world.js
@@ -509,7 +509,7 @@
 
 							return function(location) {
 								return function(events) {
-									var descend = p.descend || $api.fp.mapAllTo(false);
+									var descend = (p && p.descend) ? p.descend : $api.fp.mapAllTo(false);
 									var array = process(location,descend,events);
 									return $api.fp.Stream.from.array(array);
 								}

--- a/rhino/file/world.js
+++ b/rhino/file/world.js
@@ -509,6 +509,7 @@
 
 							return function(location) {
 								return function(events) {
+									var descend = p.descend || $api.fp.mapAllTo(false);
 									var array = process(location,p.descend,events);
 									return $api.fp.Stream.from.array(array);
 								}

--- a/rhino/file/world.js
+++ b/rhino/file/world.js
@@ -510,7 +510,7 @@
 							return function(location) {
 								return function(events) {
 									var descend = p.descend || $api.fp.mapAllTo(false);
-									var array = process(location,p.descend,events);
+									var array = process(location,descend,events);
 									return $api.fp.Stream.from.array(array);
 								}
 							}

--- a/rhino/system/java/inonit/script/runtime/io/Streams.fifty.ts
+++ b/rhino/system/java/inonit/script/runtime/io/Streams.fifty.ts
@@ -1,0 +1,28 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+namespace slime.jrunscript.native.inonit.script.runtime.io {
+	export interface Streams {
+		/**
+		 * Creates an output stream that, when written to, will write the content written to each of two output streams.
+		 *
+		 * @param one The first output stream to which to write.
+		 * @param two The second output stream to which to write.
+		 * @returns An output stream that writes to both given output streams.
+		 */
+		split: (one: java.io.OutputStream, two: java.io.OutputStream) => java.io.OutputStream
+
+		//	TODO	we don't really have a great way currently to represent bytes
+		readBytes: (input: java.io.InputStream) => slime.jrunscript.Array<number>
+
+		copy: {
+			(i: slime.jrunscript.native.java.io.InputStream, o: slime.jrunscript.native.java.io.OutputStream, closeInputStream?: boolean): void
+			(r: slime.jrunscript.native.java.io.Reader, w: slime.jrunscript.native.java.io.Writer): void
+		}
+
+		readLine: (r: java.io.Reader, terminator: string) => java.lang.String
+	}
+}

--- a/tools/code/module.fifty.ts
+++ b/tools/code/module.fifty.ts
@@ -25,6 +25,50 @@ namespace slime.tools.code {
 		})(fifty);
 	}
 
+	/**
+	 * A `Project` consists of a set of source files to be processed.
+	 */
+	export type Project = slime.jrunscript.file.world.Location[]
+
+	export interface Exports {
+		Project: {
+			from: {
+				directory: (p: {
+					root: slime.jrunscript.file.world.Location
+					descend: slime.$api.fp.Predicate<slime.jrunscript.file.world.Location>
+					isSource: (p: slime.jrunscript.file.world.Location) => slime.$api.fp.Maybe<boolean>
+				}) => Project
+			}
+		}
+	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			const { $api, jsh } = fifty.global;
+
+			fifty.tests.wip = function() {
+				var project = test.subject.Project.from.directory({
+					root: fifty.jsh.file.relative("../.."),
+					descend: function(location) {
+						if (location.pathname.indexOf(".git") != -1) {
+							debugger;
+						}
+						if (/local$/.test(location.pathname)) return false;
+						if (/\.git$/.test(location.pathname)) return false;
+						return true;
+					},
+					isSource: function(file) {
+						return $api.fp.Maybe.from.some(true);
+					}
+				});
+				jsh.shell.console(project.map($api.fp.property("pathname")).join(", "));
+			}
+		}
+	//@ts-ignore
+	)(fifty);
+
 	export interface File {
 		path: string
 		file: slime.jrunscript.file.world.Location
@@ -230,7 +274,7 @@ namespace slime.tools.code {
 
 	export namespace internal {
 		export interface functions {
-			getDirectorySourceFiles: slime.$api.fp.world.Question<
+			getDirectoryObjectSourceFiles: slime.$api.fp.world.Question<
 				{
 					base: slime.jrunscript.file.Directory
 					isText: isText
@@ -253,18 +297,16 @@ namespace slime.tools.code {
 				nowrite?: boolean
 			}) => slime.$api.fp.world.Action<slime.tools.code.File,TrailingWhitespaceEvents>
 
+			handleFilesTrailingWhitespace: (configuration?: {
+				nowrite?: boolean
+			}) => slime.$api.fp.world.Action<
+				slime.tools.code.File[],
+				TrailingWhitespaceEvents
+			>
+
 			handleFileFinalNewlines: (configuration?: {
 				nowrite?: boolean
 			}) => slime.$api.fp.world.Action<slime.tools.code.File,FinalNewlineEvents>
-
-			handleFilesTrailingWhitespace: slime.$api.fp.world.Action<
-				{
-					files: slime.tools.code.File[],
-					nowrite: boolean
-				},
-				FileEvents & TrailingWhitespaceEvents
-			>
-
 		}
 	}
 }


### PR DESCRIPTION
Also:
* Add rudimentary jsh.tools.code implementation listing project files from directory
* Fix bug with wo file listing descend argument (no automated test)
* Make mock filesystem argument more compatible with filesystem
* Move mock filesystem export to mock.fifty.ts
* In $api.fp.world.now, make Question argument required
* Move inonit.script.runtime.io.Streams definition to Java folder