### PR TITLE
#1712: Migrate rhino/shell run() stdio documentation JSAPI -> Fifty

### DIFF
--- a/rhino/shell/api.html
+++ b/rhino/shell/api.html
@@ -25,56 +25,6 @@ END LICENSE
 						<li class="object">
 							<div class="label">has properties:</div>
 							<ul>
-								<li class="object">
-									<div class="name">stdio</div>
-									<span class="type"><a href="#types.stdio">stdio</a></span>
-									<span>
-										(optional: defaults to stream-specific results as specified)
-										The streams that will be attached to the subprocess as its standard I/O streams. If the
-										value is <code>null</code> the subprocess will receive empty input and all output will be
-										discarded. Otherwise, the properties are interpreted for each stream as specified below.
-									</span>
-									<div class="label">has properties:</div>
-									<ul>
-										<li class="value">
-											<div class="name">input</div>
-											<ul>
-												<li>
-													If omitted or <code>null</code>, an empty stream is supplied as
-													input.
-												</li>
-												<li>
-													If a string, the string is supplied as input.
-												</li>
-												<li>
-													If a <a href="../io/api.html#types.binput">byte stream</a>, the stream is supplied as input.
-												</li>
-											</ul>
-										</li>
-										<li class="value">
-											<div class="name">output</div>
-											<span>(optional; if omitted, a stream that discards all output is supplied.)</span>
-											<ul>
-												<li>
-													If <code>null</code>, an stream that discards all output is supplied to the
-													subprocess.
-												</li>
-												<li>
-													If the <code>String</code> global function is supplied, subprocess output is
-													buffered and converted to a string and is returned as the output property of the
-													stdio property of the result of the subprocess.
-												</li>
-												<li>
-													If a <a href="../io/api.html#types.boutput">byte stream</a>, output from the subprocess is sent to that stream.
-												</li>
-											</ul>
-										</li>
-										<li class="value">
-											<div class="name">error</div>
-											<span>See the <code>output</code> property for detailed specification.</span>
-										</li>
-									</ul>
-								</li>
 								<li class="value" jsapi:id="run.environment">
 									<div class="name">environment</div>
 									- OR -

--- a/rhino/shell/module.js
+++ b/rhino/shell/module.js
@@ -203,7 +203,6 @@
 				};
 			}
 			if (system.sudo) this.sudo = system.sudo;
-			debugger;
 			if (system.ping) this.ping = system.ping;
 			if (system.desktop) this.inject = function(inject) {
 				system.desktop(inject.ui);

--- a/rhino/shell/run-old.fifty.ts
+++ b/rhino/shell/run-old.fifty.ts
@@ -40,16 +40,11 @@ namespace slime.jrunscript.shell {
 					error: {
 						BadCommandToken: slime.$api.error.old.Type<"ArgumentError",{}>
 					}
-					updateForStringInput: (p: slime.jrunscript.shell.invocation.old.Stdio) => slime.jrunscript.shell.internal.invocation.StdioWithInputFixed
-
-					toStdioConfiguration: (declaration: slime.jrunscript.shell.internal.invocation.StdioWithInputFixed) => slime.jrunscript.shell.run.StdioConfiguration
 
 					parseCommandToken: {
 						(arg: slime.jrunscript.shell.invocation.old.Token, index?: number, ...args: any[]): string;
 						Error: slime.$api.error.old.Type<"ArgumentError", {}>;
 					}
-
-					isLineListener: (p: slime.jrunscript.shell.invocation.old.OutputStreamConfiguration) => p is slime.jrunscript.shell.invocation.old.OutputStreamToLines
 				}
 			}
 
@@ -551,12 +546,30 @@ namespace slime.jrunscript.shell {
 				directory?: slime.jrunscript.file.Directory
 
 				/**
-				 * The standard I/O streams to supply to the subprocess. If unspecified, or if any properties are unspecified,
-				 * defaults will be used. The defaults are:
+				 * The standard I/O streams to supply to the subprocess.
+				 *
+				 * If the value is `null` the subprocess will receive empty input and all output will be discarded. Otherwise, the
+				 * properties of the given object are interpreted for each stream as specified below.
+				 *
+				 * * `input`:
+				 *     * If omitted or `null`, an empty stream is supplied as input.
+				 *     * If a string, the string is supplied as input.
+				 *     * If a {@link slime.jrunscript.runtime.io.InputStream}, the stream is supplied as input.
+				 * * `output`:
+				 *     * If `null`, a stream that discards all output is supplied to the subprocess.
+				 *     * If the `String` global function is supplied, subprocess output is buffered and converted to a string and is
+				 * returned as the `output` property of the `stdio` property of the result of the subprocess.
+				 *     * If a {@link slime.jrunscript.runtime.io.OutputStream}, output from the subprocess is sent to that stream.
+				 * * `error`: See `output` for how values are interpreted (if the output is buffered and returned, it will be the
+				 * `error` property of the `stdio` property of the result).
+				 *
+				 * If unspecified, or if any properties are unspecified, defaults will be used, which will in part by supplied by
+				 * the {@link slime.jrunscript.shell.context.Stdio | "parent"} supplied as part of the module {@link
+				 * slime.jrunscript.shell.Context}. The defaults are:
 				 *
 				 * * `input`: `null`
-				 * * `output`: This process's standard output stream
-				 * * `error`: This process's standard error stream
+				 * * `output`: The parent's output stream
+				 * * `error`: The parent's error stream
 				 */
 				stdio?: slime.jrunscript.shell.older.Invocation["stdio"]
 			}


### PR DESCRIPTION
Also:
* Refactor run-old.js internal structure to simplify; remove obsolete constructs from when there was a separate invocation.js
* Remove debugger statement