### PR TITLE
Allow Predicate.and to narrow types; use array for argument

### DIFF
--- a/loader/$api-Function.fifty.ts
+++ b/loader/$api-Function.fifty.ts
@@ -151,7 +151,10 @@ namespace slime.$api.fp {
 
 	export interface Exports {
 		Predicate: {
-			and: <T>(...predicates: $api.fp.Predicate<T>[]) => $api.fp.Predicate<T>
+			and: {
+				<A,B extends A>(predicates: [TypePredicate<A,B>, Predicate<B>]): TypePredicate<A,B>
+				<T>(...predicates: $api.fp.Predicate<T>[]): $api.fp.Predicate<T>
+			}
 			or: <T>(...predicates: $api.fp.Predicate<T>[]) => $api.fp.Predicate<T>
 			not: <T>(predicate: $api.fp.Predicate<T>) => $api.fp.Predicate<T>
 			is: <T>(value: T) => fp.Predicate<T>
@@ -175,8 +178,38 @@ namespace slime.$api.fp {
 			fifty: slime.fifty.test.Kit
 		) {
 			const verify = fifty.verify;
+			const { $api } = fifty.global;
 
 			fifty.tests.Predicate = function() {
+				fifty.run(function and() {
+					interface A {
+						a: number
+					};
+
+					interface B extends A {
+						b: number
+					}
+
+					var isB = (a: A): a is B => {
+						return typeof(a["b"]) != "undefined";
+					}
+
+					var list: A[] = [
+						{ a: 1 },
+						{ a: 2, b: 2 } as A,
+						{ a: 3 },
+						{ a: 4, b: 4} as A,
+						{ a: 5, b: 0 } as A
+					];
+
+					var bOver3 = $api.fp.Predicate.and([ isB, (b) => b.b > 3 ]);
+
+					var bsOver3 = list.filter(bOver3);
+					verify(bsOver3).length.is(1);
+					verify(bsOver3)[0].a.is(4);
+					verify(bsOver3)[0].b.is(4);
+				});
+
 				fifty.run(function property() {
 					type T = { a: number, b: string };
 

--- a/loader/$api-Function.js
+++ b/loader/$api-Function.js
@@ -122,6 +122,7 @@
 			}
 		};
 
+		/** @type { slime.$api.fp.Exports["Predicate"] } */
 		var Predicate = {
 			is: function(value) {
 				return function(p) {
@@ -146,7 +147,10 @@
 					return false;
 				}
 			},
-			and: function() {
+			and: function recurse() {
+				if (arguments.length == 1 && arguments[0] instanceof Array) {
+					return recurse.apply(this, arguments[0]);
+				}
 				var functions = Array.prototype.slice.call(arguments);
 				for (var i=0; i<functions.length; i++) {
 					if (typeof(functions[i]) != "function") throw new TypeError("All arguments must be functions; index " + i + " is not.");
@@ -253,54 +257,7 @@
 					return Object.fromEntries(results);
 				}
 			},
-			Predicate: {
-				is: function(value) {
-					return function(p) {
-						return p === value;
-					}
-				},
-				equals: function(value) {
-					return function(p) {
-						return p == value;
-					}
-				},
-				/** @type { slime.$api.fp.Exports["filter"]["or"] } */
-				or: function() {
-					var functions = Array.prototype.slice.call(arguments);
-					for (var i=0; i<functions.length; i++) {
-						if (typeof(functions[i]) != "function") throw new TypeError("All arguments must be functions; index " + i + " is not.");
-					}
-					return function(p) {
-						for (var i=0; i<functions.length; i++) {
-							if (functions[i](p)) return true;
-						}
-						return false;
-					}
-				},
-				and: function() {
-					var functions = Array.prototype.slice.call(arguments);
-					for (var i=0; i<functions.length; i++) {
-						if (typeof(functions[i]) != "function") throw new TypeError("All arguments must be functions; index " + i + " is not.");
-					}
-					return function(p) {
-						for (var i=0; i<functions.length; i++) {
-							if (!functions[i](p)) return false;
-						}
-						return true;
-					}
-				},
-				not: function(f) {
-					return function(p) {
-						return !f(p);
-					}
-				},
-				property: function(key, predicate) {
-					return pipe(
-						property(key),
-						predicate
-					);
-				}
-			},
+			Predicate: Predicate,
 			filter: {
 				or: $context.deprecate(Predicate.or),
 				and: $context.deprecate(Predicate.and),

--- a/loader/document/module.fifty.ts
+++ b/loader/document/module.fifty.ts
@@ -22,91 +22,6 @@
  * information about them.
  */
 namespace slime.runtime.document {
-	export interface Node {
-		type: string
-	}
-
-	export interface Parent extends Node {
-		children: Node[]
-	}
-
-	export interface String extends Node {
-		data: string
-	}
-
-	export interface Comment extends Node {
-		type: "comment"
-		data: string
-	}
-
-	export interface Text extends String {
-		type: "text"
-	}
-
-	export interface Doctype extends Node {
-		type: "doctype"
-		before: string
-		name: string
-		after: string
-	}
-
-	export interface Element extends Parent {
-		type: "element"
-		name: string
-		attributes: Attribute[]
-		selfClosing: boolean
-
-		/**
-		 * A string with the end tag of this element, e.g., `"</foo>"`, or `""` if the element is self-closing or otherwise has
-		 * an optional end tag.
-		 */
-		endTag: string
-	}
-
-	export interface Attribute {
-		//	TODO	may be whitespace before equals
-		//	TODO	may be whitespace after equals
-		/**
-		 * The whitespace before the attribute name.
-		 */
-		whitespace: string
-
-		name: string
-
-		/**
-		 * The quotation character (`'` or `"`) used to enclose this attribute's value.
-		 */
-		quote: string
-
-		value: string
-	}
-
-	export interface Document extends Parent {
-		type: "document"
-	}
-
-	export interface Fragment extends Parent {
-		type: "fragment"
-	}
-
-	export namespace xml {
-		export interface Declaration extends Node {
-			type: "xml-declaration"
-			data: string
-		}
-
-		export interface ProcessingInstruction extends Node {
-			type: "xml-processing-instruction"
-			target: string
-			whitespace: string
-			data: string
-		}
-
-		export interface Cdata extends String {
-			type: "cdata",
-		}
-	}
-
 	export namespace test {
 		export const subject = (function(fifty: slime.fifty.test.Kit) {
 			var script: Script = fifty.$loader.script("module.js");
@@ -179,7 +94,19 @@ namespace slime.runtime.document {
 
 	export interface Exports {
 		load: old.Exports["load"]
+	}
 
+	export namespace exports {
+		export interface Node {
+			isElementNamed: (name: string) => slime.$api.fp.TypePredicate<document.Node,document.Element>
+		}
+	}
+
+	export interface Exports {
+		Node: exports.Node
+	}
+
+	export interface Exports {
 		Parent: {
 			/**
 			 * Creates a {@link slime.$api.fp.Stream | Stream} of the descendants of this parent node. In all cases -
@@ -191,19 +118,6 @@ namespace slime.runtime.document {
 			 * contain the given node.
 			 */
 			nodes: (p: Parent) => slime.$api.fp.Stream<Node>
-		}
-
-		Document: exports.Document
-
-		Fragment: {
-			codec: {
-				string: slime.Codec<slime.runtime.document.Fragment,string>
-			}
-		}
-
-		Element: {
-			isName: (name: string) => (element: Element) => boolean
-			getAttribute: (name: string) => (element: Element) => slime.$api.fp.Maybe<string>
 		}
 	}
 
@@ -264,6 +178,27 @@ namespace slime.runtime.document {
 	//@ts-ignore
 	)(fifty);
 
+	export interface Exports {
+		Document: exports.Document
+
+		Fragment: {
+			codec: {
+				string: slime.Codec<slime.runtime.document.Fragment,string>
+			}
+		}
+	}
+
+	export namespace exports {
+		export interface Element {
+			isName: (name: string) => (element: document.Element) => boolean
+			getAttribute: (name: string) => (element: document.Element) => slime.$api.fp.Maybe<string>
+			from: element.From
+		}
+	}
+
+	export interface Exports {
+		Element: exports.Element
+	}
 
 	export type Script = slime.loader.Script<Context | void,Exports>
 }

--- a/loader/document/module.js
+++ b/loader/document/module.js
@@ -418,6 +418,23 @@
 			}
 		)();
 
+		var Elements = {
+			isName: function(name) {
+				return function(element) {
+					return element.name == name;
+				}
+			},
+			getAttribute: function(name) {
+				return function(element) {
+					var match = element.attributes.filter(function(attribute) {
+						return attribute.name == name;
+					})[0];
+					return (match) ? $api.fp.Maybe.from.some(match.value) : $api.fp.Maybe.from.nothing();
+				}
+			},
+			from: source.Element.from
+		};
+
 		/** @type { slime.runtime.document.Exports } */
 		var rv = {
 			load: function(p) {
@@ -431,7 +448,18 @@
 					throw new TypeError();
 				}
 			},
-			Node: source.Node,
+			Node: $api.Object.compose(
+				source.Node,
+				/** @type { Pick<slime.runtime.document.exports.Node,"isElementNamed"> } */({
+					isElementNamed: function(name) {
+						return $api.fp.Predicate.and([
+							source.Node.isElement,
+							Elements.isName(name)
+						]);
+					}
+				})
+			),
+			Text: source.Text,
 			Parent: {
 				nodes: function(p) {
 					return NodesStream(p, []);
@@ -466,7 +494,8 @@
 						})[0];
 						return (match) ? $api.fp.Maybe.from.some(match.value) : $api.fp.Maybe.from.nothing();
 					}
-				}
+				},
+				from: source.Element.from
 			},
 			//	TODO	temporarily disabling TypeScript while we figure out the loader/document vs. rhino/document nightmare
 			//@ts-ignore
@@ -574,7 +603,7 @@
 					if (elements.length != 1) throw new Error("Document has " + elements.length + " root elements.");
 					return elements[0];
 				}
-			},
+			}
 		};
 
 		$export(rv);

--- a/loader/document/source.fifty.ts
+++ b/loader/document/source.fifty.ts
@@ -5,16 +5,128 @@
 //	END LICENSE
 
 namespace slime.runtime.document {
-	export interface Exports {
-		Node: {
+	export interface Node {
+		type: string
+	}
+
+	export interface Parent extends Node {
+		children: Node[]
+	}
+
+	export interface String extends Node {
+		data: string
+	}
+
+	export interface Comment extends Node {
+		type: "comment"
+		data: string
+	}
+
+	export interface Text extends String {
+		type: "text"
+	}
+
+	export interface Doctype extends Node {
+		type: "doctype"
+		before: string
+		name: string
+		after: string
+	}
+
+	export interface Element extends Parent {
+		type: "element"
+		name: string
+		attributes: Attribute[]
+		selfClosing: boolean
+
+		/**
+		 * A string with the end tag of this element, e.g., `"</foo>"`, or `""` if the element is self-closing or otherwise has
+		 * an optional end tag.
+		 */
+		endTag: string
+	}
+
+	export interface Attribute {
+		//	TODO	may be whitespace before equals
+		//	TODO	may be whitespace after equals
+		/**
+		 * The whitespace before the attribute name.
+		 */
+		whitespace: string
+
+		name: string
+
+		/**
+		 * The quotation character (`'` or `"`) used to enclose this attribute's value.
+		 */
+		quote: string
+
+		value: string
+	}
+
+	export interface Document extends Parent {
+		type: "document"
+	}
+
+	export interface Fragment extends Parent {
+		type: "fragment"
+	}
+
+	export namespace xml {
+		export interface Declaration extends Node {
+			type: "xml-declaration"
+			data: string
+		}
+
+		export interface ProcessingInstruction extends Node {
+			type: "xml-processing-instruction"
+			target: string
+			whitespace: string
+			data: string
+		}
+
+		export interface Cdata extends String {
+			type: "cdata",
+		}
+	}
+
+	export namespace exports {
+		export interface Node {
 			isComment: (node: slime.runtime.document.Node) => node is slime.runtime.document.Comment
 			isText: (node: slime.runtime.document.Node) => node is slime.runtime.document.Text
 			isDoctype: (node: slime.runtime.document.Node) => node is slime.runtime.document.Doctype
 			isDocument: (node: slime.runtime.document.Node) => node is slime.runtime.document.Document
 			isElement: (node: slime.runtime.document.Node) => node is slime.runtime.document.Element
 			isFragment: (node: slime.runtime.document.Node) => node is slime.runtime.document.Fragment
-			isParent: (node: Node) => node is Parent
-			isString: (node: Node) => node is String
+			isParent: (node: document.Node) => node is document.Parent
+			isString: (node: document.Node) => node is document.String
+		}
+	}
+
+	export interface Exports {
+		Text: {
+			from: {
+				data: (data: string) => slime.runtime.document.Text
+			}
+		}
+	}
+
+	export namespace element {
+		export namespace from {
+			export interface Attribute {
+				name: string
+				value: string
+			}
+
+			export interface Parent {
+				name: string
+				attributes?: Attribute[]
+				children?: Node[]
+			}
+		}
+
+		export interface From {
+			parent: (p: element.from.Parent) => Element
 		}
 	}
 }
@@ -69,7 +181,13 @@ namespace slime.runtime.document.internal.source {
 			}) => string
 		}
 
-		Node: slime.runtime.document.Exports["Node"]
+		Node: Pick<slime.runtime.document.Exports["Node"],"isComment"|"isText"|"isDoctype"|"isDocument"|"isElement"|"isFragment"|"isString"|"isParent">
+
+		Text: slime.runtime.document.Exports["Text"]
+
+		Element: {
+			from: slime.runtime.document.Exports["Element"]["from"]
+		}
 
 		/**
 		 * Methods used internally, visible for testing.

--- a/loader/document/source.js
+++ b/loader/document/source.js
@@ -809,6 +809,37 @@
 				isParent: isParent,
 				isString: isString
 			},
+			Text: {
+				from: {
+					data: function(data) { return { type: "text", data: data }; }
+				}
+			},
+			Element: {
+				from: (function() {
+					/** @type { slime.$api.fp.Mapping<slime.runtime.document.element.from.Attribute,slime.runtime.document.Attribute> } */
+					var attribute = function(spec) {
+						return {
+							name: spec.name,
+							quote: "\"",
+							value: spec.value,
+							whitespace: " "
+						}
+					};
+
+					return {
+						parent: function(p) {
+							return {
+								type: "element",
+								name: p.name,
+								attributes: (p.attributes || []).map(attribute),
+								children: p.children || [],
+								endTag: "</" + p.name + ">",
+								selfClosing: false
+							}
+						}
+					};
+				})()
+			},
 			internal: {
 				parseStartTag: parseStartTag
 			}


### PR DESCRIPTION
Also:
* Add Node.isElementNamed to document API
* Refine document API type definitions