### PR TITLE
#214: Remove runtime CoffeeScript implementation

### DIFF
--- a/loader/browser/client.js
+++ b/loader/browser/client.js
@@ -193,9 +193,6 @@
 								name: bootstrap.getRelativePath(path),
 								js: fetcher.getCode(bootstrap.getRelativePath(path))
 							}
-						},
-						getCoffeeScript: function() {
-							return (window.CoffeeScript) ? { object: window.CoffeeScript } : null;
 						}
 					},
 					Packages: window.Packages
@@ -216,7 +213,6 @@
 					}
 					if (window.CoffeeScript) {
 						rv.compiler.update(function(was) {
-							debugger;
 							return rv.$api.fp.switch([
 								was,
 								rv.$api.compiler.getTranspiler({

--- a/loader/expression.fifty.ts
+++ b/loader/expression.fifty.ts
@@ -37,23 +37,6 @@ namespace slime {
 				 */
 				getRuntimeScript(path: string): loader.Script
 
-				/**
-				 * Should provide an implementation of CoffeeScript, if one is present.
-				 *
-				 * @returns An object containing the CoffeeScript implementation, or `null` if CoffeeScript is not present.
-				 */
-				getCoffeeScript?: () => {
-					/**
-					 * The JavaScript code for the CoffeeScript object, which can be executed to produce the CoffeeScript object.
-					 */
-					code?: string
-				} | {
-					/**
-					 * The CoffeeScript object.
-					 */
-					object?: CoffeeScript
-				}
-
 				typescript?: TypeScript
 
 				flags?: {
@@ -957,9 +940,6 @@ namespace slime {
 							verify(w).evaluate.property("CoffeeScript").is.type("object");
 
 							var subject = test.fixture(function(scope) {
-								scope.$slime.getCoffeeScript = function() {
-									return { object: w["CoffeeScript"] };
-								};
 								return scope;
 							});
 

--- a/loader/expression.js
+++ b/loader/expression.js
@@ -324,49 +324,10 @@
 			});
 		};
 
-		/**
-		 *
-		 * @param { slime.runtime.$slime.Deployment } $slime
-		 * @returns { slime.runtime.loader.Compiler }
-		 */
-		var getCoffescriptTranspiler = function($slime) {
-			/** @type { (cs: ReturnType<typeof $slime.getCoffeeScript>) => cs is { code: string } } */
-			var isCode = function(cs) {
-				return cs["code"];
-			}
-
-			/** @type { (cs: ReturnType<typeof $slime.getCoffeeScript>) => cs is { object: slime.runtime.$slime.CoffeeScript } } */
-			var isObject = function(cs) {
-				return cs["object"];
-			}
-
-			/** @type { slime.runtime.$slime.CoffeeScript } */
-			var $coffee = (function() {
-				//	TODO	rename to getCoffeescript to make consistent with camel case.
-				if (!$slime.getCoffeeScript) return null;
-				var coffeeScript = $slime.getCoffeeScript();
-				if (!coffeeScript) return null;
-				if (isCode(coffeeScript)) {
-					var target = {};
-					$engine.execute({ name: "coffee-script.js", js: String(coffeeScript.code) }, {}, target);
-					return target.CoffeeScript;
-				} else if (isObject(coffeeScript)) {
-					debugger;
-					return null;
-					//return coffeeScript.object;
-				}
-			})();
-
-			return scripts.compiler.library.getTranspiler({
-				accept: scripts.compiler.library.isMimeType("application/vnd.coffeescript"),
-				compile: ($coffee) ? $coffee.compile : void(0)
-			});
-		}
 
 		scripts.compiler.update(function(javascript) {
 			var typescript = getTypescriptTranspiler($slime);
-			var coffeescript = getCoffescriptTranspiler($slime);
-			return $api.fp.switch([ typescript, coffeescript, javascript ]);
+			return $api.fp.switch([ typescript, javascript ]);
 		})
 
 		var Loader = code.Loader({

--- a/loader/jrunscript/expression.js
+++ b/loader/jrunscript/expression.js
@@ -115,11 +115,6 @@
 							js: String($loader.getLoaderCode(path))
 						};
 					},
-					getCoffeeScript: function() {
-						var _code = $loader.getCoffeeScript();
-						if (_code) return { code: String(_code) };
-						return null;
-					},
 					typescript: (function(_ts) {
 						if (_ts) {
 							return {
@@ -152,9 +147,28 @@
 					$slime: $slime,
 					Packages: Packages
 				};
-				return $javahost.eval("slime://loader/expression.js",String($loader.getLoaderCode("expression.js")),{
+
+				/** @type { slime.runtime.Exports } */
+				var rv = $javahost.eval("slime://loader/expression.js",String($loader.getLoaderCode("expression.js")),{
 					scope: scope
 				},null);
+
+				var _coffeescript = $loader.getCoffeeScript();
+				if (_coffeescript) {
+					var target = {};
+					$engine.execute({ name: "coffee-script.js", js: String(_coffeescript) }, {}, target);
+					rv.compiler.update(function(was) {
+						return rv.$api.fp.switch([
+							was,
+							rv.$api.compiler.getTranspiler({
+								accept: rv.$api.compiler.isMimeType("application/vnd.coffeescript"),
+								compile: target.CoffeeScript.compile
+							})
+						])
+					})
+				}
+
+				return rv;
 			}
 		)();
 


### PR DESCRIPTION
Now embeddings can supply a CoffeeScript transpiler using compiler.update if they have one