### PR TITLE
Resolve #1927: Update Rhino to 1.8.0

### DIFF
--- a/README.fifty.ts
+++ b/README.fifty.ts
@@ -38,9 +38,15 @@
  *
  * ##### JVM JavaScript engine
  *
- * The test suite executes tests primarily with **Rhino {@include ./local/typedoc/dependencies.md#rhino.version}**, with some tests for the **Nashorn** engine; for JDK versions
+ * The test suite executes tests primarily with **Rhino {@include ./local/typedoc/dependencies.md#rhino.version.number}**. Since Rhino,
+ * starting with version 1.8.0, does not support JDK 8, Rhino {@include ./local/typedoc/dependencies.md#rhino.version.jdk8.number} is used
+ * for JDK 8.
+ *
+ * THe test suite also has some tests for the **Nashorn** engine; for JDK versions
  * including Nashorn, the **built-in JDK 8-14 Nashorn** is used, while for JDK versions subsequent to Nashorn's removal, standalone
- * **Nashorn {@include ./local/typedoc/dependencies.md#nashorn.standalone.version}** is used. **GraalVM** is not yet supported, although
+ * **Nashorn {@include ./local/typedoc/dependencies.md#nashorn.standalone.version}** is used.
+ *
+ * **GraalVM** is not yet supported, although
  * [development is underway](https://github.com/davidpcaldwell/slime/projects/10).
  *
  * ##### Servlet containers

--- a/contributor/dependencies/dependencies.md
+++ b/contributor/dependencies/dependencies.md
@@ -10,6 +10,10 @@
 {rhino.version.number}
 <!-- #endregion rhino.version.number -->
 
+<!-- #region rhino.version.jdk8.number -->
+{rhino.version.jdk8.number}
+<!-- #endregion rhino.version.jdk8.number -->
+
 <!-- #region nashorn.standalone.version -->
 {nashorn.standalone.version}
 <!-- #endregion nashorn.standalone.version -->

--- a/contributor/dependencies/module.fifty.ts
+++ b/contributor/dependencies/module.fifty.ts
@@ -6,6 +6,10 @@
 
 namespace slime.project.dependencies {
 	export interface Context {
+		java: {
+			version: string
+		}
+
 		library: {
 			file: slime.jrunscript.file.Exports
 		}
@@ -14,9 +18,14 @@ namespace slime.project.dependencies {
 	export interface Exports {
 		data: {
 			rhino: {
-				version: {
+				version: slime.$api.fp.Thunk<{
 					number: string
 					id: string
+				}>
+
+				versions: {
+					jdk8: string
+					default: string
 				}
 
 				sources: {
@@ -50,10 +59,14 @@ namespace slime.project.dependencies {
 
 	(
 		function(
+			Packages: slime.jrunscript.Packages,
 			fifty: slime.fifty.test.Kit
 		) {
 			const code: Script = fifty.$loader.script("module.js");
 			const subject = code({
+				java: {
+					version: String(Packages.java.lang.System.getProperty("java.version"))
+				},
 				library: {
 					file: fifty.global.jsh.file
 				}
@@ -68,7 +81,7 @@ namespace slime.project.dependencies {
 			}
 		}
 	//@ts-ignore
-	)(fifty);
+	)(Packages,fifty);
 
 	export type Script = slime.loader.Script<Context,Exports>
 }

--- a/contributor/dependencies/module.js
+++ b/contributor/dependencies/module.js
@@ -23,9 +23,22 @@
 				// jrunscript/jsh/tools/install/plugin.jsh.fifty.ts
 				// jrunscript/jsh/tools/install/plugin.jsh.js
 
-				version: {
-					number: "1.8.0",
-					id: "mozilla/1.8.0"
+				version: function() {
+					if (/^1\.8/.test($context.java.version)) {
+						return {
+							number: "1.7.15",
+							id: "mozilla/1.7.15"
+						};
+					} else {
+						return {
+							number: "1.8.0",
+							id: "mozilla/1.8.0"
+						};
+					}
+				},
+				versions: {
+					jdk8: "1.7.15",
+					default: "1.8.0"
 				},
 				sources: {
 					"mozilla/1.7.13": {
@@ -86,7 +99,8 @@
 		var getTypedocIncludes = $api.fp.thunk.value(
 			//	TODO	figure out better way to manage retrieval of non-code content; using older loader constructs for now
 			$loader.get("dependencies.md").read(String),
-			function(s) { return s.replace(/\{rhino\.version\.number}/, data.rhino.version.number ) },
+			function(s) { return s.replace(/\{rhino\.version\.number}/, data.rhino.versions.default ) },
+			function(s) { return s.replace(/\{rhino\.version\.jdk8\.number}/, data.rhino.versions.jdk8 ) },
 			function(s) { return s.replace(/\{nashorn\.standalone\.version\}/, data.nashorn.standalone.version ) }
 		);
 

--- a/contributor/dependencies/module.js
+++ b/contributor/dependencies/module.js
@@ -24,8 +24,8 @@
 				// jrunscript/jsh/tools/install/plugin.jsh.js
 
 				version: {
-					number: "1.7.15",
-					id: "mozilla/1.7.15"
+					number: "1.8.0",
+					id: "mozilla/1.8.0"
 				},
 				sources: {
 					"mozilla/1.7.13": {
@@ -38,6 +38,10 @@
 					},
 					"mozilla/1.7.15": {
 						url: "https://github.com/mozilla/rhino/releases/download/Rhino1_7_15_Release/rhino-1.7.15.jar",
+						format: "jar"
+					},
+					"mozilla/1.8.0": {
+						url: "https://repo1.maven.org/maven2/org/mozilla/rhino-all/1.8.0/rhino-all-1.8.0.jar",
 						format: "jar"
 					}
 				}

--- a/contributor/dependencies/plugin.jsh.js
+++ b/contributor/dependencies/plugin.jsh.js
@@ -7,12 +7,13 @@
 //@ts-check
 (
 	/**
+	 * @param { slime.jrunscript.Packages } Packages
 	 * @param { slime.$api.Global } $api
 	 * @param { slime.jsh.Global } jsh
 	 * @param { slime.Loader } $loader
 	 * @param { slime.jsh.plugin.Scope["plugin"] } plugin
 	 */
-	function($api,jsh,$loader,plugin) {
+	function(Packages,$api,jsh,$loader,plugin) {
 		plugin({
 			isReady: function() { return Boolean(jsh.file); },
 			load: function() {
@@ -26,6 +27,9 @@
 				/** @type { slime.project.dependencies.Script } */
 				var code = $loader.script("module.js");
 				jsh.project.dependencies = code({
+					java: {
+						version: String(Packages.java.lang.System.getProperty("java.version"))
+					},
 					library: {
 						file: jsh.file
 					}
@@ -34,4 +38,4 @@
 		});
 	}
 //@ts-ignore
-)($api,jsh,$loader,plugin);
+)(Packages,$api,jsh,$loader,plugin);

--- a/contributor/devcontainer/check
+++ b/contributor/devcontainer/check
@@ -5,11 +5,15 @@
 #
 #	END LICENSE
 
+#	Specify SLIME_WF_JDK_VERSION=n to run with different JDK; for example, SLIME_WF_JDK_VERSION=8
+
 SLIME="$(dirname $0)/../.."
+
 rm -Rf ${SLIME}/local/*
+
 ${SLIME}/jsh --add-jdk-8
 ${SLIME}/jsh --add-jdk-11
 ${SLIME}/jsh --add-jdk-17
 ${SLIME}/jsh --add-jdk-21
-#rm -Rvf ${SLIME}/local/jsh/lib/node ${SLIME}/node_modules
+
 env JSH_LAUNCHER_BASH_DEBUG=1 SLIME_WF_BASH_DEBUG=1 ${SLIME}/wf check --docker >${SLIME}/local/devcontainer-check.txt 2>&1

--- a/contributor/devcontainer/check
+++ b/contributor/devcontainer/check
@@ -7,5 +7,9 @@
 
 SLIME="$(dirname $0)/../.."
 rm -Rf ${SLIME}/local/*
+${SLIME}/jsh --add-jdk-8
+${SLIME}/jsh --add-jdk-11
+${SLIME}/jsh --add-jdk-17
+${SLIME}/jsh --add-jdk-21
 #rm -Rvf ${SLIME}/local/jsh/lib/node ${SLIME}/node_modules
 env JSH_LAUNCHER_BASH_DEBUG=1 SLIME_WF_BASH_DEBUG=1 ${SLIME}/wf check --docker >${SLIME}/local/devcontainer-check.txt 2>&1

--- a/jrunscript/jsh/launcher/test/scenario.jsh.js
+++ b/jrunscript/jsh/launcher/test/scenario.jsh.js
@@ -31,6 +31,7 @@
 							return Boolean(Packages.org.mozilla.javascript.Context.getCurrentContext());
 						})()
 					};
+					rv.version = (rv.running) ? String(Packages.org.mozilla.javascript.Context.getCurrentContext().getImplementationVersion()) : null;
 					rv.optimization = (rv.running) ? Number(Packages.org.mozilla.javascript.Context.getCurrentContext().getOptimizationLevel()) : null;
 					rv.classpath = (jsh.shell.rhino && jsh.shell.rhino.classpath) ? String(jsh.shell.rhino.classpath) : null;
 					return rv;

--- a/jrunscript/jsh/launcher/test/suite.fifty.ts
+++ b/jrunscript/jsh/launcher/test/suite.fifty.ts
@@ -20,6 +20,7 @@ namespace slime.jsh.internal.launcher.test {
 		tmp: string
 		rhino: {
 			running: boolean
+			version: string
 			optimization: number
 			classpath: string
 		}

--- a/jrunscript/jsh/tools/install/plugin.jsh.fifty.ts
+++ b/jrunscript/jsh/tools/install/plugin.jsh.fifty.ts
@@ -103,9 +103,10 @@ namespace slime.jsh.shell.tools {
 			/**
 			 * A named version of Rhino to download and install; ignored if `local` is specified. Available versions include:
 			 *
-			 * * mozilla/1.7.15 (the default, and only tested/supported version)
-			 * * mozilla/1.7.14
-			 * * mozilla/1.7.13
+			 * * mozilla/1.8.0 (the default)
+			 * * mozilla/1.7.15 (the default for JDK 8)
+			 * * mozilla/1.7.14 (unsupported)
+			 * * mozilla/1.7.13 (unsupported)
 			 */
 			version?: string
 
@@ -190,6 +191,7 @@ namespace slime.jsh.shell.tools {
 	export namespace rhino {
 		(
 			function(
+				Packages: slime.jrunscript.Packages,
 				fifty: slime.fifty.test.Kit
 			) {
 				const { verify } = fifty;
@@ -200,6 +202,9 @@ namespace slime.jsh.shell.tools {
 						function() {
 							const script: slime.project.dependencies.Script = fifty.$loader.script("../../../../contributor/dependencies/module.js");
 							return script({
+								java: {
+									version: String(Packages.java.lang.System.getProperty("java.version"))
+								},
 								library: {
 									file: jsh.file
 								}
@@ -264,7 +269,7 @@ namespace slime.jsh.shell.tools {
 						verify(captor).captured[0].type.is("console");
 						verify(captor).captured[0].evaluate(toConsoleEvent).detail.is("Replacing Rhino at " + lib.getRelativePath("js.jar") + " ...");
 						verify(captor).captured[1].type.is("console");
-						verify(captor).captured[1].evaluate(toConsoleEvent).detail.is("Installing Rhino version " + dependencies.data.rhino.version.id + " to " + lib.getRelativePath("js.jar") + " ...");
+						verify(captor).captured[1].evaluate(toConsoleEvent).detail.is("Installing Rhino version " + dependencies.data.rhino.version().id + " to " + lib.getRelativePath("js.jar") + " ...");
 						//verify(lib).getFile("js.jar").evaluate(readFile).is.not("original");
 						verify(captor.captured.type("installed")).length.is(1);
 						lib.getFile("js.jar").remove();
@@ -276,7 +281,7 @@ namespace slime.jsh.shell.tools {
 						verify(captor).captured[0].type.is("console");
 						verify(captor).captured[0].evaluate(toConsoleEvent).detail.is("No Rhino at " + lib.getRelativePath("js.jar") + "; installing ...");
 						verify(captor).captured[1].type.is("console");
-						verify(captor).captured[1].evaluate(toConsoleEvent).detail.is("Installing Rhino version " + dependencies.data.rhino.version.id + " to " + lib.getRelativePath("js.jar") + " ...");
+						verify(captor).captured[1].evaluate(toConsoleEvent).detail.is("Installing Rhino version " + dependencies.data.rhino.version().id + " to " + lib.getRelativePath("js.jar") + " ...");
 						verify(lib).getFile("js.jar").is.not(null);
 						verify(captor.captured.type("installed")).length.is(1);
 						lib.getFile("js.jar").remove();
@@ -296,7 +301,7 @@ namespace slime.jsh.shell.tools {
 				}
 			}
 		//@ts-ignore
-		)(fifty);
+		)(Packages,fifty);
 	}
 
 	export interface Exports {

--- a/jrunscript/jsh/tools/install/plugin.jsh.js
+++ b/jrunscript/jsh/tools/install/plugin.jsh.js
@@ -89,7 +89,7 @@
 									} else {
 										events.fire("console", "No Rhino at " + ooLib.getRelativePath("js.jar") + "; installing ...");
 									}
-									var version = p.version || dependencies.data.rhino.version.id;
+									var version = p.version || dependencies.data.rhino.version().id;
 									events.fire("console", "Installing Rhino version " + version + " to " + ooLib.getRelativePath("js.jar") + " ...");
 									var response = $api.fp.world.Question.now({
 										question: client({

--- a/wf.js
+++ b/wf.js
@@ -7,13 +7,14 @@
 //@ts-check
 (
 	/**
+	 * @param { slime.jrunscript.Packages } Packages
 	 * @param { slime.$api.Global } $api
 	 * @param { slime.jsh.Global } jsh
 	 * @param { slime.jsh.wf.cli.Context } $context
 	 * @param { slime.Loader } $loader
 	 * @param { slime.project.wf.Interface } $exports
 	 */
-	function($api,jsh,$context,$loader,$exports) {
+	function(Packages,$api,jsh,$context,$loader,$exports) {
 		var $$api = {
 			Function: {
 				switch: function() {
@@ -488,6 +489,9 @@
 					/** @type { slime.project.dependencies.Script } */
 					var code = $loader.script("contributor/dependencies/module.js");
 					var api = code({
+						java: {
+							version: String(Packages.java.lang.System.getProperty("java.version"))
+						},
 						library: {
 							file: jsh.file
 						}
@@ -943,4 +947,4 @@
 		}
 	}
 //@ts-ignore
-)($api,jsh,$context,$loader,$exports);
+)(Packages,$api,jsh,$context,$loader,$exports);


### PR DESCRIPTION
* Fix tests that check optimization level now that 9 is the default for anything other than interpreted mode. See https://github.com/mozilla/rhino/pull/1754