### PR TITLE
#1522: Get GraalVM debugging working again

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,10 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
+			"name": "GraalVM: Attach",
 			"type": "graalvm",
 			"request": "attach",
-			"name": "GraalVM Attach",
+			"protocol": "chromeDevTools",
 			"port": 9229
 		},
 		{

--- a/jrunscript/jsh/launcher/main.js
+++ b/jrunscript/jsh/launcher/main.js
@@ -332,6 +332,10 @@
 		}
 
 		if ($api.slime.settings.get("jsh.engine") == "graal") {
+			if (javaMajorVersion < 17) {
+				Packages.java.lang.System.err.println("GraalVM cannot be launched by a launcher running a pre-17 Java VM.");
+				Packages.java.lang.System.exit(1);
+			}
 			var lib = $api.slime.settings.get("jsh.shell.lib");
 			var polyglotLib = new Packages.java.io.File(lib, "graal/lib/polyglot");
 			$api.debug("polyglotLib = " + polyglotLib);

--- a/jsh
+++ b/jsh
@@ -383,6 +383,15 @@ if [ "$1" == "--install-graalvm" ]; then
 
 	install_maven_dependency org.graalvm.js js-language 23.1.0 ${GRAAL_POLYGLOT_LIB}/js-language.jar
 	install_maven_dependency org.graalvm.shadowed icu4j 23.1.0 ${GRAAL_POLYGLOT_LIB}/icu4j.jar
+
+	#	Note that although the documentation explicitly states these are not required --
+	#	https://www.graalvm.org/latest/tools/chrome-debugger/ says (in contract to when launching with OpenJDK):
+	#	"The Chrome Inspector tool is always available as a tool on GraalVM. No dependency needs to be explicitly declared there,"
+	#	testing indicates these absolutely are required.
+
+	install_maven_dependency org.graalvm.shadowed json 23.1.0 ${GRAAL_POLYGLOT_LIB}/json.jar
+	install_maven_dependency org.graalvm.tools profiler-tool 23.1.0 ${GRAAL_POLYGLOT_LIB}/profiler-tool.jar
+	install_maven_dependency org.graalvm.tools chromeinspector-tool 23.1.0 ${GRAAL_POLYGLOT_LIB}/chromeinspector-tool.jar
 	exit $?
 fi
 

--- a/loader/jrunscript/graal/java/inonit/script/graal/HostFactory.java
+++ b/loader/jrunscript/graal/java/inonit/script/graal/HostFactory.java
@@ -6,6 +6,8 @@
 
 package inonit.script.graal;
 
+import org.graalvm.polyglot.HostAccess;
+
 import inonit.script.engine.*;
 
 public class HostFactory extends inonit.script.engine.Host.Factory {
@@ -19,11 +21,17 @@ public class HostFactory extends inonit.script.engine.Host.Factory {
 		Thread.currentThread().setContextClassLoader(classes);
 		//	TODO	figure out how to set classpath properly
 
-		//System.err.println("HostFactory.this.create()");
 		final org.graalvm.polyglot.Context.Builder builder = org.graalvm.polyglot.Context.newBuilder("js")
-			.allowExperimentalOptions(true)
+			//	Allow reflective access to the underlying host platform
+			.allowAllAccess(true)
+
+			//	Allow experimental options. Although some configurations result in an error message saying that js.nashorn-compat
+			//	is an experimental option and this is needed, this particular configuration does not. Perhaps .allowAllAccess()
+			//	enables it?
+			//.allowExperimentalOptions(true)
+
+			//	Allow nashorn:mozilla_compat.js to be loaded
 			.option("js.nashorn-compat", "true")
-			.allowHostAccess(true)
 		;
 
 		if (configuration.inspect() != null) {


### PR DESCRIPTION
* Install Maven tool dependencies
* Fix VSCode debugging configuration

Also:
* Exit with error message when Grall shell requested and launcher JVM is not recent enough to run Graal shell