### PR TITLE
Handle parent not existing when writing files

### DIFF
--- a/rhino/file/fixtures.ts
+++ b/rhino/file/fixtures.ts
@@ -205,6 +205,12 @@ namespace slime.jrunscript.file.test {
 					var name = entry[0];
 					var value = entry[1];
 					if (isTextFile(value)) {
+						var parent = (prefix + name).split("/").slice(0,-1).join("/");
+						var parentExists = $api.fp.world.now.ask(mock.directoryExists({ pathname: parent }));
+						if (!parentExists.present) throw new Error("Unreachable");
+						if (!parentExists.value) {
+							$api.fp.world.now.ask(mock.createDirectory({ pathname: parent }));
+						}
 						var o = $api.fp.world.now.question(
 							mock.openOutputStream,
 							{ pathname: prefix + name }

--- a/rhino/file/java.js
+++ b/rhino/file/java.js
@@ -343,8 +343,19 @@
 			var maybeOutputStream = function(p) {
 				return function(events) {
 					var peer = java.newPeer(p.pathname);
-					var binary = peer.writeBinary(p.append || false);
-					return $api.fp.Maybe.from.some($context.api.io.Streams.java.adapt(binary));
+					try {
+						var binary = peer.writeBinary(p.append || false);
+						return $api.fp.Maybe.from.some($context.api.io.Streams.java.adapt(binary));
+					} catch (e) {
+						if (/java\.io\.FileNotFoundException\: (.*) \(No such file or directory\)/.test(e.message)) {
+							var parent = peer.getParent();
+							events.fire("parentNotFound", {
+								filesystem: filesystem,
+								pathname: String(parent.getScriptPath())
+							});
+						}
+						return $api.fp.Maybe.from.nothing();
+					}
 				}
 			}
 

--- a/rhino/file/mock.fifty.ts
+++ b/rhino/file/mock.fifty.ts
@@ -32,8 +32,12 @@ namespace slime.jrunscript.file.internal.mock {
 			});
 
 			fifty.tests.suite = function() {
-				fifty.load("world.fifty.ts", "spi.filesystem.openInputStreamNotFound", module.filesystem());
+				fifty.load("world.fifty.ts", "spi.filesystem", module.filesystem());
 			};
+
+			fifty.tests.wip = function() {
+				fifty.load("world.fifty.ts", "spi.filesystem.wip", module.filesystem());
+			}
 
 			fifty.tests.manual = {};
 			fifty.tests.manual.fixtures = function() {

--- a/rhino/file/module.fifty.ts
+++ b/rhino/file/module.fifty.ts
@@ -430,7 +430,6 @@ namespace slime.jrunscript.file {
 				fifty.run(fifty.tests.state.list);
 				fifty.run(fifty.tests.action.delete);
 
-				fifty.load("world.fifty.ts");
 				fifty.load("world-old.fifty.ts");
 				fifty.load("mock.fifty.ts");
 				fifty.load("wo.fifty.ts");

--- a/rhino/file/wo.fifty.ts
+++ b/rhino/file/wo.fifty.ts
@@ -308,10 +308,14 @@ namespace slime.jrunscript.file {
 				}
 
 				write: (location: Location) => {
-					string: slime.$api.fp.world.Action<{ value: string },{}>
-					stream: slime.$api.fp.world.Action<{ input: slime.jrunscript.runtime.io.InputStream },{}>
+					string: slime.$api.fp.world.Action<{ value: string }, slime.jrunscript.file.world.events.FileOpenForWrite>
+					stream: slime.$api.fp.world.Action<{ input: slime.jrunscript.runtime.io.InputStream },slime.jrunscript.file.world.events.FileOpenForWrite>
 					object: {
-						text: slime.$api.fp.world.Question<{},{},slime.$api.fp.Maybe<slime.jrunscript.runtime.io.Writer>>
+						text: slime.$api.fp.world.Question<
+							{},
+							slime.jrunscript.file.world.events.FileOpenForWrite,
+							slime.$api.fp.Maybe<slime.jrunscript.runtime.io.Writer>
+						>
 					}
 				}
 			}
@@ -715,8 +719,6 @@ namespace slime.jrunscript.file {
 						//verify(simple)[3].pathname.is("/d");
 					};
 
-					fifty.tests.wip = fifty.tests.exports.Location.directory.list;
-
 					fifty.tests.manual.issue1181 = function() {
 						var location = fifty.jsh.file.temporary.location();
 						var listing = $api.fp.world.now.question(
@@ -821,9 +823,13 @@ namespace slime.jrunscript.file {
 				const { jsh } = fifty.global;
 				const { world } = jsh.file;
 
-				fifty.tests.sandbox.filesystem.openInputStreamNotFound = function() {
-					fifty.load("world.fifty.ts", "spi.filesystem.openInputStreamNotFound", world.filesystems.os);
-				}
+				fifty.tests.sandbox.filesystem.world = function() {
+					fifty.load("world.fifty.ts", "spi.filesystem", world.filesystems.os);
+				};
+
+				fifty.tests.wip = function() {
+					fifty.load("world.fifty.ts", "spi.filesystem.wip", world.filesystems.os);
+				};
 			}
 		//@ts-ignore
 		)(fifty);

--- a/rhino/file/wo.js
+++ b/rhino/file/wo.js
@@ -39,7 +39,7 @@
 			}
 		};
 
-		/** @type { slime.jrunscript.file.location.Exports["relative"] } */
+		/** @type { slime.jrunscript.file.location.Exports["directory"]["relativePath"] } */
 		var Location_relative = function(path) {
 			return function(pathname) {
 				var absolute = pathname.pathname + pathname.filesystem.separator.pathname + path;
@@ -54,7 +54,7 @@
 		/**
 		 *
 		 * @param { slime.jrunscript.file.Location } location
-		 * @param { slime.$api.Events<{}> } events
+		 * @param { slime.$api.Events<slime.jrunscript.file.world.events.FileOpenForWrite> } events
 		 * @param { (to: slime.jrunscript.runtime.io.OutputStream) => void } write
 		 */
 		var Location_write = function(location,events,write) {
@@ -442,12 +442,7 @@
 										}
 										$api.fp.world.now.action(
 											location.filesystem.createDirectory,
-											{ pathname: location.pathname },
-											{
-												parentNotFound: function() {
-
-												}
-											}
+											{ pathname: location.pathname }
 										)
 										//	TODO	should push this event back into implementation
 										//			this way, we could inform of recursive creations as well


### PR DESCRIPTION
Also
* Add to fixtures creating parent directory when creating filesystem contents
* Remove redundant testing of filesystem world implementations