### PR TITLE
In runtime, remove APIs pertaining to Mozilla __defineGetter__

### DIFF
--- a/js/object/api.html
+++ b/js/object/api.html
@@ -227,47 +227,6 @@ END LICENSE
 					test( f.undefinedCalculator.invocations == 1 );
 				</script>
 			</li>
-			<li class="function">
-				<div class="name">lazy</div>
-				<div>
-					Defines a property on an object which is lazy-instantiated by a function the first time it is accessed.
-				</div>
-				<div>
-					The property is effectively constant.  The first time the property is accessed, the given
-					function will be invoked to define the value, which will be returned as the value (without invoking the
-					function) each time it is accessed.  The implementation uses <code>__defineGetter__</code> to attach a constant
-					version of the given function to the given named property.
-				</div>
-				<div class="arguments">
-					<div class="label">Arguments</div>
-					<ol>
-						<li><code>(object)</code> An object on which to define a property.</li>
-						<li><code>(string)</code> The name of the property to define.</li>
-						<li><code>(function)</code> The function that will be invoked to define the property's value, when/if
-							necessary.</li>
-					</ol>
-				</div>
-				<script type="application/x.jsapi#tests"><![CDATA[
-					if ($platform.Object.defineProperty && $platform.Object.defineProperty.accessor) {
-						var f = new Functions();
-
-						var math = {};
-						module.lazy(math, "four", f.calculator);
-						test( f.calculator.invocations == 0 );
-						test( math.four == 4 );
-						test( f.calculator.invocations == 1 );
-						test( math.four == 4 );
-						test( f.calculator.invocations == 1 );
-
-						module.lazy(math, "undefined", f.undefinedCalculator);
-						test( f.undefinedCalculator.invocations == 0 );
-						test( typeof(math.undefined) == "undefined" );
-						test( f.undefinedCalculator.invocations == 1 );
-						test( typeof(math.undefined) == "undefined" );
-						test( f.undefinedCalculator.invocations == 1 );
-					}
-				]]></script>
-			</li>
 			<li class="function" jsapi:id="toLiteral">
 				<div class="name">toLiteral</div>
 				<div>Converts a JavaScript value to a string literal.</div>

