### PR TITLE
Fix TypeDoc bugs

### DIFF
--- a/rhino/file/loader.js
+++ b/rhino/file/loader.js
@@ -51,7 +51,7 @@
 					var filesystem = delegate.filesystem;
 					var target = $context.library.Location.relative(path.join(filesystem.separator.pathname))(delegate);
 					var nodes = $api.fp.world.now.ask(filesystem.listDirectory({ pathname: target.pathname }));
-					if (!nodes.present) throw new Error();
+					if (!nodes.present) throw new Error("Could not list: " + target.pathname);
 
 					/** @type { (pathname: string, question: slime.$api.fp.world.Meter<{ pathname: string },void,slime.$api.fp.Maybe<boolean>>) => boolean } */
 					var presentBoolean = function(pathname,question) {

--- a/rhino/tools/hg/module.fifty.ts
+++ b/rhino/tools/hg/module.fifty.ts
@@ -41,7 +41,7 @@ namespace slime.jrunscript.tools.hg {
 		}
 	}
 
-	interface Hgrc {
+	export interface Hgrc {
 		get: (name?: string) => string | object
 
 		set: (section: string, name: string, value: string) => void

--- a/rhino/tools/node/module.fifty.ts
+++ b/rhino/tools/node/module.fifty.ts
@@ -194,7 +194,7 @@ namespace slime.jrunscript.node {
 						/**
 						 * Before installing the given {@link Module}.
 						 */
-						installing: Module
+						installing: { name: string, version?: string }
 
 						/**
 						 * After installing the given {@link Module}.

--- a/rhino/tools/node/module.js
+++ b/rhino/tools/node/module.js
@@ -319,7 +319,7 @@
 					events.fire("found", installed);
 					var satisfied = isSatisfied(p.version)(installed);
 					if (!satisfied) {
-						events.fire("installing");
+						events.fire("installing", p);
 						modules_install(p)(installation)(events);
 						installed = modules_installed(p.name)(installation)(events);
 						if (installed.present) {

--- a/tools/fifty/documentation-updater.fifty.ts
+++ b/tools/fifty/documentation-updater.fifty.ts
@@ -151,7 +151,8 @@ namespace slime.tools.documentation.updater {
 
 			};
 
-			var slime = fifty.jsh.file.relative("../..");
+			//var slime = fifty.jsh.file.relative("../..");
+			var project = jsh.shell.PWD.pathname.toString();
 
 			var timed = function<F extends (...args: any[]) => any>(f: F, callback: (elapsed: number) => void): F {
 				return function() {
@@ -165,9 +166,35 @@ namespace slime.tools.documentation.updater {
 
 			fifty.tests.manual = {};
 
+			fifty.tests.manual.update = function() {
+				var update = subject.test.Update({
+					project: jsh.file.Location.from.os(project)
+				});
+				$api.fp.world.now.tell(
+					update,
+					{
+						started: function(e) {
+							jsh.shell.console("Started: " + JSON.stringify(e.detail));
+						},
+						stderr: function(e) {
+							jsh.shell.console("STDERR (" + e.detail.out + "): " + e.detail.line);
+						},
+						stdout: function(e) {
+							jsh.shell.console("STDOUT (" + e.detail.out + "): " + e.detail.line);
+						},
+						finished: function(e) {
+							jsh.shell.console("Finished: " + JSON.stringify(e.detail));
+						},
+						errored: function(e) {
+							jsh.shell.console("Finished: " + JSON.stringify(e.detail));
+						}
+					}
+				);
+			}
+
 			var createUpdater = function() {
 				return subject.Updater({
-					project: slime.pathname,
+					project: project,
 					events: {
 						initialized: function(e) {
 							jsh.shell.console("Initialized: project=" + e.detail.project);
@@ -209,32 +236,6 @@ namespace slime.tools.documentation.updater {
 				});
 			}
 
-			fifty.tests.manual.update = function() {
-				var update = subject.test.Update({
-					project: slime
-				});
-				$api.fp.world.now.tell(
-					update,
-					{
-						started: function(e) {
-							jsh.shell.console("Started: " + JSON.stringify(e.detail));
-						},
-						stderr: function(e) {
-							jsh.shell.console("STDERR (" + e.detail.out + "): " + e.detail.line);
-						},
-						stdout: function(e) {
-							jsh.shell.console("STDOUT (" + e.detail.out + "): " + e.detail.line);
-						},
-						finished: function(e) {
-							jsh.shell.console("Finished: " + JSON.stringify(e.detail));
-						},
-						errored: function(e) {
-							jsh.shell.console("Finished: " + JSON.stringify(e.detail));
-						}
-					}
-				);
-			}
-
 			fifty.tests.manual.run = function() {
 				var updater = createUpdater();
 				updater.run();
@@ -249,48 +250,50 @@ namespace slime.tools.documentation.updater {
 				updater.run();
 			}
 
-			fifty.tests.manual.typedoc = {
-				timing: function() {
-					timed(
-						function() {
-							$api.fp.world.now.action(
-								subject.test.Update,
-								{
-									project: fifty.jsh.file.relative("../..")
+			fifty.tests.manual.timing = {};
+
+			fifty.tests.manual.timing.typedoc = function() {
+				timed(
+					function() {
+						$api.fp.world.now.action(
+							subject.test.Update,
+							{
+								project: jsh.file.Location.from.os(project)
+							},
+							{
+								started: function(e) {
+									jsh.shell.console("Started: " + JSON.stringify(e.detail));
 								},
-								{
-									started: function(e) {
-										jsh.shell.console("Started: " + JSON.stringify(e.detail));
-									},
-									stdout: function(e) {
-										jsh.shell.console("STDOUT: " + e.detail.line);
-									},
-									stderr: function(e) {
-										jsh.shell.console("STDERR: " + e.detail.line);
-									},
-									finished: function(e) {
-										jsh.shell.console("Finished: " + JSON.stringify(e.detail));
-									},
-									errored: function(e) {
-										jsh.shell.console("Errored: " + JSON.stringify(e.detail));
-									}
+								stdout: function(e) {
+									jsh.shell.console("STDOUT: " + e.detail.line);
+								},
+								stderr: function(e) {
+									jsh.shell.console("STDERR: " + e.detail.line);
+								},
+								finished: function(e) {
+									jsh.shell.console("Finished: " + JSON.stringify(e.detail));
+								},
+								errored: function(e) {
+									jsh.shell.console("Errored: " + JSON.stringify(e.detail));
 								}
-							)
-						},
-						function(elapsed) {
-							jsh.shell.console("TypeDoc took " + (elapsed / 1000).toFixed(3) + " seconds.");
-						}
-					)();
-				}
+							}
+						)
+					},
+					function(elapsed) {
+						jsh.shell.console("TypeDoc took " + (elapsed / 1000).toFixed(3) + " seconds.");
+					}
+				)();
 			}
 
-			fifty.tests.manual.timing = function() {
+			fifty.tests.manual.timing.scans = function() {
 				var git = timed(jsh.project.code.git.lastModified, function(elapsed) {
 					jsh.shell.console("git took " + elapsed + " milliseconds");
-				})({ base: slime.pathname });
+				})({ base: project });
 
 				var documentation = timed(function() {
-					var loader = jsh.file.world.Location.directory.loader.synchronous({ root: fifty.jsh.file.relative("../../local/doc/typedoc") });
+					var loader = jsh.file.Location.directory.loader.synchronous({
+						root: $api.fp.now.invoke(project, jsh.file.Location.from.os, jsh.file.Location.directory.relativePath("local/doc/typedoc"))
+					});
 					return jsh.project.code.directory.lastModified({
 						loader: loader,
 						map: $api.fp.identity

--- a/tools/fifty/documentation-updater.js
+++ b/tools/fifty/documentation-updater.js
@@ -130,7 +130,9 @@
 						})
 					},
 					documentation: function() {
-						var loader = $context.library.file.world.Location.directory.loader.synchronous({ root: documentation });
+						var exists = $api.fp.world.Meter.mapping({ meter: $context.library.file.Location.directory.exists() });
+						if (!exists(documentation)) return $api.fp.Maybe.from.nothing();
+						var loader = $context.library.file.Location.directory.loader.synchronous({ root: documentation });
 						return $context.library.code.directory.lastModified({
 							loader: loader,
 							map: $api.fp.identity

--- a/tools/wf/plugin.jsh.js
+++ b/tools/wf/plugin.jsh.js
@@ -688,7 +688,18 @@
 					var version = library.module.Project.getTypescriptVersion(project);
 					var configuration = library.module.Project.getConfigurationLocation(project);
 					$api.fp.world.now.tell(jsh.shell.tools.rhino.require());
-					jsh.shell.tools.tomcat.old.require();
+					$api.fp.world.now.action(jsh.shell.tools.tomcat.require);
+					$api.fp.world.now.action(jsh.shell.tools.node.require, void(0), {
+						found: function(e) {
+							jsh.shell.console("Found Node.js " + e.detail.version + ".");
+						},
+						removed: function(e) {
+							jsh.shell.console("Removed Node.js " + e.detail.version);
+						},
+						installed: function(e) {
+							jsh.shell.console("Installed Node.js " + e.detail.version + ".");
+						}
+					});
 					/** @type { slime.jsh.wf.internal.typescript.typedoc.Invocation } */
 					var typedocInvocation = {
 						stdio: stdio,
@@ -792,6 +803,7 @@
 											jsh.shell.console("Found TypeDoc " + e.detail);
 										},
 										notFound: function(e) {
+											debugger;
 											jsh.shell.console("TypeDoc not found.");
 										},
 										installed: function(e) {


### PR DESCRIPTION
* Fix bug in which Node module installing event omitted argument
* Do not crash scanning TypeDoc directory if it is missing

Also:
* Switch manual TypeDoc tests to use PWD rather than root
* Emit useful error message when a directory cannot be listed
* Export Hgrc type definition
* Require Node whn generating TypeDoc command
* Refine type definition for Node module 'installing' event