### PR TITLE
Fifty: refine multiplatform tests

### DIFF
--- a/js/object/Error.fifty.ts
+++ b/js/object/Error.fifty.ts
@@ -66,7 +66,7 @@ namespace slime.$api.old {
 				}
 			};
 
-			if (fifty.global.jsh) fifty.tests.platforms = fifty.jsh.platforms(fifty);
+			if (fifty.global.jsh) fifty.tests.platforms = fifty.jsh.platforms();
 		}
 	//@ts-ignore
 	)(fifty);

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -531,7 +531,7 @@ namespace slime.time {
 				fifty.load("old.fifty.ts");
 			}
 
-			if (fifty.global.jsh) fifty.tests.platforms = fifty.jsh.platforms(fifty);
+			if (fifty.global.jsh) fifty.tests.platforms = fifty.jsh.platforms();
 		}
 	//@ts-ignore
 	)(fifty);

--- a/loader/$api.fifty.ts
+++ b/loader/$api.fifty.ts
@@ -1286,7 +1286,7 @@ namespace slime.$api {
 				fifty.run(fifty.tests.exports);
 			}
 
-			if (fifty.jsh) fifty.tests.platforms = fifty.jsh.platforms(fifty);
+			if (fifty.jsh) fifty.tests.platforms = fifty.jsh.platforms();
 		}
 	//@ts-ignore
 	)(fifty)

--- a/loader/expression.fifty.ts
+++ b/loader/expression.fifty.ts
@@ -984,7 +984,7 @@ namespace slime {
 					}
 				}
 
-				if (jsh) fifty.tests.platforms = fifty.jsh.platforms(fifty);
+				if (jsh) fifty.tests.platforms = fifty.jsh.platforms();
 			}
 		//@ts-ignore
 		)( (function() { return this; })().Packages, fifty)

--- a/loader/old-loaders.fifty.ts
+++ b/loader/old-loaders.fifty.ts
@@ -291,7 +291,7 @@ namespace slime {
 				//	TODO	tests.thread, browser only?
 			};
 
-			if (fifty.jsh) tests.platforms = fifty.jsh.platforms(fifty);
+			if (fifty.jsh) tests.platforms = fifty.jsh.platforms();
 		}
 	//@ts-ignore
 	)(fifty);

--- a/tools/fifty/test.js
+++ b/tools/fifty/test.js
@@ -552,12 +552,17 @@
 				verify: function() {
 					return verify.apply(this,arguments);
 				},
-				jsh: (scopes.jsh) ? scopes.jsh({
+				jsh: void(0)
+			};
+
+			if (scopes.jsh) {
+				fifty.jsh = scopes.jsh({
 					loader: contexts.jsh.loader,
 					directory: contexts.jsh.directory,
-					filename: path
-				}) : void(0)
-			};
+					filename: path,
+					fifty: fifty
+				})
+			}
 
 			var scope = {
 				fifty: fifty,


### PR DESCRIPTION
* Add fifty.test.multiplatform to allow a definition to provide separate jsh and browser suites and run both
* Remove need to pass Fifty to fifty.jsh.platforms and fifty.jsh.multiplatform