### PR TITLE
Create new event API for wo handling

### DIFF
--- a/loader/$api-fp-impure.fifty.ts
+++ b/loader/$api-fp-impure.fifty.ts
@@ -629,6 +629,9 @@ namespace slime.$api.fp.world {
 		/** @deprecated Used almost entirely for `jsh.shell.tools.node.require`. After refactoring that, reassess. */
 		execute: <E>(tell: world.Tell<E>, handler?: slime.$api.event.Handlers<E>) => void
 
+	}
+
+	export interface Exports {
 		/** @deprecated */
 		old: {
 			/** @deprecated */
@@ -637,6 +640,75 @@ namespace slime.$api.fp.world {
 			tell: <E>(f: (events: slime.$api.Events<E>) => void) => world.old.Tell<E>
 		}
 	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			const { verify } = fifty;
+			const { $api } = fifty.global;
+
+			fifty.tests.exports.world.old = fifty.test.Parent();
+
+			fifty.tests.exports.world.old.ask = function() {
+				type E = {
+					called: void
+				};
+
+				type T = {
+					number: number
+				}
+
+				var implementation = function(events: slime.$api.Events<E>): T {
+					events.fire("called");
+					return {
+						number: 3
+					};
+				}
+
+				var captor = fifty.$api.Events.Captor({
+					called: void(0)
+				});
+
+				verify(captor).events.length.is(0);
+
+				var ask = $api.fp.world.old.ask(implementation);
+
+				var returned = ask(captor.handler);
+				verify(captor).events.length.is(1);
+				verify(returned).number.is(3);
+			}
+
+
+			fifty.tests.exports.world.old.tell = function() {
+				type E = {
+					called: void
+				};
+
+				var effects: { number: number }[] = [];
+
+				var implementation = function(events: slime.$api.Events<E>) {
+					events.fire("called");
+					effects.push({ number: 3 });
+				}
+
+				var captor = fifty.$api.Events.Captor({
+					called: void(0)
+				});
+
+				verify(captor).events.length.is(0);
+				verify(effects).length.is(0);
+
+				var tell = $api.fp.world.old.tell(implementation);
+
+				tell(captor.handler);
+				verify(captor).events.length.is(1);
+				verify(effects).length.is(1);
+				verify(effects)[0].number.is(3);
+			}
+		}
+	//@ts-ignore
+	)(fifty);
 }
 
 namespace slime.$api.fp.internal.impure {

--- a/loader/$api-fp-impure.js
+++ b/loader/$api-fp-impure.js
@@ -184,8 +184,10 @@
 
 		var input = function(ask, handler) {
 			return function() {
-				var adapted = $context.events.ask(ask);
-				return adapted(handler);
+				return $context.events.handle({
+					implementation: ask,
+					handlers: handler
+				});
 			}
 		};
 
@@ -194,9 +196,10 @@
 			Process: {
 				action: function(p) {
 					return function() {
-						var tell = p.action(p.argument);
-						var adapted = $context.events.tell(tell);
-						adapted(p.handlers);
+						return $context.events.handle({
+							implementation: p.action(p.argument),
+							handlers: p.handlers
+						});
 					}
 				}
 			},
@@ -230,9 +233,10 @@
 				output: function(handler) {
 					return function(action) {
 						return function(argument) {
-							var tell = action(argument);
-							var adapted = $context.events.tell(tell);
-							adapted(handler);
+							$context.events.handle({
+								implementation: action(argument),
+								handlers: handler
+							});
 						}
 					}
 				},
@@ -244,50 +248,62 @@
 					}
 				}
 			},
-			mapping: function(question, handler) {
+			mapping: function(question, handlers) {
 				return function(p) {
-					var ask = question(p);
-					var adapted = $context.events.ask(ask);
-					return adapted(handler);
+					return $context.events.handle({
+						implementation: question(p),
+						handlers: handlers
+					});
 				}
 			},
 			output: function(action, handler) {
 				return function(p) {
-					var tell = action(p);
-					var adapted = $context.events.tell(tell);
-					adapted(handler);
-				}
+					$context.events.handle({
+						implementation: action(p),
+						handlers: handler
+					});
+				};
 			},
 			input: input,
 			process: function(tell, handler) {
 				return function() {
-					var adapted = $context.events.tell(tell);
-					adapted(handler);
+					$context.events.handle({
+						implementation: tell,
+						handlers: handler
+					});
 				}
 			},
 			now: {
-				question: function(question, argument, handler) {
-					var ask = question(argument);
-					var adapted = $context.events.ask(ask);
-					return adapted(handler);
+				question: function(question, argument, handlers) {
+					return $context.events.handle({
+						implementation: question(argument),
+						handlers: handlers
+					});
 				},
 				action: function(action, argument, handler) {
-					var tell = action(argument);
-					var adapted = $context.events.tell(tell);
-					adapted(handler);
+					$context.events.handle({
+						implementation: action(argument),
+						handlers: handler
+					});
 				},
 				tell: function(tell, handler) {
-					var adapted = $context.events.tell(tell);
-					adapted(handler);
+					$context.events.handle({
+						implementation: tell,
+						handlers: handler
+					});
 				},
-				ask: function(ask, handler) {
-					var adapted = $context.events.ask(ask);
-					return adapted(handler);
+				ask: function(ask, handlers) {
+					return $context.events.handle({
+						implementation: ask,
+						handlers: handlers
+					});
 				}
 			},
 			execute: function(tell, handler) {
-				var adapted = $context.events.tell(tell);
-				adapted(handler);
+				$context.events.handle({
+					implementation: tell,
+					handlers: handler
+				});
 			},
 			old: {
 				ask: $context.events.ask,

--- a/loader/events.fifty.ts
+++ b/loader/events.fifty.ts
@@ -12,7 +12,14 @@ namespace slime.runtime.internal.events {
 	export interface Exports {
 		api: slime.$api.exports.Events
 
+		handle: <E,T>(p: {
+			implementation: (events: slime.$api.Events<E>) => T,
+			handlers: slime.$api.event.Handlers<E>
+		}) => T
+
+		//	TODO	used only by $api-fp-impure.js, re-exporting; need to investigate whether/how that export is used
 		ask: <E,T>(f: (events: slime.$api.Events<E>) => T) => (on?: slime.$api.event.Handlers<E>) => T
+
 		tell: slime.$api.fp.Exports["world"]["old"]["tell"]
 	}
 

--- a/loader/events.js
+++ b/loader/events.js
@@ -261,6 +261,16 @@
 					}
 				}
 			},
+			handle: function(p) {
+				var receiver = ListenersInvocationReceiver(p.handlers);
+				receiver.attach();
+				try {
+					//	TODO	'this' is almost certainly wrong. Perhaps should be optional parameter?
+					return p.implementation.call(this, receiver.emitter);
+				} finally {
+					receiver.detach();
+				}
+			},
 			ask: ask,
 			tell: tell
 		});


### PR DESCRIPTION
Switch all impure usages to new API other than those that re-exported old behavior

Also:
* Add test coverage for old behavior pending refactor reimplementing it outside events API