### PR TITLE
Rearrange type definitions for mocking jsh plugins

### DIFF
--- a/jrunscript/jsh/loader/jsh.fifty.ts
+++ b/jrunscript/jsh/loader/jsh.fifty.ts
@@ -14,7 +14,14 @@ namespace slime.jsh {
 			getPackaged(): slime.jrunscript.native.inonit.script.jsh.Shell.Packaged
 
 			plugins: {
-				mock: slime.jsh.loader.internal.plugins.Export["mock"]
+				/**
+				 * Loads a single plugin from the given loader, and applies it to the mock objects given in the argument (or real objects if
+				 * mocks are not provided), returning the modified objects for inspection by tests.
+				 *
+				 * @param p Scope objects to use when loading the plugin, and a definition of the plugin itself.
+				 * @returns objects affected by plugin loading, for evaluation
+				 */
+				mock: (p: Partial<Omit<slime.jsh.plugin.Scope,"$loader">> & { $loader: slime.old.Loader, source?: () => string }) => Pick<slime.jsh.plugin.Scope,"global"|"jsh"|"plugins">
 			}
 
 			loader: slime.jrunscript.runtime.Exports["old"]["loader"]

--- a/jrunscript/jsh/loader/plugins.fifty.ts
+++ b/jrunscript/jsh/loader/plugins.fifty.ts
@@ -185,14 +185,7 @@ namespace slime.jsh.loader.internal.plugins {
 		 */
 		load: (p: Plugins) => void
 
-		/**
-		 * Loads a single plugin from the given loader, and applies it to the mock objects given in the argument (or real objects if
-		 * mocks are not provided), returning the modified objects for inspection by tests.
-		 *
-		 * @param p Scope objects to use when loading the plugin, and a definition of the plugin itself.
-		 * @returns objects affected by plugin loading, for evaluation
-		 */
-		mock: (p: Partial<Omit<slime.jsh.plugin.Scope,"$loader">> & { $loader: slime.old.Loader, source?: () => string }) => Pick<slime.jsh.plugin.Scope,"global"|"jsh"|"plugins">
+		mock: slime.jsh.plugin.$slime["plugins"]["mock"]
 	}
 
 	(

--- a/jrunscript/jsh/script/plugin.jsh.fifty.ts
+++ b/jrunscript/jsh/script/plugin.jsh.fifty.ts
@@ -437,6 +437,7 @@ namespace slime.jsh.script {
 				var was = fifty.global.jsh.unit.$slime;
 				debugger;
 				var mocked = fifty.jsh.plugin.mock({
+					$loader: void(0),
 					jsh: fifty.global.jsh,
 					plugins: {
 						//	This is needed to load the plugin, although this is obviously a very skeletal mock of the

--- a/tools/fifty/module.fifty.ts
+++ b/tools/fifty/module.fifty.ts
@@ -189,47 +189,7 @@ namespace slime.fifty {
 					}
 				}
 			},
-			jsh?: {
-				$slime: jsh.plugin.$slime
-				file: {
-					/**
-					 * Returns a filesystem pathname corresponding to the given relative path, relative to the currently executing
-					 * file.
-					 */
-					relative: (path: string) => slime.jrunscript.file.world.Location
-
-					temporary: {
-						location: () => slime.jrunscript.file.world.object.Location
-						directory: () => slime.jrunscript.file.world.object.Location
-					}
-
-					object: {
-						getRelativePath: (p: string) => slime.jrunscript.file.Pathname
-						temporary: {
-							location: () => slime.jrunscript.file.Pathname
-							directory: () => slime.jrunscript.file.Directory
-						}
-					}
-				}
-				plugin: {
-					/**
-					 * Allows a test to load `jsh` plugins into a mock shell. Loads plugins from the same directory as the
-					 * shell, optionally specifying the global object, `jsh`, and the shared `plugins` object used by the jsh plugin
-					 * loader.
-					 */
-					mock: (p: {
-						global?: slime.jsh.plugin.Scope["global"]
-						jsh?: slime.jsh.plugin.Scope["jsh"]
-						plugins?: slime.jsh.plugin.plugins
-						$slime?: slime.jsh.plugin.$slime
-					}) => ReturnType<slime.jsh.loader.internal.plugins.Export["mock"]>
-				},
-				/**
-				 * Creates a test that will run the test suite (the `suite` part) under `jsh`, and then again under the browser,
-				 * and pass only if both parts pass.
-				 */
-				platforms: (fifty: Kit) => void
-			}
+			jsh?: kit.Jsh
 		}
 
 		(

--- a/tools/fifty/plugin.jsh.fifty.ts
+++ b/tools/fifty/plugin.jsh.fifty.ts
@@ -4,8 +4,10 @@
 //
 //	END LICENSE
 
+/**
+ * Unsupported API. `jsh` plugin used in implementing `fifty.jsh` APIs.
+ */
 namespace slime.jsh.$fifty {
-	//	TODO	should be making this available as part of Fifty object
 	export interface Exports {
 		plugin: {
 			mock: slime.jsh.loader.internal.plugins.Export["mock"]
@@ -15,6 +17,9 @@ namespace slime.jsh.$fifty {
 
 namespace slime.jsh {
 	export interface Global {
+		/**
+		 * Unsupported API. Used in implementation of supported `fifty.jsh` APIs.
+		 */
 		$fifty: slime.jsh.$fifty.Exports
 	}
 }

--- a/tools/fifty/scope-jsh.ts
+++ b/tools/fifty/scope-jsh.ts
@@ -4,14 +4,71 @@
 //
 //	END LICENSE
 
+namespace slime.fifty.test.kit {
+	export interface Jsh {
+		$slime: slime.jsh.plugin.$slime
+		file: {
+			/**
+			 * Returns a filesystem pathname corresponding to the given relative path, relative to the currently executing
+			 * file.
+			 */
+			relative: (path: string) => slime.jrunscript.file.world.Location
+
+			temporary: {
+				location: () => slime.jrunscript.file.world.object.Location
+				directory: () => slime.jrunscript.file.world.object.Location
+			}
+
+			object: {
+				getRelativePath: (p: string) => slime.jrunscript.file.Pathname
+				temporary: {
+					location: () => slime.jrunscript.file.Pathname
+					directory: () => slime.jrunscript.file.Directory
+				}
+			}
+		}
+		plugin: {
+			/**
+			 * Allows a test to load `jsh` plugins into a mock shell. Loads plugins from the same directory as the
+			 * shell, optionally specifying the global object, `jsh`, and the shared `plugins` object used by the jsh plugin
+			 * loader.
+			 */
+			mock: slime.jsh.plugin.$slime["plugins"]["mock"]
+			// mock: (p: {
+			// 	global?: slime.jsh.plugin.Scope["global"]
+			// 	jsh?: slime.jsh.plugin.Scope["jsh"]
+			// 	plugins?: slime.jsh.plugin.plugins
+			// 	$slime?: slime.jsh.plugin.$slime
+			// }) => ReturnType<slime.jsh.loader.internal.plugins.Export["mock"]>
+		}
+
+		/**
+		 * Creates a test that will run the test suite (the `suite` part) under `jsh`, and then again under the browser,
+		 * and pass only if both parts pass.
+		 */
+		platforms: (fifty: Kit) => void
+	}
+}
+
 namespace slime.fifty.test.internal.scope.jsh {
 	export interface Scope {
+		/**
+		 * A loader that will load resources from the same directory as the currently executing Fifty file.
+		 */
 		loader: slime.old.Loader
+
+		/**
+		 * The directory containing the currently executing Fifty file.
+		 */
 		directory: slime.jrunscript.file.Directory
+
+		/**
+		 * The filename of the currently executing Fifty file.
+		 */
 		filename: string
 	}
 
-	export type Export = (scope: slime.fifty.test.internal.scope.jsh.Scope) => slime.fifty.test.Kit["jsh"]
+	export type Export = (scope: slime.fifty.test.internal.scope.jsh.Scope) => slime.fifty.test.kit.Jsh
 
 	export type Script = slime.loader.Script<void,Export>
 }


### PR DESCRIPTION
Also:
* Move fifty.jsh type definitions into implementation file
* Improve fifty.jsh implementation internal documentation