### PR TITLE
jrunscript.file: Remove world relative()

### DIFF
--- a/rhino/file/java.js
+++ b/rhino/file/java.js
@@ -675,7 +675,6 @@
 					}
 				},
 				pathname: pathname_create,
-				relative: pathname_relative,
 				Pathname: {
 					isDirectory: function(pathname) {
 						var peer = java.newPeer(pathname);

--- a/rhino/file/mock.fifty.ts
+++ b/rhino/file/mock.fifty.ts
@@ -32,7 +32,6 @@ namespace slime.jrunscript.file.internal.mock {
 			});
 
 			fifty.tests.suite = function() {
-				fifty.load("world.fifty.ts", "spi.filesystem.relative", module.filesystem());
 				fifty.load("world.fifty.ts", "spi.filesystem.openInputStreamNotFound", module.filesystem());
 			};
 

--- a/rhino/file/mock.js
+++ b/rhino/file/mock.js
@@ -153,9 +153,6 @@
 						return name;
 					}
 				},
-				relative: function(base, relative) {
-					return base + SLASH + relative;
-				},
 				Directory: void(0),
 				File: void(0),
 				Pathname: void(0),

--- a/rhino/file/world.fifty.ts
+++ b/rhino/file/world.fifty.ts
@@ -86,7 +86,6 @@ namespace slime.jrunscript.file {
 				fifty.tests.spi.filesystem = function(filesystem: Filesystem) {
 					//	TODO	need better way to run this style of test
 					fifty.tests.spi.filesystem.openInputStreamNotFound(filesystem);
-					fifty.tests.spi.filesystem.relative(filesystem);
 				};
 			}
 		//@ts-ignore
@@ -143,27 +142,6 @@ namespace slime.jrunscript.file {
 			}
 		//@ts-ignore
 		)(fifty);
-
-		export interface Filesystem {
-			relative: (base: string, relative: string) => string
-		}
-
-		(
-			function(
-				fifty: slime.fifty.test.Kit
-			) {
-				const { verify } = fifty;
-
-				fifty.tests.spi.filesystem.relative = function(filesystem: Filesystem) {
-					//	TODO	Not a very good test for Windows filesystem
-					var prefix = "/";
-					var base = prefix + "foo" + filesystem.separator.pathname + "bar";
-					var relative = "baz";
-					verify(filesystem).relative(base, relative).is(prefix + ["foo", "bar", "baz"].join(filesystem.separator.pathname));
-				}
-			}
-		//@ts-ignore
-		)(fifty);
 	}
 
 	(
@@ -186,9 +164,16 @@ namespace slime.jrunscript.file {
 
 				var folder = fifty.jsh.file.object.getRelativePath(".").toString();
 				var file = "module.fifty.ts";
-				var relative = world.filesystems.os.relative(folder, file);
+
+				var filesystems_os_relative = function(folder: string, file: string) {
+					return jsh.file.Location.directory.base(
+						jsh.file.Location.from.os(folder)
+					)(file).pathname;
+				}
+
+				var relative = filesystems_os_relative(folder, file);
 				jsh.shell.console(relative);
-				var relative2 = world.filesystems.os.relative(pathname, "foo");
+				var relative2 = filesystems_os_relative(pathname, "foo");
 				jsh.shell.console(relative2);
 			}
 		}

--- a/rhino/tools/gcloud/module.js
+++ b/rhino/tools/gcloud/module.js
@@ -91,7 +91,8 @@
 					at: function at(installation) {
 						if (typeof(installation) == "undefined") throw new TypeError("'installation' must not be undefined.");
 						//	TODO	could this dependency be narrowed to world filesystem rather than whole library?
-						var executable = $context.library.file.world.filesystems.os.relative(installation, "bin/gcloud");
+						var base = $context.library.file.Location.from.os(installation);
+						var executable = $context.library.file.Location.directory.base(base)("bin/gcloud").pathname;
 						//	TODO	a lot of repetition below, but a lot of test coverage would be needed to safely refactor it
 						return {
 							config: function(config) {


### PR DESCRIPTION
Relative paths are now calculated with string manipulation using filesystem separator, not by filesystem implementations