### PR TITLE
#1243: Implement jsh.shell.jsh.Installation.from.current for packaged…

### DIFF
--- a/jrunscript/jsh/fixtures.ts
+++ b/jrunscript/jsh/fixtures.ts
@@ -45,11 +45,10 @@ namespace slime.jrunscript.jsh.test {
 							}
 						);
 
-						var isUnbuilt = function(p: slime.jsh.shell.Installation): p is slime.jsh.shell.UnbuiltInstallation {
-							return p["src"];
-						};
+						var isUnbuilt = jsh.shell.jsh.Installation.is.unbuilt;
 
-						var getBuildScript = jsh.file.Location.directory.relativePath("jrunscript/jsh/etc/build.jsh.js");
+						//	TODO	can we use jrunscript/jsh/tools/shell.jsh.js
+						var getShellToolScript = jsh.file.Location.directory.relativePath("jrunscript/jsh/tools/shell.jsh.js");
 
 						var current = jsh.shell.jsh.Installation.from.current();
 						if (isUnbuilt(current)) {
@@ -69,12 +68,11 @@ namespace slime.jrunscript.jsh.test {
 							$api.fp.now.invoke(
 								asJshIntention({
 									shell: current,
-									script: getBuildScript(jsh.file.Location.from.os(current.src)).pathname,
+									script: getShellToolScript(jsh.file.Location.from.os(current.src)).pathname,
 									arguments: $api.Array.build(function(rv) {
-										rv.push(TMPDIR.pathname);
-										rv.push("-notest");
-										rv.push("-nodoc");
-										if (rhino.present) rv.push("-rhino", rhino.value.pathname);
+										rv.push("build");
+										rv.push("--destination", TMPDIR.pathname);
+										if (rhino.present) rv.push("--rhino", rhino.value.pathname);
 									}),
 									stdio: {
 										output: "line",
@@ -95,7 +93,6 @@ namespace slime.jrunscript.jsh.test {
 								)
 							);
 
-							jsh.shell.console("TMPDIR = " + TMPDIR.pathname);
 							var canonical = String(jsh.file.Pathname(TMPDIR.pathname).java.adapt().getCanonicalPath());
 							return {
 								home: canonical

--- a/jrunscript/jsh/manual.fifty.ts
+++ b/jrunscript/jsh/manual.fifty.ts
@@ -9,22 +9,19 @@
 		$api: slime.$api.Global,
 		jsh: slime.jsh.Global
 	) => {
+		var asJshIntention: slime.$api.fp.Identity<slime.jsh.shell.Intention> = $api.fp.identity;
+
+		var fixtures = (function() {
+			var script: slime.jrunscript.jsh.test.Script = jsh.script.loader.script("fixtures.ts");
+			return script();
+		})();
+
 		jsh.script.cli.main(
 			jsh.script.cli.program({
 				commands: {
 					run: {
 						built: function(p) {
-							var fixtures = (function() {
-								var script: slime.jrunscript.jsh.test.Script = jsh.script.loader.script("fixtures.ts");
-								return script();
-							})();
-
 							var shell = fixtures.shells.built();
-
-							jsh.shell.console("Build to " + shell.home);
-							jsh.shell.console("arguments = [" + p.arguments.join(" ") + "]");
-
-							var asJshIntention: slime.$api.fp.Identity<slime.jsh.shell.Intention> = $api.fp.identity;
 
 							var exit = $api.fp.now.invoke(
 								asJshIntention({
@@ -51,6 +48,83 @@
 							);
 
 							jsh.shell.exit(exit.status);
+						},
+						packaged: function(p) {
+							var to = $api.fp.world.now.question(
+								jsh.file.Location.from.temporary(jsh.file.world.filesystems.os),
+								{
+									directory: false,
+									suffix: ".jar"
+								}
+							);
+
+							var at = $api.fp.now.invoke(
+								fixtures.shells.unbuilt(),
+								$api.fp.property("src"),
+								jsh.file.Location.from.os,
+								jsh.file.Location.directory.base,
+								function(base) {
+									return function(path: string) {
+										return base(path).pathname;
+									}
+								}
+							);
+
+							var build = $api.fp.now.invoke(
+								asJshIntention({
+									shell: fixtures.shells.unbuilt(),
+									script: at("jrunscript/jsh/tools/shell.jsh.js"),
+									arguments: $api.Array.build(function(rv) {
+										rv.push("package");
+										rv.push("--script", at("jrunscript/jsh/test/jsh-data.jsh.js")),
+										rv.push("--to", to.pathname);
+									}),
+									stdio: {
+										output: "line",
+										error: "line"
+									}
+								}),
+								jsh.shell.jsh.Intention.toShellIntention,
+								$api.fp.world.mapping(
+									jsh.shell.subprocess.question,
+									{
+										stdout: function(e) {
+											jsh.shell.console("package.jsh.js OUTPUT: " + e.detail.line);
+										},
+										stderr: function(e) {
+											jsh.shell.console("package.jsh.js CONSOLE: " + e.detail.line);
+										}
+									}
+								)
+							);
+
+							if (build.status != 0) throw new Error("package.jsh.js exit status: " + build.status);
+
+							var exit = $api.fp.now.invoke(
+								//	TODO	what about VM invocation stuff
+								//	TODO	test arguments, properties, environment perhaps
+								asJshIntention({
+									package: to.pathname,
+									stdio: {
+										output: "line",
+										error: "line"
+									}
+								}),
+								jsh.shell.jsh.Intention.toShellIntention,
+								$api.fp.world.mapping(
+									jsh.shell.subprocess.question,
+									{
+										stdout: jsh.shell.Invocation.handler.stdio.line(function(e) {
+											jsh.shell.console(to.pathname + " OUTPUT: " + e.detail.line);
+										}),
+										stderr: jsh.shell.Invocation.handler.stdio.line(function(e) {
+											jsh.shell.console(to.pathname + " CONSOLE: " + e.detail.line);
+										})
+									}
+								)
+							);
+
+							return exit.status;
 						}
 					}
 				}

--- a/jrunscript/jsh/shell/jsh.fifty.ts
+++ b/jrunscript/jsh/shell/jsh.fifty.ts
@@ -16,6 +16,8 @@ namespace slime.jsh.shell {
 			 */
 			jsh: (configuration: slime.jrunscript.native.inonit.script.jsh.Shell.Environment, script: slime.jrunscript.file.File, arguments: string[]) => number
 
+			packaged: slime.$api.fp.impure.Input<slime.$api.fp.Maybe<string>>
+
 			api: {
 				js: any
 				java: slime.jrunscript.host.Exports
@@ -81,13 +83,19 @@ namespace slime.jsh.shell {
 		url: string
 	}
 
+	export type ExternalInstallation = UnbuiltInstallation | BuiltInstallation | UrlInstallation
+
 	export type Installation = UnbuiltInstallation | BuiltInstallation | PackagedInstallation | UrlInstallation
 
+	export type ExternalInstallationInvocation = {
+		shell: ExternalInstallation,
+		script: string
+	}
+
+	export type Invocation = ExternalInstallationInvocation | PackagedInstallation
+
 	export type Intention = (
-		{
-			shell: Installation,
-			script: string
-		}
+		Invocation
 		& Pick<slime.jrunscript.shell.run.Intention,"arguments" | "environment" | "stdio" | "directory">
 	)
 
@@ -100,6 +108,10 @@ namespace slime.jsh.shell {
 				 * Returns the `jsh` installation that is running the current shell. Only implemented for unbuilt shells currently.
 				 */
 				current: slime.$api.fp.impure.Input<Installation>
+			}
+
+			is: {
+				unbuilt: (p: Installation) => p is UnbuiltInstallation
 			}
 		}
 

--- a/jrunscript/jsh/shell/plugin.jsh.js
+++ b/jrunscript/jsh/shell/plugin.jsh.js
@@ -49,6 +49,13 @@
 						);
 						return $slime.jsh(configuration,_invocation)
 					},
+					packaged: function() {
+						if ($slime.getPackaged()) {
+							return $api.fp.Maybe.from.some(String($slime.getPackaged().getFile().getCanonicalPath()));
+						} else {
+							return $api.fp.Maybe.from.nothing();
+						}
+					},
 					module: plugins.shell
 				};
 

--- a/jrunscript/jsh/test/plugin.jsh.js
+++ b/jrunscript/jsh/test/plugin.jsh.js
@@ -140,7 +140,7 @@ plugin({
 				})(p);
 				args.push(SLIME.getRelativePath("rhino/jrunscript/api.js"));
 				args.push("jsh");
-				args.push(SLIME.getRelativePath("jsh/etc/build.jsh.js"));
+				args.push(SLIME.getRelativePath("jrunscript/jsh/etc/build.jsh.js"));
 				args.push(JSH_HOME);
 				args.push("-notest");
 				args.push("-nodoc");


### PR DESCRIPTION
… applications

Also:
* Fix regression in requireBuiltShell() introduced by folder reorganization
* Revamp type definitions for slime.jsh.shell.Intention to reflect packaged shells
* Switch built shell fixture to use shell.jsh.js rather than jsh/etc/build.jsh.js
* Implement manual test for packaged shells