### PR TITLE
Resolve #1295: Link in slime.fifty.test namespace comment to tools/fifty/test-browser.jsh.js does not work when embedded

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,6 +41,7 @@
 		}
 	},
 	"service": "local",
+	"runServices": ["local"],
 	"workspaceFolder": "/slime",
 	"postCreateCommand": "/bin/bash .devcontainer/post-create-command.bash"
 }

--- a/.devcontainer/post-create-command.bash
+++ b/.devcontainer/post-create-command.bash
@@ -10,3 +10,5 @@ ${SLIME}/jsh --add-jdk-8
 ${SLIME}/jsh --add-jdk-11
 ${SLIME}/jsh --add-jdk-17
 ${SLIME}/jsh --add-jdk-21
+
+apt update && apt install chromium -y

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"label": "(Local only) Documentation: Show",
+			"label": "Documentation: Show",
 			"detail": "Serves the project documentation and opens a browser to view it",
 			"type": "shell",
 			"command": "./wf documentation",
@@ -135,7 +135,7 @@
 			"problemMatcher": []
 		},
 		{
-			"label": "(Local only) Fifty (browser): Run wip() Test in Current File",
+			"label": "Fifty (browser): Run wip() Test in Current File",
 			"type": "shell",
 			"command": "./fifty",
 			"args": [

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,6 @@ x-base-box: &box
     depends_on:
       - chrome
       - firefox
-      - novnc
 
 x-base-test: &test
     <<: *box
@@ -60,6 +59,10 @@ services:
   # (to the local/ subdirectory, like installing JDKs, Rhino, Tomcat, and so forth) will persist between runs.
   #
   # Also used by the devcontainer implementation.
+  #
+  # The primary user interface for the container is the novnc interface, which can be reached at http://localhost:7902/vnc.html.
+  # The chrome and firefox services are still started so that the container can emulate the CI tests for debugging CI-only failures
+  # via the contributor/devcomtainer/check script.
   local:
     <<: *box
     environment:
@@ -77,6 +80,10 @@ services:
       - ./local/docker/home:/root
     ports:
       - 8000:8000
+    depends_on:
+      - novnc
+      - chrome
+      - firefox
 
   chrome:
     image: seleniarm/standalone-chromium
@@ -92,6 +99,9 @@ services:
     image: theasp/novnc:latest
     environment:
       RUN_XTERM: no
+    env_file:
+      # Can specify DISPLAY_WIDTH and DISPLAY_HEIGHT for the desktop in the below file; defaults are 1024 and 768.
+      - local/devcontainer/novnc.env
     ports:
       - 7902:8080
 

--- a/rhino/shell/browser/chrome.fifty.ts
+++ b/rhino/shell/browser/chrome.fifty.ts
@@ -104,6 +104,7 @@ namespace slime.jrunscript.shell.browser.internal.chrome {
 		}
 		HOME: slime.jrunscript.file.Directory
 		TMPDIR: slime.jrunscript.file.Directory
+		USER: string
 		environment: any
 	}
 
@@ -127,6 +128,7 @@ namespace slime.jrunscript.shell.browser.internal.chrome {
 			return script({
 				HOME: fifty.global.jsh.shell.HOME,
 				TMPDIR: fifty.global.jsh.shell.TMPDIR,
+				USER: fifty.global.jsh.shell.USER,
 				api: {
 					java: fifty.global.jsh.java,
 					file: fifty.global.jsh.file

--- a/rhino/shell/browser/chrome.js
+++ b/rhino/shell/browser/chrome.js
@@ -176,6 +176,9 @@
 				if (m.arguments) {
 					args.push.apply(args,m.arguments);
 				}
+				if ($context.USER == "root") {
+					args.push("--no-sandbox");
+				}
 				if (m.app) {
 					if (m.position || m.size) {
 						var script = [];
@@ -450,6 +453,13 @@
 						return new Chrome({
 							program: $context.api.file.Pathname("/opt/google/chrome/chrome").file,
 							user: $context.HOME.getSubdirectory(".config/google-chrome")
+						});
+					}
+
+					if ($context.api.file.Pathname("/usr/bin/chromium").file) {
+						return new Chrome({
+							program: $context.api.file.Pathname("/usr/bin/chromium").file,
+							user: $context.HOME.getSubdirectory(".config/chromium")
 						});
 					}
 				}

--- a/rhino/shell/browser/module.fifty.ts
+++ b/rhino/shell/browser/module.fifty.ts
@@ -15,6 +15,7 @@ namespace slime.jrunscript.shell.browser {
 		run: slime.jrunscript.shell.internal.run.old.Exports["run"]
 		HOME: slime.jrunscript.file.Directory
 		TMPDIR: slime.jrunscript.file.Directory
+		USER: string
 		environment: any
 	}
 
@@ -28,6 +29,7 @@ namespace slime.jrunscript.shell.browser {
 				os: jsh.shell.os,
 				HOME: jsh.shell.HOME,
 				TMPDIR: jsh.shell.TMPDIR,
+				USER: jsh.shell.USER,
 				run: jsh.shell.run,
 				environment: {},
 				api: {
@@ -184,6 +186,7 @@ namespace slime.jrunscript.shell.browser {
 				os: jsh.shell.os,
 				HOME: jsh.shell.HOME,
 				TMPDIR: jsh.shell.TMPDIR,
+				USER: jsh.shell.USER,
 				run: jsh.shell.run,
 				environment: {},
 				api: {

--- a/rhino/shell/module.js
+++ b/rhino/shell/module.js
@@ -660,11 +660,13 @@
 			browser: void(0),
 			inject: {
 				httpd: function(module) {
+					/** @type { slime.jrunscript.shell.browser.Script } */
 					var script = $loader.script("browser/module.js");
 					var exports = script({
 						os: $exports.os,
 						HOME: $exports.HOME,
 						TMPDIR: $exports.TMPDIR,
+						USER: $exports.USER,
 						run: scripts.run_old.run,
 						environment: environment,
 						api: {

--- a/tools/fifty/documentation-updater.js
+++ b/tools/fifty/documentation-updater.js
@@ -82,6 +82,7 @@
 				if (exit.status == 0) {
 					events.fire("finished", object);
 				} else {
+					events.fire("stderr", { out: tmp.pathname, line: "TypeDoc exit code: " + exit.status });
 					events.fire("errored", object);
 				}
 			}

--- a/tools/fifty/test.fifty.ts
+++ b/tools/fifty/test.fifty.ts
@@ -53,8 +53,9 @@
  * `/fifty test.browser [--chrome:data pathname] [--base pathname] file.fifty.ts [--part part] [--interactive] [--chrome:debug:vscode]`
  *
  * This invokes the underlying `tools/fifty/test-browser.jsh.js` script. The
- * [script's code](../src/tools/fifty/test-browser.jsh.js?as=text) defines the semantics of the
- * command-line arguments.
+ * script itself, included below, defines the semantics of the command-line arguments.
+ *
+ * {@includeCode ./test-browser.jsh.js}
  *
  * ### Running Fifty tests in both `jsh` and a browser
  *


### PR DESCRIPTION
* Inline the code for the script and change documentation to indicate that

Also:
* Allow browsing documentation in devcontainer
* Revise dependencies in Docker Compose
* Allow NoVNC to be configured via environment file