### PR TITLE
#1114: Make <link> a void element

### DIFF
--- a/contributor/metrics.jsh.js
+++ b/contributor/metrics.jsh.js
@@ -11,7 +11,7 @@
 	 * @param { slime.jsh.Global } jsh
 	 */
 	function($api,jsh) {
-		jsh.shell.tools.rhino.install();
+		jsh.shell.tools.rhino.require();
 
 		var SLIME = jsh.script.file.parent.parent;
 

--- a/jrunscript/io/api.html
+++ b/jrunscript/io/api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>SLIME Java I/O</title>
-	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css" />
 	<script type="text/javascript" src="../../loader/api/api.js"></script>
 </head>
 <body>

--- a/js/object/api.html
+++ b/js/object/api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>JavaScript language constructs</title>
-	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css" />
 	<script type="text/javascript" src="../../loader/api/api.js"></script>
 </head>
 <body>

--- a/jsh/launcher/api.html
+++ b/jsh/launcher/api.html
@@ -117,10 +117,10 @@ END LICENSE
 						It checks to see whether the <code>JSH_LAUNCHER_JDK_HOME</code> environment variable
 						is defined, and if so, it uses the JDK found in that location.
 					</li>
-					</li>
 					<li>For an unbuilt shell, it checks in the <code>JSH_LOCAL_JDKS</code> location (default:
 						<code>local/jdk</code>), looking for a
 						<code>default</code> directory.
+					</li>
 					<li>
 						It then checks in the SLIME user installation directory
 						(<code>JSH_USER_JDKS</code>; by default: <code>$HOME/.slime/jdk</code>),

--- a/jsh/launcher/api.html
+++ b/jsh/launcher/api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>Running jsh</title>
-	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css" />
 	<style>
 		h2 {
 			font-style: italic;

--- a/jsh/launcher/internal.api.html
+++ b/jsh/launcher/internal.api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>jsh Launcher</title>
-	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css" />
 	<script type="text/javascript" src="../../loader/api/api.js"></script>
 	<style>
 		table#settings { border-collapse: collapse; }

--- a/jsh/loader/loader.api.html
+++ b/jsh/loader/loader.api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>jsh loader</title>
-	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css" />
 	<script type="text/javascript" src="../../loader/api/api.js"></script>
 </head>
 <body>

--- a/jsh/script/Application.api.html
+++ b/jsh/script/Application.api.html
@@ -10,7 +10,7 @@ END LICENSE
 <head>
 	<title>Application</title>
 	<!--	TODO	change these to use local copies of these files at the appropriate location	-->
-	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css" />
 	<script type="text/javascript" src="../../loader/api/api.js"></script>
 </head>
 <body>

--- a/jsh/script/plugin.jsh.api.html
+++ b/jsh/script/plugin.jsh.api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>jsh.script</title>
-	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css" />
 	<script type="text/javascript" src="../../loader/api/api.js"></script>
 	<style type="text/css">
 		#getopts { border-collapse: collapse; margin: 0em 0.5em; }

--- a/jsh/unit/api.html
+++ b/jsh/unit/api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>jsapi</title>
-	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css" />
 	<script type="text/javascript" src="../../loader/api/api.js"></script>
 </head>
 <body>

--- a/loader/api/api.html
+++ b/loader/api/api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>SLIME HTML definitions</title>
-	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css" />
 	<script type="text/javascript" src="../../loader/api/api.js"></script>
 	<style type="text/css">
 		div.template {

--- a/loader/api/test/data/1/api.html
+++ b/loader/api/test/data/1/api.html
@@ -8,7 +8,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>loader/api 1</title>
-	<link rel="stylesheet" type="text/css" href="../../../../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../../../../loader/api/api.css" />
 	<script type="text/javascript" src="../../../../../loader/api/api.js"></script>
 </head>
 <body>

--- a/loader/api/test/data/1/bar.api.html
+++ b/loader/api/test/data/1/bar.api.html
@@ -8,7 +8,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>bar</title>
-	<link rel="stylesheet" type="text/css" href="../../../../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../../../../loader/api/api.css" />
 	<script type="text/javascript" src="../../../../../loader/api/api.js"></script>
 </head>
 <body>

--- a/loader/api/test/data/1/foo.api.html
+++ b/loader/api/test/data/1/foo.api.html
@@ -8,7 +8,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title></title>
-	<link rel="stylesheet" type="text/css" href="../../../../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../../../../loader/api/api.css" />
 	<script type="text/javascript" src="../../../../../loader/api/api.js"></script>
 </head>
 <body>

--- a/loader/browser/client.api.html
+++ b/loader/browser/client.api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>SLIME: browser loader</title>
-	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css" />
 	<script type="text/javascript" src="../../loader/api/api.js"></script>
 </head>
 <body>

--- a/loader/jrunscript/api.html
+++ b/loader/jrunscript/api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>SLIME Java Runtime</title>
-	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css" />
 	<script type="text/javascript" src="../../loader/api/api.js"></script>
 </head>
 <body>

--- a/loader/jrunscript/java/api.html
+++ b/loader/jrunscript/java/api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>Rhino runtime tests</title>
-	<link rel="stylesheet" type="text/css" href="../../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../../loader/api/api.css" />
 	<script type="text/javascript" src="../../../loader/api/api.js"></script>
 </head>
 <body>

--- a/loader/jrunscript/test/data/2/api.html
+++ b/loader/jrunscript/test/data/2/api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title></title>
-	<link rel="stylesheet" type="text/css" href="../../../../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../../../../loader/api/api.css" />
 	<script type="text/javascript" src="../../../../../loader/api/api.js"></script>
 </head>
 <body>

--- a/rhino/shell/api.html
+++ b/rhino/shell/api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3c.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>jrunscript-based interaction with shell</title>
-	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css" />
 	<script type="text/javascript" src="../../loader/api/api.js"></script>
 </head>
 <body>

--- a/rhino/shell/plugin.jsh.api.html
+++ b/rhino/shell/plugin.jsh.api.html
@@ -9,7 +9,7 @@ END LICENSE
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:jsapi="http://www.inonit.com/jsapi">
 <head>
 	<title>jsh.shell</title>
-	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css"></link>
+	<link rel="stylesheet" type="text/css" href="../../loader/api/api.css" />
 	<script type="text/javascript" src="../../loader/api/api.js"></script>
 	<script>
 		window.slime.definition.inherited = function() {


### PR DESCRIPTION
The parser currently only robustly supports HTML. Although it has a Settings concept, the Settings are not completely implemented, and so the parser hard-codes things that would be in the Settings to HTML.