### PR TITLE
Move deprecated events APIs to fp.impure

### DIFF
--- a/loader/$api-fp-impure.js
+++ b/loader/$api-fp-impure.js
@@ -191,6 +191,15 @@
 			}
 		};
 
+		var oldAsk = function(f) {
+			return function(handlers) {
+				return $context.events.handle({
+					implementation: f,
+					handlers: handlers
+				})
+			}
+		};
+
 		/** @type { slime.$api.fp.world.Exports } */
 		var world = {
 			Process: {
@@ -306,8 +315,8 @@
 				});
 			},
 			old: {
-				ask: $context.events.ask,
-				tell: $context.events.tell
+				ask: oldAsk,
+				tell: oldAsk
 			}
 		}
 

--- a/loader/$api.js
+++ b/loader/$api.js
@@ -525,12 +525,12 @@
 			}
 		}
 
-		$exports.events = events.api;
+		$exports.events = events.exports;
 
 		$exports.Events = Object.assign(
-			$exports.deprecate(events.api.create),
+			$exports.deprecate(events.exports.create),
 			{
-				Function: $exports.deprecate(events.api.Function),
+				Function: $exports.deprecate(events.exports.Function),
 			}
 		);
 

--- a/loader/events.fifty.ts
+++ b/loader/events.fifty.ts
@@ -10,17 +10,18 @@ namespace slime.runtime.internal.events {
 	}
 
 	export interface Exports {
-		api: slime.$api.exports.Events
+		/**
+		 * Implements the `$api.events` API.
+		 */
+		exports: slime.$api.exports.Events
 
+		/**
+		 * Helper function, not exported to `$api`, which assists in implementing various wo constructs in `$api.fp.world`.
+		 */
 		handle: <E,T>(p: {
 			implementation: (events: slime.$api.Events<E>) => T,
 			handlers: slime.$api.event.Handlers<E>
 		}) => T
-
-		//	TODO	used only by $api-fp-impure.js, re-exporting; need to investigate whether/how that export is used
-		ask: <E,T>(f: (events: slime.$api.Events<E>) => T) => (on?: slime.$api.event.Handlers<E>) => T
-
-		tell: slime.$api.fp.Exports["world"]["old"]["tell"]
 	}
 
 	export namespace test {
@@ -110,10 +111,6 @@ namespace slime.$api {
 
 			//	TODO	could probably use parameterized types to improve accuracy
 			Function: <P,R>(f: (p: P, events: any) => R, defaultListeners?: object) => (argument: P, receiver?: slime.$api.event.Function.Receiver) => R
-
-			Handler: {
-				attach: <T>(events: slime.$api.Events<T>) => (handler: slime.$api.event.Handlers<T>) => void
-			}
 		}
 
 		declare const marker: unique symbol;
@@ -169,7 +166,7 @@ namespace slime.$api {
 						}
 					};
 
-					var attached = subject.api.Handlers.attached(handlers);
+					var attached = subject.exports.Handlers.attached(handlers);
 
 					attached.fire("a", 1);
 					attached.fire("a", 2);
@@ -181,7 +178,7 @@ namespace slime.$api {
 					attached.fire("a", 3);
 					verify(as.length).is(3);
 
-					subject.api.Handlers.detach(attached);
+					subject.exports.Handlers.detach(attached);
 					attached.fire("a", 4);
 					verify(as.length).is(3);
 				}

--- a/loader/events.js
+++ b/loader/events.js
@@ -191,50 +191,15 @@
 			}
 		};
 
-		/** @type { slime.runtime.internal.events.Exports["ask"] } */
-		function ask(f) {
-			var rv = function(on) {
-				var receiver = ListenersInvocationReceiver(on);
-				receiver.attach();
-				try {
-					return f.call(this, receiver.emitter);
-				} finally {
-					receiver.detach();
-				}
-			}
-			return rv;
-		}
-
-		/** @type { slime.runtime.internal.events.Exports["tell"] } */
-		function tell(f) {
-			var rv = function(on) {
-				var receiver = ListenersInvocationReceiver(on);
-				receiver.attach();
-				try {
-					f.call(this, receiver.emitter);
-				} finally {
-					receiver.detach();
-				}
-			}
-			return rv;
-		}
-
 		/** @type { ReturnType<ListenersInvocationReceiver>[] } */
 		var attachedHandlers = [];
 
 		$export({
-			api: {
+			exports: {
 				create: function(p) {
 					return new Emitter(p);
 				},
 				Function: listening,
-				Handler: {
-					attach: function(events) {
-						return function(handler) {
-							attach(events,handler);
-						}
-					}
-				},
 				Handlers: {
 					/** @template { any } D */
 					attached: function(handlers) {
@@ -270,9 +235,7 @@
 				} finally {
 					receiver.detach();
 				}
-			},
-			ask: ask,
-			tell: tell
+			}
 		});
 	}
 //@ts-ignore


### PR DESCRIPTION
Also:
* Rename events exports implementation to exports from api
* Remove unused events Handler.attach