### PR TITLE
Implement `fifty jsh` to run top-level scripts

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -45,7 +45,7 @@
 		},
 		{
 			"label": "Git: Create branch",
-			"detail": "Creates a new branch based on newly-fetched origin/master and checks it out.",
+			"detail": "Creates a new branch based on newly-fetched origin/main and checks it out.",
 			"type": "shell",
 			"command": "./wf git.branch ${input:branchName}",
 			"problemMatcher": []

--- a/jrunscript/jsh/manual.fifty.ts
+++ b/jrunscript/jsh/manual.fifty.ts
@@ -1,0 +1,117 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+(
+	(
+		$api: slime.$api.Global,
+		jsh: slime.jsh.Global
+	) => {
+		jsh.script.cli.main(
+			jsh.script.cli.program({
+				commands: {
+					run: {
+						built: function(p) {
+							var TMPDIR = $api.fp.world.now.question(
+								jsh.file.Location.from.temporary(jsh.file.world.filesystems.os),
+								{
+									directory: true
+								}
+							);
+
+							var isUnbuilt = function(p: slime.jsh.shell.Installation): p is slime.jsh.shell.UnbuiltInstallation {
+								return p["src"];
+							};
+
+							var getBuildScript = jsh.file.Location.directory.relativePath("jrunscript/jsh/etc/build.jsh.js");
+
+							var current = jsh.shell.jsh.Installation.from.current();
+							if (isUnbuilt(current)) {
+								var rhino: slime.$api.fp.Maybe<slime.jrunscript.file.Location> = $api.fp.now.invoke(
+									current,
+									$api.fp.property("src"),
+									jsh.file.Location.from.os,
+									jsh.file.Location.directory.relativePath("local/jsh/lib/js.jar"),
+									function(location) {
+										var exists = $api.fp.world.mapping(jsh.file.Location.file.exists())(location);
+										return (exists) ? $api.fp.Maybe.from.some(location) : $api.fp.Maybe.from.nothing();
+									}
+								);
+
+								var asJshIntention: slime.$api.fp.Identity<slime.jsh.shell.Intention> = $api.fp.identity;
+
+								$api.fp.now.invoke(
+									asJshIntention({
+										shell: {
+											src: current.src
+										},
+										script: getBuildScript(jsh.file.Location.from.os(current.src)).pathname,
+										arguments: $api.Array.build(function(rv) {
+											rv.push(TMPDIR.pathname);
+											rv.push("-notest");
+											rv.push("-nodoc");
+											if (rhino.present) rv.push("-rhino", rhino.value.pathname);
+										}),
+										stdio: {
+											output: "line",
+											error: "line"
+										}
+									}),
+									jsh.shell.jsh.Intention.toShellIntention,
+									$api.fp.world.output(
+										jsh.shell.subprocess.action,
+										{
+											stdout: function(e) {
+												jsh.shell.console("jsh build STDOUT: " + e.detail.line);
+											},
+											stderr: function(e) {
+												jsh.shell.console("jsh build STDERR: " + e.detail.line);
+											}
+										}
+									)
+								);
+
+								jsh.shell.console("Build to " + TMPDIR.pathname);
+								jsh.shell.console("arguments = [" + p.arguments.join(" ") + "]");
+
+								var exit = $api.fp.now.invoke(
+									asJshIntention({
+										shell: {
+											home: TMPDIR.pathname
+										},
+										script: p.arguments[0],
+										arguments: p.arguments.slice(1),
+										stdio: {
+											output: "line",
+											error: "line"
+										}
+									}),
+									jsh.shell.jsh.Intention.toShellIntention,
+									$api.fp.world.mapping(
+										jsh.shell.subprocess.question,
+										{
+											stdout: function(e) {
+												jsh.shell.console("BUILT SHELL OUTPUT: " + e.detail.line);
+											},
+											stderr: function(e) {
+												jsh.shell.console("BUILT SHELL CONSOLE: " + e.detail.line);
+											}
+										}
+									)
+								);
+
+								jsh.shell.exit(exit.status);
+							} else {
+								jsh.shell.console("Only unbuilt shells can be built.");
+								jsh.shell.exit(1);
+							}
+						}
+					}
+				}
+			})
+		)
+	}
+//@ts-ignore
+)($api,jsh);

--- a/jrunscript/jsh/script/plugin.jsh.fifty.ts
+++ b/jrunscript/jsh/script/plugin.jsh.fifty.ts
@@ -386,6 +386,12 @@ namespace slime.jsh.script {
 			}
 
 			parser: {
+				/**
+				 * Resolves a command-line argument of type `Pathname`.
+				 *
+				 * @param argument A string, presumably provided by a command-line invoker
+				 * @returns A full `Pathname` representing the provided string, resolving relative paths as needed.
+				 */
 				pathname: (argument: string) => slime.jrunscript.file.Pathname
 			}
 

--- a/jrunscript/jsh/shell/jsh.fifty.ts
+++ b/jrunscript/jsh/shell/jsh.fifty.ts
@@ -85,9 +85,7 @@ namespace slime.jsh.shell {
 
 	export type Intention = (
 		{
-			shell: {
-				src: string
-			},
+			shell: Installation,
 			script: string
 		}
 		& Pick<slime.jrunscript.shell.run.Intention,"arguments" | "environment" | "stdio" | "directory">

--- a/jrunscript/jsh/tools/shell.jsh.js
+++ b/jrunscript/jsh/tools/shell.jsh.js
@@ -27,25 +27,40 @@
 
 							var current = jsh.shell.jsh.Installation.from.current();
 							if (isUnbuilt(current)) {
-							/** @type { slime.jsh.shell.Intention } */
-								var intention = {
-									shell: {
-										src: current.src
-									},
-									script: getBuildScript(jsh.file.Location.from.os(current.src)).pathname,
-									arguments: $api.Array.build(function(rv) {
-										rv.push(p.options.destination.toString());
-										rv.push("-notest");
-										rv.push("-nodoc");
-										if (p.options.rhino) rv.push("-rhino", p.options.rhino.toString());
+								/** @type { slime.$api.fp.Identity<slime.jsh.shell.Intention> } */
+								var asJshIntention = $api.fp.identity;
 
+								$api.fp.now.invoke(
+									asJshIntention({
+										shell: {
+											src: current.src
+										},
+										script: getBuildScript(jsh.file.Location.from.os(current.src)).pathname,
+										arguments: $api.Array.build(function(rv) {
+											rv.push(p.options.destination.toString());
+											rv.push("-notest");
+											rv.push("-nodoc");
+											if (p.options.rhino) rv.push("-rhino", p.options.rhino.toString());
+
+										}),
+										stdio: {
+											output: "line",
+											error: "line"
+										}
 									}),
-									stdio: {
-										output: "string",
-										error: "line"
-									}
-								};
-
+									jsh.shell.jsh.Intention.toShellIntention,
+									$api.fp.world.output(
+										jsh.shell.subprocess.action,
+										{
+											stdout: function(e) {
+												jsh.shell.console("jsh build STDOUT: " + e.detail.line);
+											},
+											stderr: function(e) {
+												jsh.shell.console("jsh build STDERR: " + e.detail.line);
+											}
+										}
+									)
+								)
 							} else {
 								jsh.shell.console("Only unbuilt shells can be built.");
 								jsh.shell.exit(1);

--- a/tools/fifty.jsh.js
+++ b/tools/fifty.jsh.js
@@ -90,6 +90,37 @@
 							jsh.shell.exit(p.status);
 						}
 					)
+				},
+				jsh: function(p) {
+					/** @type { (p: slime.jsh.shell.Installation) => p is slime.jsh.shell.UnbuiltInstallation } */
+					var isUnbuilt = function(p) {
+						return p["src"];
+					};
+
+					var current = jsh.shell.jsh.Installation.from.current();
+
+					/** @type { slime.$api.fp.Identity<slime.jsh.shell.Intention> } */
+					var asJshIntention = $api.fp.identity;
+
+					//	TODO	may not need to limit shells at all here
+					if (isUnbuilt(current)) {
+						$api.fp.now.invoke(
+							asJshIntention({
+								shell: {
+									src: current.src
+								},
+								script: p.arguments[0],
+								arguments: p.arguments.slice(1)
+							}),
+							jsh.shell.jsh.Intention.toShellIntention,
+							$api.fp.world.output(
+								jsh.shell.subprocess.action
+							)
+						)
+					} else {
+						jsh.shell.console("Only unbuilt shells can be built.");
+						jsh.shell.exit(1);
+					}
 				}
 			}
 		});

--- a/wf.fifty.ts
+++ b/wf.fifty.ts
@@ -57,7 +57,7 @@ namespace slime.project.wf {
 	export interface Interface extends slime.jsh.wf.standard.Interface {
 		git: slime.jsh.wf.standard.Interface["git"] & {
 			/**
-			 * Creates a branch based on the current `master` from `origin` and checks it out. The first argument is used as
+			 * Creates a branch based on the current `main` from `origin` and checks it out. The first argument is used as
 			 * the branch name.
 			 */
 			branch: slime.jsh.script.cli.Command<Options>


### PR DESCRIPTION
Also:
* Implement new `shell.jsh.js build` wrapper for build script
* Implement toShellIntention for jsh Intentions using built shells
* Allow non-unbuilt shells in jsh Intentions
* Implement a Fifty jsh script to run a script in a built shell
* Document jsh.script.cli.parser.pathname
* Update obsolete documentation references to `master` branch