### PR TITLE
Fix regression in executing TypeScript files

### DIFF
--- a/rhino/shell/tsc.js
+++ b/rhino/shell/tsc.js
@@ -79,7 +79,9 @@
 
 			if (!rv.present) throw new Error("Error attempting to compile TypeScript.");
 
-			return rv.value;
+			var updated = rv.value.replace("export {};", "/* Removed by rhino/shell/tsc.js: export {}; */");
+
+			return updated;
 		};
 
 		$export({


### PR DESCRIPTION
Incloude the shim removing the export statement, so TypeScript files can be loaded as modules