### PR TITLE
Make it possible for Fifty multiplatform tests not to be named "suite"

### DIFF
--- a/js/object/Error.fifty.ts
+++ b/js/object/Error.fifty.ts
@@ -66,7 +66,7 @@ namespace slime.$api.old {
 				}
 			};
 
-			if (fifty.global.jsh) fifty.tests.platforms = fifty.jsh.platforms();
+			fifty.test.platforms();
 		}
 	//@ts-ignore
 	)(fifty);

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -577,7 +577,7 @@ namespace slime.time {
 				fifty.load("old.fifty.ts");
 			}
 
-			if (fifty.global.jsh) fifty.tests.platforms = fifty.jsh.platforms();
+			fifty.test.platforms();
 		}
 	//@ts-ignore
 	)(fifty);

--- a/loader/$api.fifty.ts
+++ b/loader/$api.fifty.ts
@@ -1286,7 +1286,7 @@ namespace slime.$api {
 				fifty.run(fifty.tests.exports);
 			}
 
-			if (fifty.jsh) fifty.tests.platforms = fifty.jsh.platforms();
+			fifty.test.platforms();
 		}
 	//@ts-ignore
 	)(fifty)

--- a/loader/expression.fifty.ts
+++ b/loader/expression.fifty.ts
@@ -984,7 +984,7 @@ namespace slime {
 					}
 				}
 
-				if (jsh) fifty.tests.platforms = fifty.jsh.platforms();
+				fifty.test.platforms();
 			}
 		//@ts-ignore
 		)( (function() { return this; })().Packages, fifty)

--- a/loader/old-loaders.fifty.ts
+++ b/loader/old-loaders.fifty.ts
@@ -291,7 +291,7 @@ namespace slime {
 				//	TODO	tests.thread, browser only?
 			};
 
-			if (fifty.jsh) tests.platforms = fifty.jsh.platforms();
+			fifty.test.platforms();
 		}
 	//@ts-ignore
 	)(fifty);

--- a/tools/fifty/scope-jsh.ts
+++ b/tools/fifty/scope-jsh.ts
@@ -49,6 +49,8 @@ namespace slime.fifty.test.kit {
 		//	TODO	revise so that Kit is not needed as an argument; in test.js we already have it
 
 		/**
+		 * @deprecated Replaced by `fifty.test.platforms()`.
+		 *
 		 * Creates a test that will run the test suite (the `suite` part) under `jsh`, and then again under the browser,
 		 * and pass only if both parts pass.
 		 */
@@ -58,13 +60,10 @@ namespace slime.fifty.test.kit {
 		 * Internal; used to implement `fifty.multiplatform` when running Fifty under `jsh`.
 		 */
 		multiplatform: (p: {
+			name: string
 			jsh?: () => void
 			browser?: () => void
-		}) => {
-			(): void
-			jsh?: () => void
-			browser?: () => void
-		}
+		}) => void
 	}
 }
 
@@ -196,7 +195,7 @@ namespace slime.fifty.test.internal.scope.jsh {
 										arguments: [
 											"test.browser",
 											file.relative(scope.filename).pathname,
-											"--part", "suite.browser"
+											"--part", suite.name + "." + "browser"
 										]
 									})
 								);
@@ -209,7 +208,7 @@ namespace slime.fifty.test.internal.scope.jsh {
 								browser: suite.browser
 							}
 						);
-						return rv;
+						fifty.tests[suite.name] = rv;
 					}
 				}
 			}

--- a/tools/fifty/test.fifty.ts
+++ b/tools/fifty/test.fifty.ts
@@ -58,19 +58,15 @@
  *
  * ### Running Fifty tests in both `jsh` and a browser
  *
- * To run a test suite that runs the same definition in both `jsh` and a browser:
- *
- * First, make sure the test suite defines a test - that runs under `jsh` only - using `fifty.jsh.platforms` (usually named
- * `fifty.tests.platforms` by convention), like this one:
- *
- * `if (fifty.jsh) fifty.tests.platforms = fifty.jsh.platforms(fifty);`
+ * To run a test suite that runs the same definition in both `jsh` and a browser, just invoke the `fifty.test.platforms()` method,
+ * which will create a test named `platforms` that runs the `suite` test in both `jsh` and a browser.
  *
  * Then, the suite can be run via:
  *
  * `./fifty test.jsh file.fifty.ts --part platforms`.
  *
  * This will run the platforms test under `jsh`, which first runs the suite under `jsh`, then launches a browser to run it
- * again. See {@link slime.fifty.test.Kit}, specifically the `jsh.platforms` method.
+ * again. See {@link slime.fifty.test.Kit}, specifically the `test.platforms` method.
  */
 namespace slime.fifty.test {
 	export type verify = slime.definition.verify.Verify
@@ -100,6 +96,12 @@ namespace slime.fifty.test {
 		(path: string, part?: string)
 	}
 
+	export interface MultiplatformTest {
+		(): void
+		jsh?: () => void
+		browser?: () => void
+	}
+
 	/**
 	 * The variable that appears as `fifty` within the scope of Fifty definition files when executing tests.
 	 */
@@ -125,13 +127,12 @@ namespace slime.fifty.test {
 			 * platform suites can be run individually.
 			 */
 			multiplatform: (p: {
+				name: string
 				jsh?: () => void
 				browser?: () => void
-			}) => {
-				(): void
-				jsh?: () => void
-				browser?: () => void
-			}
+			}) => void
+
+			platforms: () => void
 		}
 
 		evaluate: {

--- a/tools/fifty/test.js
+++ b/tools/fifty/test.js
@@ -535,7 +535,8 @@
 						};
 						return rv;
 					},
-					multiplatform: void(0)
+					multiplatform: void(0),
+					platforms: void(0)
 				},
 				evaluate: {
 					create: function(f,string) {
@@ -573,8 +574,21 @@
 						if (p.browser) p.browser();
 					};
 					rv.browser = p.browser;
-					return rv;
+					fifty.tests[p.name] = rv;
 				};
+			}
+
+			fifty.test.platforms = function() {
+				fifty.test.multiplatform({
+					name: "platforms",
+					jsh: function() {
+						fifty.run(fifty.tests.suite);
+					},
+					browser: function() {
+						//fifty.tests.suite();
+						fifty.run(fifty.tests.suite);
+					}
+				});
 			}
 
 			var scope = {


### PR DESCRIPTION
Also:
* Specify name when creating multiplatform test
* Implement fifty.test.platforms, which adds a test called "platforms" that runs the suite in both jsh and a browser