--- a/js/object/module.fifty.ts
+++ b/js/object/module.fifty.ts
@@ -12,9 +12,86 @@ namespace slime.js.old {
 		globals: boolean
 	}
 
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			fifty.tests.exports = fifty.test.Parent();
+		}
+	//@ts-ignore
+	)(fifty);
+
+	export interface Exports {
+		/**
+		 * Defines a property on an object which is lazy-instantiated by a function the first time it is accessed.
+		 *
+		 * The property is effectively constant. The first time the property is accessed, the given function will be invoked to
+		 * define the value, which will be returned as the value (without invoking the function) each time it is accessed.
+		 * The property will be enumerable.
+		 *
+		 * This function is only present if Object.defineProperty is available.
+		 *
+		 * @param a An object on which to define a property
+		 * @param n The name of the property to define
+		 * @param v The function that will be invoked to define the property's value, when/if necessary.
+		 * @returns The object, augmented with the new property.
+		 */
+		lazy?: <T extends object,K extends string,V>(a: T, n: K, v: () => V) => T & { [k in K]: V }
+	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			const { verify } = fifty;
+			var module = fifty.$loader.module("module.js");
+
+			var Functions = function() {
+				var calculator = Object.assign(function() {
+					calculator.invocations++;
+					return 2*2;
+				}, {
+					invocations: 0
+				});
+
+				var undefinedCalculator = Object.assign(function() {
+					undefinedCalculator.invocations++;
+					return;
+				}, {
+					invocations: 0
+				});
+
+				this.calculator = calculator;
+				this.undefinedCalculator = undefinedCalculator;
+			}
+
+			fifty.tests.exports.lazy = function() {
+				var f = new Functions();
+
+				var test = function(b) {
+					verify(b).is(true);
+				}
+
+				var math = module.lazy({}, "four", f.calculator);
+				test( f.calculator.invocations == 0 );
+				test( math.four == 4 );
+				test( f.calculator.invocations == 1 );
+				test( math.four == 4 );
+				test( f.calculator.invocations == 1 );
+
+				math = module.lazy(math, "undefined", f.undefinedCalculator);
+				test( f.undefinedCalculator.invocations == 0 );
+				test( typeof(math.undefined) == "undefined" );
+				test( f.undefinedCalculator.invocations == 1 );
+				test( typeof(math.undefined) == "undefined" );
+				test( f.undefinedCalculator.invocations == 1 );
+			}
+		}
+	//@ts-ignore
+	)(fifty);
+
 	export interface Exports {
 		constant: any
-		lazy: any
 		toLiteral: any
 		ObjectTransformer: any
 		properties: any
@@ -39,6 +116,7 @@ namespace slime.js.old {
 			fifty: slime.fifty.test.Kit
 		) {
 			fifty.tests.suite = function() {
+				fifty.run(fifty.tests.exports);
 				fifty.load("Error.fifty.ts");
 			}
 		}

--- a/js/object/module.js
+++ b/js/object/module.js
@@ -45,9 +45,18 @@
 
 		$exports.constant = deprecate(constant);
 
-		if ($platform && $platform.Object.defineProperty && $platform.Object.defineProperty.accessor) {
+		if ($platform.Object.defineProperty) {
+			//@ts-ignore
 			$exports.lazy = function(object,name,getter) {
-				object.__defineGetter__(name, constant(getter));
+				Object.defineProperty(
+					object,
+					name,
+					{
+						enumerable: true,
+						get: constant(getter)
+					}
+				);
+				return object;
 			}
 		}
 
@@ -241,7 +250,7 @@
 			//	TODO	method install() that adds these methods (or a properties object?) to Object, making them non-enumerable if possible
 		}
 		$exports.properties = properties;
-		if ($platform && $platform.Object.defineProperty && $platform.Object.defineProperty.accessor) {
+		if ($platform && $platform.Object.defineProperty) {
 			$api.experimental($exports,"properties");
 		}
 

--- a/loader/$api-flag.fifty.ts
+++ b/loader/$api-flag.fifty.ts
@@ -196,7 +196,7 @@ namespace slime.$api {
 					}
 				}
 
-				var accessor = $platform && $platform.Object.defineProperty && $platform.Object.defineProperty.accessor;
+				var accessor = $platform && $platform.Object.defineProperty;
 				if (accessor) {
 					deprecate(x,"foo");
 					var yes = expectWarn(true);

--- a/loader/expression.fifty.ts
+++ b/loader/expression.fifty.ts
@@ -88,21 +88,11 @@ namespace slime {
 			 */
 			Object: {
 				/**
-				 * An object containing properties describing the platform's meta-object capabilities.
+				 * If `true`, the platform supports the ECMA-262 version 5 `Object.defineProperty` method.
 				 */
-				defineProperty?: {
-					/**
-					 * If `true`, the platform supports the ECMA-262 version 5 `Object.defineProperty` method.
-					 */
-					ecma?: boolean
-
-					//	TODO	rename
-					/**
-					 * If `true`, the platform supports `__defineGetter__` and `__defineSetter__` as defined by Mozilla.
-					 */
-					accessor?: boolean
-				}
+				defineProperty: boolean
 			}
+
 			e4x: any
 			MetaObject: any
 			java: any

--- a/loader/expression.js
+++ b/loader/expression.js
@@ -59,14 +59,10 @@
 			function($engine) {
 				/** @type { slime.runtime.$platform } */
 				var $exports = {};
-				$exports.Object = {};
-				if (Object.defineProperty) {
-					$exports.Object.defineProperty = { ecma: true };
-				}
-				if (Object.prototype.__defineGetter__) {
-					if (!$exports.Object.defineProperty) $exports.Object.defineProperty = {};
-					$exports.Object.defineProperty.accessor = true;
-				}
+
+				$exports.Object = {
+					defineProperty: Boolean(Object.defineProperty)
+				};
 
 				var global = (function() { return this; })();
 				if (global && global.XML && global.XMLList) {


### PR DESCRIPTION
Also:
* #1584: Remove usage of __defineGetter__ in js/object lazy()
* Migrate js/object lazy() definition JSAPI -> Fifty