### PR TITLE
Resolve #1002: Make jsh Rhino installation world-oriented

### DIFF
--- a/jrunscript/jsh/launcher/main.js
+++ b/jrunscript/jsh/launcher/main.js
@@ -186,15 +186,7 @@
 		var defaultEngine = (function() {
 			if (shell.rhino) return "rhino";
 			if ($api.jsh.engines.nashorn) return "nashorn";
-			//	Download Rhino
-			//	TODO	documentation appears to be wrong; it warns that if the appropriate engine is not present the shell will not be
-			//			run
-			$api.console("No default engine; downloading Rhino ...");
-			var _file = $api.rhino.download();
-			$api.console("Using Rhino downloaded to " + _file + ".");
-			shell.rhino = [_file.toURI().toURL()];
-			$api.slime.settings.set("jsh.engine.rhino.classpath", String(_file.getCanonicalPath()));
-			return "rhino";
+			throw new Error("Neither Rhino nor Nashorn available; was this invoked in a way other than using the top-level jsh script?");
 		})();
 		$api.debug("shell after engine selection = " + shell);
 		if (!defaultEngine) {

--- a/jsh
+++ b/jsh
@@ -261,22 +261,6 @@ JSH_BOOTSTRAP_RHINO="${JSH_SHELL_LIB}/js.jar"
 JSH_BOOTSTRAP_NASHORN="${JSH_SHELL_LIB}/nashorn.jar"
 JSH_BOOTSTRAP_NASHORN_LIBRARIES=(asm asm-commons asm-tree asm-util)
 
-install_rhino() {
-	if [ "$0" == "bash" ]; then
-		>&2 echo "Cannot install Rhino into remote shell; exiting."
-		exit 1
-	fi
-	# If JSR-223 Rhino worked with jrunscript ...
-	# JSH_BOOTSTRAP_RHINO_ENGINE="$(dirname $0)/local/jsh/lib/jsr223.jar"
-	#	TODO	redundant with rhino/jrunscript/api.js
-	RHINO_URL="https://github.com/mozilla/rhino/releases/download/Rhino1_7_15_Release/rhino-1.7.15.jar"
-	# If JSR-223 Rhino worked with jrunscript ...
-	# RHINO_ENGINE_URL=https://github.com/mozilla/rhino/releases/download/Rhino1_7_15_Release/rhino-engine-1.7.15.jar
-	download_install ${RHINO_URL} ${JSH_BOOTSTRAP_RHINO}
-	# If JSR-223 Rhino worked with jrunscript ...
-	# download_install ${RHINO_ENGINE_URL} ${JSH_BOOTSTRAP_RHINO_ENGINE}
-}
-
 get_maven_dependency() {
 	GROUP=$1
 	ARTIFACT=$2

--- a/rhino/jrunscript/api.fifty.ts
+++ b/rhino/jrunscript/api.fifty.ts
@@ -58,7 +58,7 @@ namespace slime.jrunscript {
 namespace slime.internal.jrunscript.bootstrap {
 	/**
 	 * An object that can be used to configure the invocation of the `api.js` script, by setting the `$api` property of the global
-	 * object to an object of this type. This value will be replaced by the {@link Global} value exported by the script.
+	 * object to an object of this type. This value will be *overwritten* by the {@link Global} value exported by the script.
 	 */
 	export interface Configuration {
 		script?: {
@@ -145,8 +145,10 @@ namespace slime.internal.jrunscript.bootstrap {
 	}
 
 	/**
-	 * The `Global` is the type definition for the global `this` value (i.e., `globalThis` in other environments) in `jrunscript`
-	 * bootstrap environments.
+	 * The `Global` is the type definition that is applied to the script's `this` value. Normally, the global object (`globalThis`)
+	 * is used, but the script is compatible with any object being used for this purpose.
+	 *
+	 * The script can receive parameters if they are already attached to `this.$api`; see {@link Configuration}.
 	 *
 	 * @typeParam T - An object specifying a set of properties to add to the `$api` property.
 	 * @typeParam J - An object specifying a set of properties to add to the `$api.java` property.
@@ -222,7 +224,6 @@ namespace slime.internal.jrunscript.bootstrap {
 
 			rhino: {
 				classpath: slime.jrunscript.native.java.io.File
-				download: (version?: string) => slime.jrunscript.native.java.io.File
 				isPresent: () => boolean
 				running: () => slime.jrunscript.native.org.mozilla.javascript.Context
 			}

--- a/rhino/jrunscript/api.html
+++ b/rhino/jrunscript/api.html
@@ -15,51 +15,10 @@ END LICENSE
 	</head>
 	<body>
 		<div>
-			The <code>api.js</code> script configures a local jrunscript execution environment to contain APIs that are useful
-			for jrunscript-based scripts. Depending on how it is invoked, it may also execute other programs.
 		</div>
 		<div>
 			<h1>Context</h1>
-			<div>
-				The script is typically invoked with the global object as <code>this</code>, although it is compatible with using
-				any object for this purpose.
-			</div>
-			<div>
-				It can receive parameters if they are already attached to <code>this</code>:
-			</div>
 			<ul>
-				<li class="object">
-					<div class="name">$api</div>
-					<span>
-						An object providing configuration information to the script.
-						<strong>This object will be overwritten by the script itself.</strong>
-					</span>
-					<div class="label">has properties:</div>
-					<ul>
-						<li class="value">
-							<div class="name">script</div>
-							<span class="type">__TYPE__</span>
-							<span>__DESCRIPTION__</span>
-						</li>
-						<li class="value">
-							<div class="name">arguments</div>
-							<span class="type">__TYPE__</span>
-							<span>__DESCRIPTION__</span>
-						</li>
-						<li class="object">
-							<div class="name">engine</div>
-							<span>__DESCRIPTION__</span>
-							<div class="label">has properties:</div>
-							<ul>
-								<li class="value">
-									<div class="name">script</div>
-									<span class="type">__TYPE__</span>
-									<span>__DESCRIPTION__</span>
-								</li>
-							</ul>
-						</li>
-					</ul>
-				</li>
 				<li class="function">
 					<div class="name">readFile</div>
 					<span>

--- a/rhino/jrunscript/api.js
+++ b/rhino/jrunscript/api.js
@@ -1270,61 +1270,6 @@
 				nashorn: null,
 				rhino: $engine.classpath
 			}),
-			download: function(version) {
-				if (!version) version = "mozilla/1.7.15";
-				var sources = {
-					"mozilla/1.7.13": {
-						url: "https://github.com/mozilla/rhino/releases/download/Rhino1_7_13_Release/rhino-1.7.13.jar",
-						format: "jar"
-					},
-					"mozilla/1.7.14": {
-						url: "https://github.com/mozilla/rhino/releases/download/Rhino1_7_14_Release/rhino-1.7.14.jar",
-						format: "jar"
-					},
-					"mozilla/1.7.15": {
-						url: "https://github.com/mozilla/rhino/releases/download/Rhino1_7_15_Release/rhino-1.7.15.jar",
-						format: "jar"
-					}
-				};
-				var source = sources[version];
-				//	TODO	possibly not the right variable to use, but band-aiding to pass tests
-				if (/^https\:\/\/github\.com/.test(source.url) && $api.shell.environment.JSH_GITHUB_API_PROTOCOL == "http") {
-					source.url = source.url.replace("https://", "http://");
-				}
-				if (!source) throw new Error("No known way to retrieve Rhino version " + version);
-				var tmpdir = Packages.java.io.File.createTempFile("jsh-install",null);
-				tmpdir["delete"]();
-				tmpdir.mkdirs();
-				if (!tmpdir.exists()) {
-					throw new Error("Failed to create temporary file.");
-				}
-				var tmprhino = new Packages.java.io.File(tmpdir,"js.jar");
-				var _url = new Packages.java.net.URL(source.url);
-				Packages.java.lang.System.err.println("Downloading Rhino from " + _url);
-				var _connection = _url.openConnection();
-				$api.debug("Rhino download: opened connection " + _connection);
-				if (source.format == "dist") {
-					var _zipstream = new Packages.java.util.zip.ZipInputStream(_connection.getInputStream());
-					var _entry;
-					while(_entry = _zipstream.getNextEntry()) {
-						var name = String(_entry.getName());
-						var path = name.split("/");
-						if (path[1] == "js.jar") {
-							var out = new Packages.java.io.FileOutputStream(tmprhino);
-							$api.io.copy(_zipstream,out);
-						}
-					}
-					Packages.java.lang.System.err.println("Downloaded Rhino to " + tmprhino);
-					return tmprhino;
-				} else if (source.format == "jar") {
-					$api.debug("Rhino download: getting response code ...");
-					$api.debug("Rhino download status: " + _connection.getResponseCode());
-					$api.io.copy(_connection.getInputStream(), new Packages.java.io.FileOutputStream(tmprhino));
-					return tmprhino;
-				} else {
-					throw new Error("Unsupported Rhino format: version=" + version + " format=" + source.format);
-				}
-			},
 			isPresent: rhino.isPresent,
 			running: rhino.running
 		};


### PR DESCRIPTION
* Remove jrunscript bootstrap $api.rhino.download
* Remove jsh script Rhino installation code
* Change jsh launcher script to remove code that contradicted documentation and tried to install Rhino when Nashorn was not present