### PR TITLE
Handle errors emitted by typedoc.invocation in documentation-updater

### DIFF
--- a/fifty
+++ b/fifty
@@ -6,4 +6,4 @@
 #	END LICENSE
 
 BASE=$(dirname $0)
-${BASE}/jsh.bash ${BASE}/tools/fifty.jsh.js "$@"
+${BASE}/jsh ${BASE}/tools/fifty.jsh.js "$@"

--- a/tools/fifty/documentation-updater.fifty.ts
+++ b/tools/fifty/documentation-updater.fifty.ts
@@ -49,7 +49,7 @@ namespace slime.tools.documentation.updater {
 		 * gives access to an object representing the running update, including the output directory to which its output will be
 		 * written.
 		 *
-		 * This method terminates when the update process terminates, after firing either a `finished` or a `processed` event,
+		 * This method terminates when the update process terminates, after firing either a `finished` or a `errored` event,
 		 * both of which also give access to the output directory to which TypeDoc documentation would have been written.
 		 */
 		export type Update = slime.$api.fp.world.Means<

--- a/tools/fifty/documentation-updater.js
+++ b/tools/fifty/documentation-updater.js
@@ -20,14 +20,24 @@
 					directory: true
 				}));
 
-				var invocation = $context.typedoc.invocation({
-					project: { base: p.project.pathname },
-					stdio: {
-						output: "line",
-						error: "line"
-					},
-					out: tmp.pathname
-				});
+				var invocation;
+				try {
+					invocation = $context.typedoc.invocation({
+						project: { base: p.project.pathname },
+						stdio: {
+							output: "line",
+							error: "line"
+						},
+						out: tmp.pathname
+					});
+				} catch (e) {
+					events.fire("stderr", { out: tmp.pathname, line: String(e) });
+					events.fire("errored", {
+						out: function() { return tmp.pathname; },
+						started: function() { return null; },
+						kill: function() {}
+					})
+				}
 
 				/** @type { number } */
 				var started;


### PR DESCRIPTION
Also:
* Remove reference to jsh.bash
* Fix documentation error
* Modernize parts of tools/fifty/documentation.jsh.js