### PR TITLE
Add $api.fp.mapping.from

### DIFF
--- a/jrunscript/jsh/shell/jsh.fifty.ts
+++ b/jrunscript/jsh/shell/jsh.fifty.ts
@@ -845,18 +845,18 @@ namespace slime.jsh.shell {
 			fifty.tests.exports.jsh.shells = function() {
 				var unbuilt = run(test.shells.unbuilt().invoke({
 					script: script,
-					environment: $api.fp.Mapping.all(environment),
+					environment: $api.fp.mapping.all(environment),
 					stdio: stdio
 				}));
 
 				var built = run(test.shells.built(false).invoke({
 					script: script,
-					environment: $api.fp.Mapping.all(environment),
+					environment: $api.fp.mapping.all(environment),
 					stdio: stdio
 				}));
 
 				var packaged = run(test.shells.packaged(script).invoke({
-					environment: $api.fp.Mapping.all(environment),
+					environment: $api.fp.mapping.all(environment),
 					stdio: stdio
 				}));
 

--- a/jrunscript/jsh/tools/install/rhino.jsh.js
+++ b/jrunscript/jsh/tools/install/rhino.jsh.js
@@ -20,7 +20,7 @@
 					$api.fp.world.Means.now({
 						means: jsh.shell.tools.rhino.require.world(),
 						order: {
-							replace: $api.fp.Mapping.all(p.options.replace),
+							replace: $api.fp.mapping.all(p.options.replace),
 							version: p.options.version
 						},
 						handlers: {

--- a/jrunscript/tools/install/module.fifty.ts
+++ b/jrunscript/tools/install/module.fifty.ts
@@ -328,7 +328,7 @@ namespace slime.jrunscript.tools.install {
 						function() {
 							var download = subject.Distribution.from.file({
 								url: URL,
-								prefix: $api.fp.Mapping.all("prefix/")
+								prefix: $api.fp.mapping.all("prefix/")
 							});
 
 							verify(download).url.is("http://example.com/foo/bar.tar.gz");

--- a/loader/$api-Function.fifty.ts
+++ b/loader/$api-Function.fifty.ts
@@ -172,7 +172,38 @@ namespace slime.$api.fp {
 	)(fifty);
 
 	export namespace exports {
-		export interface Mapping {
+		export interface mapping {
+			from: {
+				value: <P,R>(r: R) => (p: P) => R
+				thunk: <P,R>(thunk: fp.Thunk<R>) => Mapping<P,R>
+			}
+		}
+
+		(
+			function(
+				fifty: slime.fifty.test.Kit
+			) {
+				const { verify } = fifty;
+				const { $api } = fifty.global;
+
+				fifty.tests.exports.mapping.from = function() {
+					const value = 2;
+					const thunkValue = 3;
+
+					const byValue = $api.fp.mapping.from.value(value);
+					const byThunk = $api.fp.mapping.from.thunk( () => thunkValue );
+
+					verify(byValue(8)).is(value);
+					verify(byValue(10)).is(value);
+					verify(byThunk(9)).is(thunkValue);
+					verify(byThunk(11)).is(thunkValue);
+				}
+			}
+		//@ts-ignore
+		)(fifty);
+
+		export interface mapping {
+			/** @deprecated Use `from.value()`. */
 			all: <P,R>(r: R) => (p: P) => R
 		}
 	}
@@ -181,7 +212,7 @@ namespace slime.$api.fp {
 		/**
 		 * APIs related to {@link Mapping}s.
 		 */
-		Mapping: exports.Mapping
+		mapping: exports.mapping
 
 
 		/**
@@ -202,12 +233,12 @@ namespace slime.$api.fp {
 	}
 
 	export namespace exports {
-		export interface Mapping {
+		export interface mapping {
 			/**
-			 * Given a {@link Mapping}, creates a `Mapping` that, given an argument, returns a {@link Thunk} that will, when
+			 * Given a {@link mapping}, creates a `Mapping` that, given an argument, returns a {@link Thunk} that will, when
 			 * invoked, invoke the underlying mapping with that argument and return the result.
 			 */
-			thunk: <P,R>(p: fp.Mapping<P,R>) => fp.Mapping<P,Thunk<R>>
+			thunks: <P,R>(p: fp.Mapping<P,R>) => fp.Mapping<P,Thunk<R>>
 		}
 
 		(
@@ -217,10 +248,10 @@ namespace slime.$api.fp {
 				const { verify } = fifty;
 				const { $api } = fifty.global;
 
-				fifty.tests.exports.mapping.thunk = function() {
+				fifty.tests.exports.mapping.thunks = function() {
 					var double: fp.Mapping<number,number> = (n: number) => n*2;
 
-					var t1 = $api.fp.Mapping.thunk(double)(2);
+					var t1 = $api.fp.mapping.thunks(double)(2);
 
 					verify(t1()).is(4);
 				}
@@ -418,7 +449,7 @@ namespace slime.$api.fp {
 	//			analogous to $api.fp.now, with first argument as function, or maybe all arguments as functions?
 
 	export namespace exports {
-		export interface Mapping {
+		export interface mapping {
 			properties: <P,R>(p: {
 				[k in keyof R]: (p: P) => R[k]
 			}) => (p: P) => R
@@ -434,7 +465,7 @@ namespace slime.$api.fp {
 				fifty.tests.exports.mapping.properties = function() {
 					var x = $api.fp.now.map(
 						2,
-						$api.fp.Mapping.properties({
+						$api.fp.mapping.properties({
 							single: function(d) { return d; },
 							double: function(d) { return d*2 },
 							triple: function(d) { return d*3 }
@@ -451,7 +482,7 @@ namespace slime.$api.fp {
 	}
 
 	export namespace exports {
-		export interface Mapping {
+		export interface mapping {
 			/**
 			 * Given a Mapping invocation (consisting of a mapping and an argument), return the result of the mapping for the
 			 * argument.

--- a/loader/$api-Function.js
+++ b/loader/$api-Function.js
@@ -242,13 +242,25 @@
 					return rv;
 				}
 			},
-			Mapping: {
-				all: function(r) {
+			mapping: {
+				from: {
+					value: function(r) {
+						return function(p) {
+							return r;
+						}
+					},
+					thunk: function(f) {
+						return function(p) {
+							return f();
+						}
+					}
+				},
+				all: $context.deprecate(function(r) {
 					return function(p) {
 						return r;
 					}
-				},
-				thunk: function(mapping) {
+				}),
+				thunks: function(mapping) {
 					return function(p) {
 						return function() {
 							return mapping(p);

--- a/rhino/file/wo-directory.fifty.ts
+++ b/rhino/file/wo-directory.fifty.ts
@@ -285,7 +285,7 @@ namespace slime.jrunscript.file.exports.location {
 					function(location) {
 						return {
 							target: location,
-							descend: $api.fp.Mapping.all(false)
+							descend: $api.fp.mapping.all(false)
 						}
 					},
 					$api.fp.world.Sensor.old.mapping({ sensor: subject.Location.directory.list.world }),
@@ -297,7 +297,7 @@ namespace slime.jrunscript.file.exports.location {
 					function(location) {
 						return {
 							target: location,
-							descend: $api.fp.Mapping.all(true)
+							descend: $api.fp.mapping.all(true)
 						}
 					},
 					$api.fp.world.Sensor.old.mapping({ sensor: subject.Location.directory.list.world }),

--- a/rhino/file/wo-directory.js
+++ b/rhino/file/wo-directory.js
@@ -109,7 +109,7 @@
 					};
 
 					return function(events) {
-						var descend = (p && p.descend) ? p.descend : $api.fp.Mapping.all(false);
+						var descend = (p && p.descend) ? p.descend : $api.fp.mapping.all(false);
 						var array = process(p.target,descend,events);
 						return $api.fp.Stream.from.array(array);
 					}
@@ -257,7 +257,7 @@
 
 		var list_iterate_simple = $api.fp.now(
 			$api.fp.world.Sensor.old.mapping({ sensor: wo.directory.list }),
-			$api.fp.curry({ descend: $api.fp.Mapping.all(false) }),
+			$api.fp.curry({ descend: $api.fp.mapping.all(false) }),
 			$api.fp.flatten("target")
 		);
 
@@ -289,7 +289,7 @@
 								return function(location) {
 									return wo.directory.list({
 										target: location,
-										descend: (configuration && configuration.descend) ? configuration.descend : $api.fp.Mapping.all(false)
+										descend: (configuration && configuration.descend) ? configuration.descend : $api.fp.mapping.all(false)
 									});
 								}
 							},
@@ -299,7 +299,7 @@
 										sensor: wo.directory.list,
 										subject: {
 											target: location,
-											descend: (configuration && configuration.descend) ? configuration.descend : $api.fp.Mapping.all(false)
+											descend: (configuration && configuration.descend) ? configuration.descend : $api.fp.mapping.all(false)
 										}
 									});
 								}

--- a/rhino/file/wo.js
+++ b/rhino/file/wo.js
@@ -148,7 +148,7 @@
 
 		var lastModifiedSimple = $api.fp.pipe(
 			asLocation,
-			$api.fp.Mapping.properties({
+			$api.fp.mapping.properties({
 				argument: function(p) { return { pathname: p.pathname }},
 				partial: $api.fp.pipe(
 					$api.fp.property("filesystem"),
@@ -156,14 +156,14 @@
 					$api.fp.world.Sensor.mapping()
 				)
 			}),
-			$api.fp.Mapping.properties({
+			$api.fp.mapping.properties({
 				argument: $api.fp.property("argument"),
 				mapping: $api.fp.pipe(
 					$api.fp.property("partial"),
 					$api.fp.Partial.impure.exception( function(p) { return new Error("Could not obtain last modified date for " + p.pathname); })
 				)
 			}),
-			$api.fp.Mapping.invocation
+			$api.fp.mapping.invocation
 		)
 
 		var Location = {
@@ -551,8 +551,8 @@
 						pathname: temporary({ directory: false, remove: true }),
 						location: $api.fp.impure.Input.map(
 							temporary({ directory: false, remove: true }),
-							$api.fp.Mapping.properties({
-								filesystem: $api.fp.Mapping.all(world),
+							$api.fp.mapping.properties({
+								filesystem: $api.fp.mapping.all(world),
 								pathname: $api.fp.identity
 							})
 						),

--- a/rhino/tools/git/commands.fifty.ts
+++ b/rhino/tools/git/commands.fifty.ts
@@ -341,7 +341,7 @@ namespace slime.jrunscript.tools.git {
 				fixtures.edit(
 					child,
 					"a",
-					$api.fp.Mapping.all("a")
+					$api.fp.mapping.all("a")
 				);
 				child.api.command(add).argument({ files: ["a"] }).run();
 				child.api.command(fixtures.commands.commit).argument({ message: "it" }).run();
@@ -375,7 +375,7 @@ namespace slime.jrunscript.tools.git {
 				fixtures.edit(
 					grandchild,
 					"file",
-					$api.fp.Mapping.all("file")
+					$api.fp.mapping.all("file")
 				);
 				grandchild.api.command(add).argument({ files: ["file"] }).run();
 				grandchild.api.command(fixtures.commands.commit).argument({ message: "message" }).run();

--- a/rhino/tools/maven/module.fifty.ts
+++ b/rhino/tools/maven/module.fifty.ts
@@ -478,7 +478,7 @@ namespace slime.jrunscript.tools.maven {
 
 				var atStart = subject.xml.edit.insert.element({
 					parent: jsh.document.Document.element,
-					after: $api.fp.Mapping.all(null),
+					after: $api.fp.mapping.all(null),
 					lines: 1,
 					indent: "  ",
 					element: foo

--- a/tools/code/module.fifty.ts
+++ b/tools/code/module.fifty.ts
@@ -117,7 +117,7 @@ namespace slime.tools.code {
 						root: jsh.shell.PWD.pathname.os.adapt(),
 						submodules: true,
 						excludes: {
-							isSource: $api.fp.Mapping.all($api.fp.Maybe.from.some(true))
+							isSource: $api.fp.mapping.all($api.fp.Maybe.from.some(true))
 						}
 					}),
 					{


### PR DESCRIPTION
Also:
* rename $api.fp.Mapping to $api.fp.mapping to be consistent with Thunk (and seemingly better convention)
* Deprecate $api.fp.mapping.all at compile-time and runtime