### PR TITLE
Move unimplemented fixtures for jsh shell types

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,7 +26,7 @@
 			"label": "Java: Install JDK",
 			"detail": "Installs the default JDK into this shell",
 			"type": "shell",
-			"command": "./jsh.bash --install-jdk",
+			"command": "./jsh --install-jdk",
 			"problemMatcher": []
 		},
 		{
@@ -73,7 +73,7 @@
 		{
 			"label": "ESLint: Create categorized report",
 			"type": "shell",
-			"command": "./jsh.bash contributor/eslint-report.jsh.js",
+			"command": "./jsh contributor/eslint-report.jsh.js",
 			"problemMatcher": [],
 			"presentation": {
 				"echo": false,
@@ -101,7 +101,7 @@
 		{
 			"label": "jsh: Run Current File",
 			"type": "shell",
-			"command": "./jsh.bash ${file}",
+			"command": "./jsh ${file}",
 			"problemMatcher": [],
 			"runOptions": {
 				"reevaluateOnRerun": false
@@ -111,7 +111,7 @@
 			"label": "jsh: Debug Current File",
 			"detail": "(Local only) Run the current script under the Rhino debugger",
 			"type": "shell",
-			"command": "./jsh.bash ${file}",
+			"command": "./jsh ${file}",
 			"problemMatcher": [],
 			"options": {
 				"env": {
@@ -157,7 +157,7 @@
 		{
 			"label": "Project: Update MPL headers",
 			"type": "shell",
-			"command": "./jsh.bash contributor/code/license.jsh.js --fix",
+			"command": "./jsh contributor/code/license.jsh.js --fix",
 			"problemMatcher": []
 		},
 		{

--- a/jrunscript/io/mime.fifty.ts
+++ b/jrunscript/io/mime.fifty.ts
@@ -9,7 +9,7 @@ namespace slime.jrunscript.io.mime {
 		/** @deprecated */
 		gae?: boolean
 		nojavamail: boolean
-		$slime: Pick<jsh.plugin.$slime,"mime" | "Resource">
+		$slime: Pick<slime.jsh.plugin.$slime,"mime" | "Resource">
 		api: {
 			java: slime.jrunscript.host.Exports
 			io: {

--- a/jrunscript/jsh/fixtures.ts
+++ b/jrunscript/jsh/fixtures.ts
@@ -1,0 +1,49 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+namespace slime.jrunscript.jsh.test {
+	export interface Exports {
+	}
+
+	export type Script = slime.loader.Script<void,Exports>;
+
+	(
+		function($export: slime.loader.Export<Exports>) {
+			// const shells: {
+			// 	unbuilt: slime.$api.fp.impure.Input<string>
+			// 	built: slime.$api.fp.impure.Input<string>
+			// 	packaged: slime.$api.fp.impure.Input<string>
+			// 	remote: slime.$api.fp.impure.Input<string>
+			// } = (
+			// 	function() {
+			// 		var getTemporaryLocationProperty: (name: string) => slime.$api.fp.impure.Input<string> = function() {
+
+			// 		}
+
+			// 		var inTemporaryLocation = function(p: {
+			// 			propertyName: string
+			// 			build: (destination: string) => void
+			// 		}) {
+			// 			var location =
+			// 		}
+
+			// 		return {
+			// 			unbuilt: function() {
+			// 				return fifty.jsh.file.relative("../../../");
+			// 			},
+			// 			built: function() {
+
+			// 			}
+			// 		}
+			// 	}
+			// )();
+
+			$export({
+			});
+		}
+	//@ts-ignore
+	)($export);
+}

--- a/jrunscript/jsh/shell/jsh.fifty.ts
+++ b/jrunscript/jsh/shell/jsh.fifty.ts
@@ -103,35 +103,6 @@ namespace slime.jsh.shell {
 			const { verify } = fifty;
 			const { $api, jsh } = fifty.global;
 
-			// const shells: {
-			// 	unbuilt: slime.$api.fp.impure.Input<string>
-			// 	built: slime.$api.fp.impure.Input<string>
-			// 	packaged: slime.$api.fp.impure.Input<string>
-			// 	remote: slime.$api.fp.impure.Input<string>
-			// } = (
-			// 	function() {
-			// 		var getTemporaryLocationProperty: (name: string) => slime.$api.fp.impure.Input<string> = function() {
-
-			// 		}
-
-			// 		var inTemporaryLocation = function(p: {
-			// 			propertyName: string
-			// 			build: (destination: string) => void
-			// 		}) {
-			// 			var location =
-			// 		}
-
-			// 		return {
-			// 			unbuilt: function() {
-			// 				return fifty.jsh.file.relative("../../../");
-			// 			},
-			// 			built: function() {
-
-			// 			}
-			// 		}
-			// 	}
-			// )();
-
 			fifty.tests.exports.jsh.Installation = fifty.test.Parent();
 			fifty.tests.exports.jsh.Installation.from = fifty.test.Parent();
 			fifty.tests.exports.jsh.Installation.from.unbuilt = function() {

--- a/rhino/mail/module.fifty.ts
+++ b/rhino/mail/module.fifty.ts
@@ -10,7 +10,7 @@ namespace slime.jrunscript.mail {
 			java: slime.jrunscript.host.Exports
 			io: slime.jrunscript.io.Exports
 			mime: any
-			shell: jsh.shell.Exports
+			shell: slime.jsh.shell.Exports
 		}
 	}
 

--- a/wf.js
+++ b/wf.js
@@ -286,7 +286,7 @@
 
 			if (license.status) {
 				events.fire("console", "License headers need to be updated; run:");
-				events.fire("console", "./jsh.bash contributor/code/license.jsh.js --fix");
+				events.fire("console", "./jsh contributor/code/license.jsh.js --fix");
 				success = false;
 			} else {
 				events.fire("console", "All license headers are correct.")


### PR DESCRIPTION
Also:
* Update VSCode tasks, license error message to use ./jsh not ./jsh.bash
* Update references to jsh. namespace to be fully qualified