### PR TITLE
Refine type definitions for jsh subshells

### DIFF
--- a/jrunscript/jsh/loader/jsh.fifty.ts
+++ b/jrunscript/jsh/loader/jsh.fifty.ts
@@ -48,9 +48,11 @@ namespace slime.jsh {
 
 		export namespace internal {
 			export interface Runtime extends slime.jrunscript.runtime.Exports {
-				//	provided by engine-specific rhino.js and nashorn.js
-				exit: any
-				jsh: any
+				//	implementations provided by engine-specific rhino.js and nashorn.js
+
+				exit: (status: number) => never
+
+				jsh: (configuration: slime.jrunscript.native.inonit.script.jsh.Shell.Environment, invocation: slime.jrunscript.native.inonit.script.jsh.Shell.Invocation) => number
 			}
 		}
 
@@ -78,6 +80,7 @@ namespace slime.jsh {
 				fifty: slime.fifty.test.Kit
 			) {
 				var verify = fifty.verify;
+				var $api = fifty.global.$api;
 				var jsh = fifty.global.jsh;
 
 				type exports = { foo: string }
@@ -119,7 +122,8 @@ namespace slime.jsh {
 							script: fifty.jsh.file.object.getRelativePath("test/jsh-loader-code/main.jsh.js").file,
 							stdio: {
 								output: String
-							}
+							},
+							evaluate: $api.fp.identity
 						});
 						return JSON.parse(result.stdio.output);
 					})();

--- a/jrunscript/jsh/loader/jsh.js
+++ b/jrunscript/jsh/loader/jsh.js
@@ -8,7 +8,7 @@
 (
 	/**
 	 *
-	 * @param { { jsh: any } } global
+	 * @param { { jsh: Partial<slime.jsh.Global> } } global
 	 * @param { slime.jrunscript.Packages } Packages
 	 * @param { any } JavaAdapter
 	 * @param { slime.jrunscript.native.inonit.script.jsh.Shell } $jsh
@@ -476,15 +476,17 @@
 		global.jsh.loader.run(
 			{
 				name: $jsh.getInvocation().getScript().getSource().getSourceName(),
-				string: (function() {
-					//	TODO	this code is repeated inside loader.js; should factor out
-					var _reader = $jsh.getInvocation().getScript().getSource().getReader();
-					var rv = String(new Packages.inonit.script.runtime.io.Streams().readString(_reader));
-					if (rv.substring(0,2) == "#!") {
-						rv = "//" + rv;
+				read: {
+					string: function() {
+						//	TODO	this code is repeated inside loader.js; should factor out
+						var _reader = $jsh.getInvocation().getScript().getSource().getReader();
+						var rv = String(new Packages.inonit.script.runtime.io.Streams().readString(_reader));
+						if (rv.substring(0,2) == "#!") {
+							rv = "//" + rv;
+						}
+						return rv;
 					}
-					return rv;
-				})()
+				}
 			},
 			Object.assign({}, this, {
 				main: internal.deprecate(function(supplied) {

--- a/rhino/shell/jsh.fifty.ts
+++ b/rhino/shell/jsh.fifty.ts
@@ -14,7 +14,7 @@ namespace slime.jsh.shell {
 			/**
 			 * Provides access to the shell's subshell implementation, allowing a new shell to be invoked within the same process.
 			 */
-			jsh: any
+			jsh: (configuration: slime.jrunscript.native.inonit.script.jsh.Shell.Environment, script: slime.jrunscript.file.File, arguments: string[]) => number
 
 			api: {
 				js: any
@@ -87,6 +87,39 @@ namespace slime.jsh.shell {
 
 	type Argument = string | slime.jrunscript.file.Pathname | slime.jrunscript.file.Node | slime.jrunscript.file.File | slime.jrunscript.file.Directory
 
+	export namespace oo {
+		export interface Result {
+			status: number
+			jsh: {
+				script: Invocation["script"]
+				arguments: Invocation["arguments"]
+			}
+			environment: Invocation["environment"]
+			directory: Invocation["directory"]
+			workingDirectory: Invocation["workingDirectory"]
+
+			//	TODO	Plenty of working code indicates this property is present, but so far, analysis of the code has not revealed
+			//			why that might be
+			stdio: Invocation["stdio"]
+		}
+
+		export interface Invocation<R = Result> {
+			shell?: slime.jrunscript.file.Directory
+			fork?: boolean
+
+			script: slime.jrunscript.file.File
+			arguments?: Argument[]
+			environment?: any
+			stdio?: any
+			directory?: any
+			workingDirectory?: any
+			properties?: { [x: string]: string }
+
+			on?: slime.jrunscript.shell.run.old.Argument["on"]
+			evaluate?: (p: Result) => R
+		}
+	}
+
 	export interface Exports extends slime.jrunscript.shell.Exports {
 		/**
 		 * The JavaScript engine executing the loader process for the shell, e.g., `rhino`, `nashorn`.
@@ -132,19 +165,8 @@ namespace slime.jsh.shell {
 		shell: any
 
 		jsh: {
-			(p: {
-				shell?: slime.jrunscript.file.Directory
-				script: slime.jrunscript.file.File
-				fork?: boolean
-				evaluate?: (p: any) => any
-				arguments?: Argument[]
-				environment?: any
-				stdio?: any
-				directory?: any
-				workingDirectory?: any
-				properties?: { [x: string]: string }
-				on?: slime.jrunscript.shell.run.old.Argument["on"]
-			}): any
+			<R>(p: oo.Invocation<R>): R
+
 			src?: slime.jrunscript.file.Directory
 			require: (p: { satisfied: () => boolean, install: () => void }, events?: $api.event.Function.Receiver ) => void
 			lib?: slime.jrunscript.file.Directory

--- a/rhino/shell/jsh.js
+++ b/rhino/shell/jsh.js
@@ -32,7 +32,7 @@
 				return {
 					command: "bash",
 					arguments: $api.Array.build(function(rv) {
-						rv.push($context.api.file.world.Location.relative("jsh.bash")($context.api.file.world.Location.from.os(p.shell.src)).pathname);
+						rv.push($context.api.file.Location.relative("jsh")($context.api.file.Location.from.os(p.shell.src)).pathname);
 						rv.push(p.script);
 						if (p.arguments) rv.push.apply(rv, p.arguments);
 					}),
@@ -409,7 +409,7 @@
 					var status = $context.jsh(
 						configuration,
 						p.script,
-						p.arguments
+						p.arguments.map(String)
 					);
 					var evaluate = (p.evaluate) ? p.evaluate : function(result) {
 						if (result.status === null) {


### PR DESCRIPTION
Support work on #922

Also:
* Remove deprecated world.Location calls
* Remove jsh loader usage of undocumented slime.jsh.loader.Code type