### PR TITLE
Resolve #1490: Make standalone Nashorn handling DRY

### DIFF
--- a/contributor/suite.jsh.js
+++ b/contributor/suite.jsh.js
@@ -174,8 +174,7 @@
 				var launch = (jsh.shell.jsh.home) ? [jsh.shell.jsh.home.getRelativePath("jsh.js").toString()] : [jsh.shell.jsh.src.getRelativePath("rhino/jrunscript/api.js").toString(), "jsh"];
 				(
 					function addNashornBootstrapLibraries() {
-						//	TODO	Not DRY: Should parse out of ./jsh, like jrunscript/jsh/shell/jsh.js does
-						var names = ["asm","asm-commons","asm-tree","asm-util","nashorn"];
+						var names = jsh.internal.bootstrap.nashorn.dependencies.names.concat(["nashorn"]);
 						//	TODO	Should only be used for versions of Java that need it
 						if (jsh.shell.jsh.home && jsh.shell.jsh.home.getFile("lib/nashorn.jar")) {
 							launch = [

--- a/jrunscript/jsh/_.fifty.ts
+++ b/jrunscript/jsh/_.fifty.ts
@@ -152,7 +152,7 @@ namespace slime.jsh {
  * #### `slime.js`
  *
  * This script, also apparently used in the `jsh` build process, creates an `$api.slime` object of type {@link
- * slime.internal.jsh.launcher.Slime} object providing SLIME-specific functionality.
+ * slime.jsh.internal.launcher.Slime} object providing SLIME-specific functionality.
  *
  * ### Packaged application launcher (`inonit.script.jsh.launcher.Main`)
  *

--- a/jrunscript/jsh/etc/api.js
+++ b/jrunscript/jsh/etc/api.js
@@ -69,6 +69,7 @@
 		"rhino/ip/",
 		"jrunscript/jsh/shell/",
 		"jrunscript/jsh/script/",
+		"rhino/jrunscript/",
 	].forEach(function(path) {
 		components.add(path, { jsh: { api: true, module: true }});
 	});

--- a/jrunscript/jsh/etc/build.jsh.js
+++ b/jrunscript/jsh/etc/build.jsh.js
@@ -306,8 +306,7 @@
 		}
 
 		if (SLIME.getFile("local/jsh/lib/nashorn.jar")) {
-			//	TODO	Not DRY; should parse these names out of ./jsh
-			["asm.jar", "asm-commons.jar", "asm-tree.jar", "asm-util.jar", "nashorn.jar"].forEach(function(library) {
+			jsh.internal.bootstrap.nashorn.dependencies.jarNames.concat(["nashorn.jar"]).forEach(function(library) {
 				SLIME.getFile("local/jsh/lib/" + library).copy(destination.shell.getSubdirectory("lib"));
 			});
 		}

--- a/jrunscript/jsh/launcher/javac.fifty.ts
+++ b/jrunscript/jsh/launcher/javac.fifty.ts
@@ -4,7 +4,7 @@
 //
 //	END LICENSE
 
-namespace slime.internal.jsh.launcher.javac {
+namespace slime.jsh.internal.launcher.javac {
 	export type compile = (p: {
 		files: slime.jrunscript.native.java.net.URL[]
 		destination: slime.jrunscript.native.java.io.File

--- a/jrunscript/jsh/launcher/javac.js
+++ b/jrunscript/jsh/launcher/javac.js
@@ -7,7 +7,7 @@
 //@ts-check
 (
 	/**
-	 * @this { slime.internal.jrunscript.bootstrap.Global<{},{ compile: slime.internal.jsh.launcher.javac.compile }> }
+	 * @this { slime.internal.jrunscript.bootstrap.Global<{},{ compile: slime.jsh.internal.launcher.javac.compile }> }
 	 */
 	function() {
 		var Packages = this.Packages;
@@ -33,7 +33,7 @@
 			return rv;
 		};
 
-		/** @typedef { (p: Parameters<slime.internal.jsh.launcher.javac.compile>[0], c: { console: slime.jrunscript.native.java.io.OutputStream, arguments: string[] }) => void } JavaCompiler */
+		/** @typedef { (p: Parameters<slime.jsh.internal.launcher.javac.compile>[0], c: { console: slime.jrunscript.native.java.io.OutputStream, arguments: string[] }) => void } JavaCompiler */
 
 		/** @type { JavaCompiler } */
 		var toolProviderApiCompile = function(p,c) {
@@ -629,7 +629,7 @@
 			}
 		}
 
-		/** @type { slime.internal.jsh.launcher.javac.compile } */
+		/** @type { slime.jsh.internal.launcher.javac.compile } */
 		$api.java.compile = function(p) {
 			$api.debug("Java compile:");
 			$api.debug("classpath = " + p.classpath);

--- a/jrunscript/jsh/launcher/jsh.bash
+++ b/jrunscript/jsh/launcher/jsh.bash
@@ -27,6 +27,7 @@ fi
 
 if [ -f "$(dirname $0)/lib/nashorn.jar" ]; then
 	LIB="$(dirname $0)/lib"
+	# @notdry nashorn-dependencies
 	JSH_JVM_OPTIONS="-classpath ${LIB}/asm.jar:${LIB}/asm-commons.jar:${LIB}/asm-tree.jar:${LIB}/asm-util.jar:${LIB}/nashorn.jar ${JSH_JVM_OPTIONS}"
 fi
 

--- a/jrunscript/jsh/launcher/launcher.fifty.ts
+++ b/jrunscript/jsh/launcher/launcher.fifty.ts
@@ -4,7 +4,7 @@
 //
 //	END LICENSE
 
-namespace slime.internal.jsh.launcher {
+namespace slime.jsh.internal.launcher {
 	export interface Installation {
 		rhino: slime.jrunscript.native.java.net.URL[]
 		nashorn: slime.jrunscript.native.java.net.URL[]
@@ -49,12 +49,12 @@ namespace slime.internal.jsh.launcher {
 	}
 
 	interface Additions {
-		slime: slime.internal.jsh.launcher.Slime
-		jsh: slime.internal.jsh.launcher.Jsh
+		slime: slime.jsh.internal.launcher.Slime
+		jsh: slime.jsh.internal.launcher.Jsh
 	}
 
 	interface JavaAdditions {
-		compile: slime.internal.jsh.launcher.javac.compile
+		compile: slime.jsh.internal.launcher.javac.compile
 	}
 
 	export type Global = slime.internal.jrunscript.bootstrap.Global<Additions,JavaAdditions>

--- a/jrunscript/jsh/launcher/launcher.js
+++ b/jrunscript/jsh/launcher/launcher.js
@@ -7,7 +7,7 @@
 //@ts-check
 (
 	/**
-	 * @this { slime.internal.jsh.launcher.Global }
+	 * @this { slime.jsh.internal.launcher.Global }
 	 */
 	function() {
 		//	NOTES ABOUT UNSUPPORTED PLATFORMS
@@ -234,8 +234,8 @@
 			$$api.script.resolve("javac.js").load();
 
 			/**
-			 * @type { slime.internal.jsh.launcher.Jsh["Unbuilt"] }
-			 * @param { ConstructorParameters<slime.internal.jsh.launcher.Jsh["Unbuilt"]>[0] } p
+			 * @type { slime.jsh.internal.launcher.Jsh["Unbuilt"] }
+			 * @param { ConstructorParameters<slime.jsh.internal.launcher.Jsh["Unbuilt"]>[0] } p
 			 */
 			$$api.jsh.Unbuilt = function(p) {
 				if (!p) throw new TypeError("Required: arguments[0]");
@@ -401,7 +401,7 @@
 				}
 
 				if (new Packages.java.io.File(home, "lib/nashorn.jar").exists()) {
-					this.nashorn = ["asm", "asm-commons", "asm-tree", "asm-util", "nashorn"].map(function(name) {
+					this.nashorn = $$api.nashorn.dependencies.names.concat(["nashorn"]).map(function(name) {
 						return new Packages.java.io.File(home, "lib/" + name + ".jar").toURI().toURL()
 					});
 				}

--- a/jrunscript/jsh/launcher/main.js
+++ b/jrunscript/jsh/launcher/main.js
@@ -11,7 +11,7 @@
 (
 	/**
 	 *
-	 * @this { slime.internal.jrunscript.bootstrap.Global<{ slime: slime.internal.jsh.launcher.Slime, jsh: any }> }
+	 * @this { slime.internal.jrunscript.bootstrap.Global<{ slime: slime.jsh.internal.launcher.Slime, jsh: any }> }
 	 */
 	function() {
 		var Java = this.Java;
@@ -29,7 +29,7 @@
 			} else {
 				//	TODO	hard-codes assumption of built shell and hard-codes assumption unbuilt shell will arrive via launcher script; should
 				//			tighten this implementation
-				/** @type { slime.internal.jsh.launcher.SlimeConfiguration } */
+				/** @type { slime.jsh.internal.launcher.SlimeConfiguration } */
 				var slimeConfiguration = {
 					built: $api.script.file.getParentFile()
 				};
@@ -142,13 +142,7 @@
 					if ($api.slime.settings.get("jsh.shell.lib") && lib.file) {
 						if (new Packages.java.io.File(lib.file, "nashorn.jar").exists()) {
 							$api.debug("nashorn.jar found");
-							return [
-								"asm.jar",
-								"asm-commons.jar",
-								"asm-tree.jar",
-								"asm-util.jar",
-								"nashorn.jar"
-							].map(function(filename) {
+							return $api.nashorn.dependencies.jarNames.concat(["nashorn.jar"]).map(function(filename) {
 								return new Packages.java.io.File(lib.file, filename).toURI().toURL();
 							});
 						}

--- a/jrunscript/jsh/launcher/native/jsh.c
+++ b/jrunscript/jsh/launcher/native/jsh.c
@@ -228,6 +228,7 @@ int main(int argc, char **argv) {
 
 	if (!access(nashorn_jar, F_OK)) {
 		debug("nashorn.jar found; should add to classpath\n");
+		//	@notdry nashorn-dependencies
 		char* PATH = get_shell_path(jsh_home, "lib/asm.jar");
 		debug("PATH = %s\n", PATH);
 		PATH = path_append(PATH, get_shell_path(jsh_home, "lib/asm-commons.jar"));

--- a/jrunscript/jsh/launcher/slime.fifty.ts
+++ b/jrunscript/jsh/launcher/slime.fifty.ts
@@ -4,7 +4,7 @@
 //
 //	END LICENSE
 
-namespace slime.internal.jsh.launcher {
+namespace slime.jsh.internal.launcher {
 	//	would like to use namespace slime but that conflicts with same name of top-level namespace
 	export interface SlimeConfiguration {
 		built?: slime.jrunscript.native.java.io.File

--- a/jrunscript/jsh/launcher/slime.js
+++ b/jrunscript/jsh/launcher/slime.js
@@ -7,18 +7,18 @@
 //@ts-check
 (
 	/**
-	 * @this { slime.internal.jrunscript.bootstrap.Global<{ slime: slime.internal.jsh.launcher.Slime }> }
+	 * @this { slime.internal.jrunscript.bootstrap.Global<{ slime: slime.jsh.internal.launcher.Slime }> }
 	 */
 	function() {
 		var Packages = this.Packages;
 		var $$api = this.$api;
 
-		/** @type { (p: any) => slime.internal.jsh.launcher.SlimeConfiguration } */
+		/** @type { (p: any) => slime.jsh.internal.launcher.SlimeConfiguration } */
 		function toSlimeConfiguration(p) {
 			return p;
 		}
 
-		/** @type { slime.internal.jsh.launcher.SlimeConfiguration } */
+		/** @type { slime.jsh.internal.launcher.SlimeConfiguration } */
 		var configuration = toSlimeConfiguration($$api.slime);
 
 		//	Provide better implementation that uses Java delegate, replacing pure JavaScript version supplied by api.js
@@ -41,7 +41,7 @@
 		}
 
 		$$api.slime = (function(was) {
-			/** @type { slime.internal.jsh.launcher.Slime } */
+			/** @type { slime.jsh.internal.launcher.Slime } */
 			var rv;
 			if (was && was.built) {
 				rv = {
@@ -70,7 +70,7 @@
 				var isHttp = $$api.script.url && /^http/.test(String($$api.script.url.getProtocol()));
 				if (isSourceFile || isHttp) {
 					rv.src = (function() {
-						/** @type { Partial<slime.internal.jsh.launcher.Slime["src"]> } */
+						/** @type { Partial<slime.jsh.internal.launcher.Slime["src"]> } */
 						var rv;
 						if ($$api.script.file) {
 							rv = (function() {
@@ -190,12 +190,12 @@
 
 						/**
 						 *
-						 * @param { Partial<slime.internal.jsh.launcher.Slime["src"]> } partial
-						 * @returns { slime.internal.jsh.launcher.Slime["src"] }
+						 * @param { Partial<slime.jsh.internal.launcher.Slime["src"]> } partial
+						 * @returns { slime.jsh.internal.launcher.Slime["src"] }
 						 */
 						function complete(partial) {
 							/**
-							 * @type { (partial: Partial<slime.internal.jsh.launcher.Slime["src"]>) => partial is slime.internal.jsh.launcher.Slime["src"] } partial
+							 * @type { (partial: Partial<slime.jsh.internal.launcher.Slime["src"]>) => partial is slime.jsh.internal.launcher.Slime["src"] } partial
 							 */
 							function isComplete(partial) {
 								return true;

--- a/jrunscript/jsh/launcher/suite.fifty.ts
+++ b/jrunscript/jsh/launcher/suite.fifty.ts
@@ -4,7 +4,7 @@
 //
 //	END LICENSE
 
-namespace slime.internal.jsh.launcher {
+namespace slime.jsh.internal.launcher {
 	export namespace test {
 		export const shells = (function(fifty: slime.fifty.test.Kit) {
 			var script: slime.jsh.test.Script = fifty.$loader.script("../fixtures.ts");

--- a/jrunscript/jsh/shell/jsh.fifty.ts
+++ b/jrunscript/jsh/shell/jsh.fifty.ts
@@ -24,6 +24,7 @@ namespace slime.jsh.shell {
 				io: slime.jrunscript.io.Exports
 				file: slime.jrunscript.file.Exports
 				script: slime.jsh.script.Exports
+				bootstrap: slime.internal.jrunscript.bootstrap.Api<{}>
 			}
 
 			PATH: slime.jrunscript.file.Searchpath

--- a/jrunscript/jsh/shell/plugin.jsh.js
+++ b/jrunscript/jsh/shell/plugin.jsh.js
@@ -19,7 +19,7 @@
 	function(Packages,$api,plugins,jsh,$slime,$loader,plugin) {
 		plugin({
 			isReady: function() {
-				return Boolean(plugins.shell && plugins.stdio && jsh.script);
+				return Boolean(plugins.shell && plugins.stdio && jsh.internal && jsh.internal.bootstrap && jsh.script);
 			},
 			load: function() {
 				/** @type { slime.jrunscript.shell.Exports } */
@@ -33,7 +33,8 @@
 						java: jsh.java,
 						io: jsh.io,
 						file: jsh.file,
-						script: jsh.script
+						script: jsh.script,
+						bootstrap: jsh.internal.bootstrap
 					},
 					PATH: module.PATH,
 					stdio: plugins.stdio,

--- a/jrunscript/jsh/test/plugin.jsh.fifty.ts
+++ b/jrunscript/jsh/test/plugin.jsh.fifty.ts
@@ -1,0 +1,11 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+namespace slime.jsh {
+	export interface Global {
+		test: any
+	}
+}

--- a/jrunscript/jsh/test/plugin.jsh.js
+++ b/jrunscript/jsh/test/plugin.jsh.js
@@ -4,200 +4,215 @@
 //
 //	END LICENSE
 
-plugin({
-	isReady: function() {
-		return jsh.js && jsh.script && jsh.shell;
-	},
-	load: function() {
-		if (!jsh.test) jsh.test = {};
-		jsh.test.relaunchInDebugger = function(p) {
-			for (var i=0; i<jsh.script.arguments.length; i++) {
-				if (jsh.script.arguments[i] == p.argument) {
-					var args = Array.prototype.slice.call(jsh.script.arguments);
-					args.splice(i,1);
-					var shell = (function() {
-						if (jsh.shell.jsh.src) return jsh.shell.jsh.src;
-						throw new Error("Unimplemented: relaunchInDebugger for non-unbuilt shell.");
-					})();
-					jsh.shell.jsh({
-						shell: shell,
-						script: jsh.script.file,
-						arguments: args,
-						environment: jsh.js.Object.set({}, jsh.shell.environment, {
-							JSH_DEBUG_SCRIPT: "rhino"
-						}),
-						evaluate: function(result) {
-							jsh.shell.exit(result.status);
+//@ts-check
+(
+	/**
+	 *
+	 * @param { slime.$api.Global } $api
+	 * @param { slime.jsh.Global } jsh
+	 * @param { slime.jsh.plugin.Scope["plugin"] } plugin
+	 */
+	function($api,jsh,plugin) {
+		//	TODO	should the test APIs be documented and available? Are they automatically loaded?
+
+		plugin({
+			isReady: function() {
+				return Boolean(jsh.js && jsh.script && jsh.shell);
+			},
+			load: function() {
+				if (!jsh.test) jsh.test = {};
+				jsh.test.relaunchInDebugger = function(p) {
+					for (var i=0; i<jsh.script.arguments.length; i++) {
+						if (jsh.script.arguments[i] == p.argument) {
+							var args = Array.prototype.slice.call(jsh.script.arguments);
+							args.splice(i,1);
+							var shell = (function() {
+								if (jsh.shell.jsh.src) return jsh.shell.jsh.src;
+								throw new Error("Unimplemented: relaunchInDebugger for non-unbuilt shell.");
+							})();
+							jsh.shell.jsh({
+								shell: shell,
+								script: jsh.script.file,
+								arguments: args,
+								environment: jsh.js.Object.set({}, jsh.shell.environment, {
+									JSH_DEBUG_SCRIPT: "rhino"
+								}),
+								evaluate: function(result) {
+									jsh.shell.exit(result.status);
+								}
+							});
 						}
+					}
+				}
+			}
+		})
+
+		plugin({
+			isReady: function() {
+				return Boolean(jsh.js && jsh.io && jsh.shell && jsh.unit);
+			},
+			load: function() {
+				if (!jsh.test) jsh.test = {};
+
+				jsh.test.Suite = function(p) {
+					return new jsh.unit.Suite.Fork(jsh.js.Object.set({}, p, {
+						run: jsh.shell.jsh,
+						arguments: ["-scenario", "-view", "stdio"]
+					}));
+				};
+
+				//	if -scenario is on command line, invokes scenario, otherwise run()
+				//	scenario: receives a composite scenario as this, receives command-line arguments as function arguments, view argument
+				//		[console/webview/child] determines format of scenario reporting
+				//	run: receives processed results of getopts as argument
+				jsh.test.integration = function(o) {
+					var parameters = jsh.script.getopts({
+						options: {
+							scenario: false,
+							part: String,
+							view: "console"
+						},
+						unhandled: jsh.script.getopts.UNEXPECTED_OPTION_PARSER.SKIP
 					});
-				}
-			}
-		}
-	}
-})
-
-plugin({
-	isReady: function() {
-		return jsh.js && jsh.io && jsh.shell && jsh.unit;
-	},
-	load: function() {
-		if (!jsh.test) jsh.test = {};
-
-		jsh.test.Suite = function(p) {
-			return new jsh.unit.Suite.Fork(jsh.js.Object.set({}, p, {
-				run: jsh.shell.jsh,
-				arguments: ["-scenario", "-view", "stdio"]
-			}));
-		};
-
-		//	if -scenario is on command line, invokes scenario, otherwise run()
-		//	scenario: receives a composite scenario as this, receives command-line arguments as function arguments, view argument
-		//		[console/webview/child] determines format of scenario reporting
-		//	run: receives processed results of getopts as argument
-		jsh.test.integration = function(o) {
-			var parameters = jsh.script.getopts({
-				options: {
-					scenario: false,
-					part: String,
-					view: "console"
-				},
-				unhandled: jsh.script.getopts.UNEXPECTED_OPTION_PARSER.SKIP
-			});
-			var getopts = (o.getopts) ? jsh.script.getopts(o.getopts, parameters.arguments) : { options: {}, arguments: parameters.arguments };
-			if (parameters.options.scenario) {
-				var scenario = new jsh.unit.Suite({
-					name: jsh.script.file.pathname.basename
-				});
-				o.scenario.call(scenario,getopts);
-				var path = (parameters.options.part) ? parameters.options.part.split("/") : void(0);
-				jsh.unit.interface.create(scenario, { view: parameters.options.view, path: path });
-			} else {
-				o.run(getopts);
-			}
-		};
-	}
-});
-
-plugin({
-	isReady: function() {
-		return jsh.shell && jsh.script;
-	},
-	load: function() {
-		if (!jsh.test) jsh.test = {};
-		jsh.test.buildShell = function(p) {
-			if (!p) p = {};
-			if (!p.to) {
-				p.to = jsh.shell.TMPDIR.createTemporary({ directory: true }).pathname;
-				p.to.directory.remove();
-			}
-			jsh.shell.jsh({
-				script: jsh.shell.jsh.src.getFile("jsh/etc/build.jsh.js"),
-				arguments: (function(rv) {
-					rv.push(p.to);
-					rv.push("-notest", "-nodoc");
-					if (jsh.shell.jsh.lib.getFile("js.jar")) {
-						rv.push("-rhino",jsh.shell.jsh.lib.getFile("js.jar"));
+					var getopts = (o.getopts) ? jsh.script.getopts(o.getopts, parameters.arguments) : { options: {}, arguments: parameters.arguments };
+					if (parameters.options.scenario) {
+						var scenario = new jsh.unit.Suite({
+							name: jsh.script.file.pathname.basename
+						});
+						o.scenario.call(scenario,getopts);
+						var path = (parameters.options.part) ? parameters.options.part.split("/") : void(0);
+						jsh.unit.interface.create(scenario, { view: parameters.options.view, path: path });
+					} else {
+						o.run(getopts);
 					}
-					return rv;
-				})([])
-			});
-			return p.to.directory;
-		}
-		jsh.test.requireBuiltShell = function(p) {
-			if (!p) p = {};
-			if (!jsh.shell.jsh.home) {
-				jsh.shell.console("Building shell in which to relaunch " + jsh.script.file + " ...");
-				//	TODO	this probably does not make sense; why do we require callers to have exactly these on the command line,
-				//			with no prefixing or anything? Probably leftover cruft.
-				var parameters = jsh.script.getopts({
-					options: {
-						executable: false,
-						install: jsh.script.getopts.ARRAY(String),
-						downloads: jsh.file.Pathname,
-						rhino: jsh.file.Pathname
-					},
-					unhandled: jsh.script.getopts.UNEXPECTED_OPTION_PARSER.SKIP
-				});
-				if (p.rhino) {
-					parameters.options.rhino = p.rhino;
-				}
-				var JSH_HOME = jsh.shell.TMPDIR.createTemporary({ directory: true });
-				//	TODO	locate jrunscript using Java home
-				//	TODO	add these APIs for properties, etc., to jsh.shell.jrunscript
-				var args = [];
-				if (parameters.options.downloads) {
-					args.push("-Djsh.build.downloads=" + parameters.options.downloads);
-				}
-				// if (parameters.options.rhino) {
-				// 	args.push("-Djsh.build.rhino.jar=" + parameters.options.rhino);
-				// } else if (Packages.java.lang.System.getProperty("jsh.engine.rhino.classpath")) {
-				// 	args.push("-Djsh.engine.rhino.classpath=" + Packages.java.lang.System.getProperty("jsh.engine.rhino.classpath"));
-				// }
-				var SLIME = (function(p) {
-					if (p && p.src) return p.src;
-					if (jsh.shell.jsh.home) return jsh.shell.jsh.home.getSubdirectory("src");
-					return jsh.shell.jsh.src;
-				})(p);
-				if (SLIME.getFile("local/jsh/lib/nashorn.jar")) {
-					args.push(
-						"-classpath",
-						["asm", "asm-commons", "asm-tree", "asm-util", "nashorn"].map(function(name) {
-							return SLIME.getRelativePath("local/jsh/lib/" + name + ".jar").toString()
-						//	TODO	platform-specific
-						}).join(":")
-					);
-				}
-				args.push(SLIME.getRelativePath("rhino/jrunscript/api.js"));
-				args.push("jsh");
-				args.push(SLIME.getRelativePath("jrunscript/jsh/etc/build.jsh.js"));
-				args.push(JSH_HOME);
-				args.push("-notest");
-				args.push("-nodoc");
-				if (parameters.options.rhino) {
-					args.push("-rhino", parameters.options.rhino);
-				}
-				if (parameters.options.executable) {
-					args.push("-executable");
-				}
-				parameters.options.install.forEach(function(addon) {
-					args.push("-install", addon);
-				});
-				jsh.shell.run({
-					command: jsh.shell.java.jrunscript,
-					arguments: args
-				});
-				var environment = {};
-				for (var x in jsh.shell.environment) {
-					environment[x] = jsh.shell.environment[x];
-				}
-				// //	TODO	probably not necessary; just relaunching should do this
-				// if (jsh.shell.jsh.lib.getSubdirectory("tomcat")) {
-				// 	jsh.shell.echo("Adding Tomcat to shell ...")
-				// 	environment.CATALINA_HOME = String(jsh.shell.jsh.lib.getSubdirectory("tomcat"));
-				// }
-				jsh.shell.echo("Relaunching " + jsh.script.file + " with arguments " + parameters.arguments);
-				jsh.shell.jsh({
-					fork: true,
-					shell: JSH_HOME,
-					environment: environment,
-					script: jsh.script.file,
-					arguments: parameters.arguments,
-					evaluate: function(result) {
-						jsh.shell.exit(result.status);
-					}
-				});
+				};
 			}
-		}
-	}
-});
+		});
 
-plugin({
-	isReady: function() {
-		return jsh.unit && jsh.unit.mock;
-	},
-	load: function() {
-		if (!jsh.test) jsh.test = {};
-		jsh.test.mock = jsh.unit.mock;
-		$api.deprecate(jsh.test,"mock");
+		plugin({
+			isReady: function() {
+				return Boolean(jsh.internal && jsh.internal.bootstrap && jsh.shell && jsh.script);
+			},
+			load: function() {
+				if (!jsh.test) jsh.test = {};
+				jsh.test.buildShell = function(p) {
+					if (!p) p = {};
+					if (!p.to) {
+						p.to = jsh.shell.TMPDIR.createTemporary({ directory: true }).pathname;
+						p.to.directory.remove();
+					}
+					jsh.shell.jsh({
+						script: jsh.shell.jsh.src.getFile("jsh/etc/build.jsh.js"),
+						arguments: (function(rv) {
+							rv.push(p.to);
+							rv.push("-notest", "-nodoc");
+							if (jsh.shell.jsh.lib.getFile("js.jar")) {
+								rv.push("-rhino",jsh.shell.jsh.lib.getFile("js.jar"));
+							}
+							return rv;
+						})([])
+					});
+					return p.to.directory;
+				}
+				jsh.test.requireBuiltShell = function(p) {
+					if (!p) p = {};
+					if (!jsh.shell.jsh.home) {
+						jsh.shell.console("Building shell in which to relaunch " + jsh.script.file + " ...");
+						//	TODO	this probably does not make sense; why do we require callers to have exactly these on the command line,
+						//			with no prefixing or anything? Probably leftover cruft.
+						var parameters = jsh.script.getopts({
+							options: {
+								executable: false,
+								install: jsh.script.getopts.ARRAY(String),
+								downloads: jsh.file.Pathname,
+								rhino: jsh.file.Pathname
+							},
+							unhandled: jsh.script.getopts.UNEXPECTED_OPTION_PARSER.SKIP
+						});
+						if (p.rhino) {
+							parameters.options.rhino = p.rhino;
+						}
+						var JSH_HOME = jsh.shell.TMPDIR.createTemporary({ directory: true });
+						//	TODO	locate jrunscript using Java home
+						//	TODO	add these APIs for properties, etc., to jsh.shell.jrunscript
+						var args = [];
+						if (parameters.options.downloads) {
+							args.push("-Djsh.build.downloads=" + parameters.options.downloads);
+						}
+						// if (parameters.options.rhino) {
+						// 	args.push("-Djsh.build.rhino.jar=" + parameters.options.rhino);
+						// } else if (Packages.java.lang.System.getProperty("jsh.engine.rhino.classpath")) {
+						// 	args.push("-Djsh.engine.rhino.classpath=" + Packages.java.lang.System.getProperty("jsh.engine.rhino.classpath"));
+						// }
+						var SLIME = (function(p) {
+							if (p && p.src) return p.src;
+							if (jsh.shell.jsh.home) return jsh.shell.jsh.home.getSubdirectory("src");
+							return jsh.shell.jsh.src;
+						})(p);
+						if (SLIME.getFile("local/jsh/lib/nashorn.jar")) {
+							args.push(
+								"-classpath",
+								jsh.internal.bootstrap.nashorn.dependencies.names.concat(["nashorn"]).map(function(name) {
+									return SLIME.getRelativePath("local/jsh/lib/" + name + ".jar").toString()
+								//	TODO	platform-specific
+								}).join(":")
+							);
+						}
+						args.push(SLIME.getRelativePath("rhino/jrunscript/api.js"));
+						args.push("jsh");
+						args.push(SLIME.getRelativePath("jrunscript/jsh/etc/build.jsh.js"));
+						args.push(JSH_HOME);
+						args.push("-notest");
+						args.push("-nodoc");
+						if (parameters.options.rhino) {
+							args.push("-rhino", parameters.options.rhino);
+						}
+						if (parameters.options.executable) {
+							args.push("-executable");
+						}
+						parameters.options.install.forEach(function(addon) {
+							args.push("-install", addon);
+						});
+						jsh.shell.run({
+							command: jsh.shell.java.jrunscript,
+							arguments: args
+						});
+						var environment = {};
+						for (var x in jsh.shell.environment) {
+							environment[x] = jsh.shell.environment[x];
+						}
+						// //	TODO	probably not necessary; just relaunching should do this
+						// if (jsh.shell.jsh.lib.getSubdirectory("tomcat")) {
+						// 	jsh.shell.echo("Adding Tomcat to shell ...")
+						// 	environment.CATALINA_HOME = String(jsh.shell.jsh.lib.getSubdirectory("tomcat"));
+						// }
+						jsh.shell.echo("Relaunching " + jsh.script.file + " with arguments " + parameters.arguments);
+						jsh.shell.jsh({
+							fork: true,
+							shell: JSH_HOME,
+							environment: environment,
+							script: jsh.script.file,
+							arguments: parameters.arguments,
+							evaluate: function(result) {
+								jsh.shell.exit(result.status);
+							}
+						});
+					}
+				}
+			}
+		});
+
+		plugin({
+			isReady: function() {
+				return Boolean(jsh.unit && jsh.unit.mock);
+			},
+			load: function() {
+				if (!jsh.test) jsh.test = {};
+				jsh.test.mock = jsh.unit.mock;
+				$api.deprecate(jsh.test,"mock");
+			}
+		})
+
 	}
-})
+//@ts-ignore
+)($api,jsh,plugin);

--- a/jrunscript/jsh/tools/install/plugin.jsh.fifty.ts
+++ b/jrunscript/jsh/tools/install/plugin.jsh.fifty.ts
@@ -131,6 +131,8 @@ namespace slime.jsh.shell.tools {
 			 * Used to decide whether to replace the existing installation if one is found. If Rhino is already present at the
 			 * installation location, this function will be invoked with the version of Rhino that is currently installed.
 			 *
+			 * If this function is not omitted, the default is not to replace the existing version.
+			 *
 			 * @param version The version of Rhino found
 			 * @returns `true` to replace the installation; `false` to leave it in place.
 			 */

--- a/jrunscript/jsh/tools/install/rhino.jsh.js
+++ b/jrunscript/jsh/tools/install/rhino.jsh.js
@@ -20,7 +20,7 @@
 					$api.fp.world.Means.now({
 						means: jsh.shell.tools.rhino.require.world(),
 						order: {
-							replace: $api.fp.mapping.all(p.options.replace),
+							replace: $api.fp.mapping.from.value(p.options.replace),
 							version: p.options.version
 						},
 						handlers: {

--- a/jsh
+++ b/jsh
@@ -260,7 +260,10 @@ install_jdk() {
 
 JSH_BOOTSTRAP_RHINO="${JSH_SHELL_LIB}/js.jar"
 JSH_BOOTSTRAP_NASHORN="${JSH_SHELL_LIB}/nashorn.jar"
-JSH_BOOTSTRAP_NASHORN_LIBRARIES="asm asm-commons asm-tree asm-util"
+# @notdry nashorn-dependencies
+JSH_BOOTSTRAP_NASHORN_LIBRARIES_GROUP=org.ow2.asm
+JSH_BOOTSTRAP_NASHORN_LIBRARIES_ARTIFACTS="asm asm-commons asm-tree asm-util"
+JSH_BOOTSTRAP_NASHORN_LIBRARIES_VERSION=7.3.1
 
 get_maven_dependency() {
 	GROUP=$1
@@ -278,7 +281,7 @@ get_bootstrap_nashorn_classpath() {
 	rv=""
 	local WAS_IFS=${IFS}
 	IFS=" "
-	set -- ${JSH_BOOTSTRAP_NASHORN_LIBRARIES}
+	set -- ${JSH_BOOTSTRAP_NASHORN_LIBRARIES_ARTIFACTS}
 	for name in "$@"; do
 		if [ -n "${rv}" ]; then
 			rv="${rv}:"
@@ -293,11 +296,15 @@ install_nashorn() {
 	local WAS_IFS=${IFS}
 
 	IFS=" "
-	set -- ${JSH_BOOTSTRAP_NASHORN_LIBRARIES}
+	set -- ${JSH_BOOTSTRAP_NASHORN_LIBRARIES_ARTIFACTS}
 
 	#	Derived from https://repo1.maven.org/maven2/org/openjdk/nashorn/nashorn-core/15.6/nashorn-core-15.6.pom
 	for name in "$@"; do
-		install_maven_dependency org.ow2.asm ${name} 7.3.1 ${JSH_SHELL_LIB}/${name}.jar
+		install_maven_dependency \
+			${JSH_BOOTSTRAP_NASHORN_LIBRARIES_GROUP} \
+			${name} \
+			${JSH_BOOTSTRAP_NASHORN_LIBRARIES_VERSION} \
+			${JSH_SHELL_LIB}/${name}.jar
 	done
 	IFS="${WAS_IFS}"
 

--- a/loader/Loader.fifty.ts
+++ b/loader/Loader.fifty.ts
@@ -17,17 +17,23 @@ namespace slime {
 		export type Module<C,E> = ($context: C) => E
 
 		export interface Store {
-			script: <C,E>(path: string) => ($context: C) => E
+			script: <C,E>(path: string) => Module<C,E>
+
+			/**
+			 * @deprecated Exists for compatibility with {@link slime.Loader} and likely to be removed.
+			 *
+			 * Immediately executes the script at the given path, using the given scope as the script's scope, and the given target
+			 * as the `this` target for the script.
+			 */
+			run: <S,T>(path: string, scope: S, target: T) => void
 		}
 
 		export interface Exports {
 			Store: {
-				from: {
-					default: <T>(p: {
-						store: slime.runtime.content.Store<T>
-						adapt: (t: T) => Code
-					}) => Store
-				}
+				content: <T>(p: {
+					store: slime.runtime.content.Store<T>
+					adapt: (t: T) => Code
+				}) => Store
 			}
 		}
 
@@ -43,7 +49,7 @@ namespace slime {
 					const { jsh } = fifty.global;
 
 					if (jsh) {
-						var $loader = jsh.loader.Store.from.default({
+						var $loader = jsh.loader.Store.content({
 							store: jsh.file.Location.directory.content.Index( fifty.jsh.file.relative(".") ),
 							adapt: function(t) {
 								return {

--- a/loader/scripts.fifty.ts
+++ b/loader/scripts.fifty.ts
@@ -93,7 +93,7 @@ namespace slime.runtime.internal.scripts {
 			 * Compiles the given `code` script, executes it in a scope containing the values provided by `scope`, and using the
 			 * `this` target with which the `run` function was invoked.
 			 */
-			run: (code: slime.runtime.loader.Code, scope: { [name: string]: any }) => void
+			run: (this: { [name: string]: any }, code: slime.runtime.loader.Code, scope: { [name: string]: any }) => void
 
 			old: {
 				value: (code: slime.runtime.loader.Code, scope: { [name: string]: any }) => any

--- a/loader/scripts.js
+++ b/loader/scripts.js
@@ -116,17 +116,22 @@
 		/**
 		 * @type { slime.runtime.internal.scripts.Exports["methods"]["run"] }
 		 */
-		function run(script,scope) {
-			if (!script || typeof(script) != "object") {
-				throw new TypeError("'object' must be an object, not " + script);
+		function run(code,scope) {
+			if (!code || typeof(code) != "object") {
+				throw new TypeError("'object' must be a slime.runtime.loader.Code object, not " + code);
 			}
-			if (typeof(script.read) != "function") throw new Error("Not resource: no read() function");
+			if (typeof(code.read) != "function") throw new Error("Not slime.runtime.loader.Code: no read() function");
 
-			var code = compiler(script);
+			var compile = $api.fp.now(
+				compiler,
+				$api.fp.Partial.impure.exception(
+					function(code) {
+						return new TypeError("Code " + code.name + " cannot be converted to JavaScript; type = " + code.type())
+					}
+				)
+			);
 
-			if (!code.present) {
-				throw new TypeError("Resource " + script.name + " cannot be converted to JavaScript; type = " + script.type());
-			}
+			var script = compile(code);
 
 			var target = this;
 
@@ -145,7 +150,7 @@
 			scope.$api = $api;
 
 			$engine.execute(
-				code.value,
+				script,
 				scope,
 				target
 			);

--- a/rhino/file/fixtures.ts
+++ b/rhino/file/fixtures.ts
@@ -111,7 +111,10 @@ namespace slime.jrunscript.file.internal.test {
 								java: java,
 								mime: jsh.unit.$slime.mime
 							}
-						})
+						}),
+						loader: {
+							Store: jsh.loader.Store
+						}
 					}
 				}
 			)();

--- a/rhino/file/module.fifty.ts
+++ b/rhino/file/module.fifty.ts
@@ -21,6 +21,9 @@ namespace slime.jrunscript.file {
 			js: slime.$api.old.Exports
 			java: slime.jrunscript.java.Exports
 			io: slime.jrunscript.io.Exports
+			loader: {
+				Store: slime.runtime.loader.Exports["Store"]
+			}
 		}
 
 		/**

--- a/rhino/file/module.js
+++ b/rhino/file/module.js
@@ -46,7 +46,8 @@
 		var wo = code.wo({
 			library: {
 				java: $context.api.java,
-				io: $context.api.io
+				io: $context.api.io,
+				loader: $context.api.loader
 			},
 			filesystem: {
 				os: world.filesystems.os

--- a/rhino/file/plugin.jsh.js
+++ b/rhino/file/plugin.jsh.js
@@ -26,7 +26,10 @@
 					api: {
 						js: jsh.js,
 						java: jsh.java,
-						io: jsh.io
+						io: jsh.io,
+						loader: {
+							Store: jsh.loader.Store
+						}
 					},
 					pathext: void(0),
 					cygwin: void(0)

--- a/rhino/file/wo-directory.fifty.ts
+++ b/rhino/file/wo-directory.fifty.ts
@@ -598,6 +598,12 @@ namespace slime.jrunscript.file.exports.location {
 		}
 	//@ts-ignore
 	)(fifty);
+
+	export interface Directory {
+		Loader: {
+			simple: (root: slime.jrunscript.file.Location) => slime.runtime.loader.Store
+		}
+	}
 }
 
 namespace slime.jrunscript.file.internal.wo.directory {
@@ -607,9 +613,11 @@ namespace slime.jrunscript.file.internal.wo.directory {
 		Location_relative: slime.jrunscript.file.exports.Location["directory"]["relativePath"]
 		Location_parent: slime.jrunscript.file.exports.Location["parent"]
 		Location_directory_exists: slime.jrunscript.file.Exports["Location"]["directory"]["exists"]
+		Location_file_read_string: slime.jrunscript.file.Exports["Location"]["file"]["read"]["string"]
 		Location_file_write: slime.jrunscript.file.Exports["Location"]["file"]["write"]
 		ensureParent: slime.$api.fp.world.Means<slime.jrunscript.file.Location, { created: string }>
 		remove: slime.$api.fp.world.Means<slime.jrunscript.file.Location,void>
+		Store: slime.runtime.loader.Exports["Store"]
 	}
 
 	export type Exports = slime.jrunscript.file.exports.location.Directory

--- a/rhino/file/wo-directory.js
+++ b/rhino/file/wo-directory.js
@@ -316,6 +316,27 @@
 			content: {
 				Index: content_Index,
 				mirror: content_mirror
+			},
+			Loader: {
+				simple: function(root) {
+					return $context.Store.content({
+						//	@notdry Search for all instances of Store.content and have them share implementation
+						store: content_Index(
+							root
+						),
+						adapt: function(t) {
+							return {
+								name: t.pathname,
+								type: function() {
+									return $api.mime.Type.fromName( $context.Location_basename(t) )
+								},
+								read: function() {
+									return $context.Location_file_read_string.simple(t);
+								}
+							}
+						}
+					})
+				}
 			}
 		})
 	}

--- a/rhino/file/wo.fifty.ts
+++ b/rhino/file/wo.fifty.ts
@@ -782,6 +782,9 @@ namespace slime.jrunscript.file.internal.wo {
 		library: {
 			java: slime.jrunscript.java.Exports
 			io: slime.jrunscript.io.Exports
+			loader: {
+				Store: slime.runtime.loader.Exports["Store"]
+			}
 		}
 		filesystem: {
 			os: slime.jrunscript.file.world.Filesystem

--- a/rhino/jrunscript/api.js
+++ b/rhino/jrunscript/api.js
@@ -62,8 +62,6 @@
 
 		/** @type { slime.internal.jrunscript.bootstrap.Configuration } */
 		var configuration = toConfiguration(this["$api"]);
-		var $script = (configuration && configuration.script) ? configuration.script : null;
-		var $arguments = (configuration && configuration.arguments) ? configuration.arguments : null;
 
 		/**
 		 * @type { slime.internal.jrunscript.bootstrap.Global<{},{}>["$api"] }
@@ -290,6 +288,7 @@
 		var JavaAdapter = this.JavaAdapter;
 
 		var nashorn = (
+			/** @returns { slime.internal.jrunscript.bootstrap.Api<{}>["nashorn"] } */
 			function() {
 				//	TODO	A little bit of this logic is duplicated in loader/jrunscript/nashorn.js; we could make this method
 				//			available there somehow, perhaps, although it might be tricky getting things organized between
@@ -328,7 +327,21 @@
 					return true;
 				}
 
+				/** @notdry nashorn-dependencies reference */
+				var mavenDependencies = ["asm","asm-commons","asm-tree","asm-util"].map(function(name) {
+					return {
+						group: "org.ow2.asm",
+						artifact: name,
+						version: "7.3.1"
+					}
+				});
+
 				return {
+					dependencies: {
+						maven: mavenDependencies,
+						names: mavenDependencies.map(function(dependency) { return dependency.artifact; }),
+						jarNames: mavenDependencies.map(function(dependency) { return dependency.artifact + ".jar"; })
+					},
 					isPresent: isPresent,
 					running: function() {
 						if ($getContext) {
@@ -931,14 +944,20 @@
 				interpret: interpret
 			}
 
-			if ($script && $script.url) {
+			if (configuration && configuration.script && configuration.script.url) {
 				$api.script = new $api.Script({
-					url: new Packages.java.net.URL($script.url)
+					url: new Packages.java.net.URL(configuration.script.url)
 				});
-			} else if ($script && $script.file) {
+			} else if (configuration && configuration.script && configuration.script.file) {
 				$api.script = new $api.Script({
-					file: new Packages.java.io.File($script.file)
+					file: new Packages.java.io.File(configuration.script.file)
 				});
+			} else if (/\.slime\!api\.js$/.test($engine.script)) {
+				//	Indicates this is embedded API in a built shell.
+				$api.script = null;
+				if (configuration.arguments.length != 1 || configuration.arguments[0] != "api") {
+					throw new Error("Loading api.js from .slime should be done only for embedding API.");
+				}
 			} else {
 				$api.script = new $api.Script({
 					string: $engine.script
@@ -951,8 +970,8 @@
 				}
 			}
 
-			if ($arguments) {
-				$api.arguments = $arguments;
+			if (configuration && configuration.arguments) {
+				$api.arguments = configuration.arguments;
 			} else {
 				$api.arguments = (function() {
 					//	TODO	Use $api.engine.resolve
@@ -1430,7 +1449,21 @@
 	function() {
 		var Packages = this.Packages;
 		var $api = this.$api;
+
+		/**
+		 * The script's "query string," which has different meanings based on how the script is invoked.
+		 *
+		 * * If it is invoked by URL, the actual query string, excluding the `?`.
+		 * * If it is invoked with arguments, and the first argument starts with `?`, that argument, excluding the `?`
+		 * * If it is invoked with arguments, and the first argument is `jsh`, `jsh`.
+		 * * If it is invoked with arguments, and the first argument is `api`, `api`.
+		 */
 		var $query = (function() {
+			//	The only way we presently don't have a script is in the embedding-in-built-shell scenario
+			if (!$api.script) {
+				return $api.arguments.shift();
+			}
+
 			if ($api.script.url && $api.script.url.getQuery()) {
 				return String($api.script.url.getQuery());
 			}

--- a/rhino/jrunscript/api.js
+++ b/rhino/jrunscript/api.js
@@ -665,7 +665,7 @@
 						if (e.javaException) {
 							e.javaException.printStackTrace();
 						}
-						throw new Error("Could not parse: " + string);
+						throw new Error("Could not parse: " + string + " $engine.script = " + $engine.script);
 					}
 					if (String(url.getProtocol()) == "file") {
 						return {
@@ -957,6 +957,12 @@
 				$api.script = null;
 				if (configuration.arguments.length != 1 || configuration.arguments[0] != "api") {
 					throw new Error("Loading api.js from .slime should be done only for embedding API.");
+				}
+			} else if (/\.zip\!(.*)\/rhino\/jrunscript\/api\.js$/.test($engine.script)) {
+				//	Indicates this is embedded API in a remote shell.
+				$api.script = null;
+				if (configuration.arguments.length != 1 || configuration.arguments[0] != "api") {
+					throw new Error("Loading api.js from .zip should be done only for embedding API.");
 				}
 			} else {
 				$api.script = new $api.Script({

--- a/rhino/jrunscript/embed.fifty.ts
+++ b/rhino/jrunscript/embed.fifty.ts
@@ -34,5 +34,5 @@ namespace slime.jrunscript.bootstrap {
 	//@ts-ignore
 	)(fifty);
 
-	export type Script = slime.loader.Script<Context,Exports>
+	export type Script = slime.runtime.loader.Module<Context,Exports>
 }

--- a/rhino/jrunscript/embed.js
+++ b/rhino/jrunscript/embed.js
@@ -10,7 +10,7 @@
 	 *
 	 * @param { slime.$api.Global } $api
 	 * @param { slime.jrunscript.bootstrap.Context } $context
-	 * @param { slime.Loader } $loader
+	 * @param { slime.runtime.loader.Store } $loader
 	 * @param { slime.loader.Export<slime.jrunscript.bootstrap.Exports> } $export
 	 */
 	function(Packages,JavaAdapter,$api,$context,$loader,$export) {

--- a/rhino/jrunscript/plugin.jsh.fifty.ts
+++ b/rhino/jrunscript/plugin.jsh.fifty.ts
@@ -1,0 +1,26 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+namespace slime.jsh {
+	export interface Global {
+		internal: {
+			bootstrap: slime.internal.jrunscript.bootstrap.Api<{}>
+		}
+	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			const { jsh } = fifty.global;
+
+			fifty.tests.manual = function() {
+				jsh.shell.console(String(jsh.internal.bootstrap));
+			}
+		}
+	//@ts-ignore
+	)(fifty);
+}

--- a/rhino/jrunscript/plugin.jsh.js
+++ b/rhino/jrunscript/plugin.jsh.js
@@ -1,0 +1,32 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+//@ts-check
+(
+	/**
+	 *
+	 * @param { slime.$api.Global } $api
+	 * @param { slime.jsh.Global } jsh
+	 * @param { slime.Loader } $loader
+	 * @param { slime.jsh.plugin.Scope["plugin"] } plugin
+	 */
+	function($api,jsh,$loader,plugin) {
+		plugin({
+			load: function() {
+				/** @type { slime.jrunscript.bootstrap.Script } */
+				var jrunscriptBootstrap = $loader.script("embed.js");
+				var jrunscriptBootstrapApis = jrunscriptBootstrap({
+					debug: false,
+					script: {}
+				});
+				jsh.internal = {
+					bootstrap: jrunscriptBootstrapApis
+				};
+			}
+		})
+	}
+//@ts-ignore
+)($api,jsh,$loader,plugin);

--- a/rhino/shell/module.fifty.ts
+++ b/rhino/shell/module.fifty.ts
@@ -90,37 +90,59 @@ namespace slime.jrunscript.shell {
 					},
 					$slime: jsh.unit.$slime
 				});
+				const file: slime.jrunscript.file.Script = fifty.$loader.script("../../rhino/file/");
 				this.api = {
 					js: fifty.$loader.module("../../js/object/"),
 					java: java,
 					io: io,
-					file: fifty.$loader.module("../../rhino/file/", new function() {
-						if (jsh.shell.environment.PATHEXT) {
-							this.pathext = jsh.shell.environment.PATHEXT.split(";");
-						}
-						this.$rhino = jsh.unit.$slime;
-						this.api = {
-							io: io,
-							js: jsh.js,
-							java: jsh.java
-						};
-						this.$pwd = String(jsh.shell.properties.object.user.dir);
-						this.addFinalizer = jsh.loader.addFinalizer;
-						//	TODO	below copy-pasted from rhino/file/api.html
-						//	TODO	switch to use appropriate jsh properties, rather than accessing Java system properties directly
-						var System = Packages.java.lang.System;
-						if (System.getProperty("cygwin.root")) {
-							this.cygwin = {
-								root: String( System.getProperty("cygwin.root") )
-							};
-							if (System.getProperty("cygwin.paths")) {
-								//	Using the paths helper currently does not seem to work in the embedded situation when running inside
-								//	the SDK server
-								//	TODO	check this
-								this.cygwin.paths = String( System.getProperty("cygwin.paths") );
+					file: file(
+						(
+							function() {
+								var pathext = void(0);
+								if (jsh.shell.environment.PATHEXT) {
+									pathext = jsh.shell.environment.PATHEXT.split(";");
+								}
+								this.$rhino = jsh.unit.$slime;
+								this.api = {
+									io: io,
+									js: jsh.js,
+									java: jsh.java
+								};
+								this.$pwd = String(jsh.shell.properties.object.user.dir);
+								this.addFinalizer = jsh.loader.addFinalizer;
+								//	TODO	below copy-pasted from rhino/file/api.html
+								//	TODO	switch to use appropriate jsh properties, rather than accessing Java system properties directly
+								var System = Packages.java.lang.System;
+								var cygwin = void(0);
+								if (System.getProperty("cygwin.root")) {
+									cygwin = {
+										root: String( System.getProperty("cygwin.root") )
+									};
+									if (System.getProperty("cygwin.paths")) {
+										//	Using the paths helper currently does not seem to work in the embedded situation when running inside
+										//	the SDK server
+										//	TODO	check this
+										cygwin.paths = String( System.getProperty("cygwin.paths") );
+									}
+								}
+								return {
+									pathext: pathext,
+									$rhino: jsh.unit.$slime,
+									api: {
+										io: io,
+										js: jsh.js,
+										java: jsh.java,
+										loader: {
+											Store: jsh.loader.Store
+										}
+									},
+									$pwd: String(jsh.shell.properties.object.user.dir),
+									addFinalizer: jsh.loader.addFinalizer,
+									cygwin: cygwin
+								}
 							}
-						}
-					}),
+						)()
+					),
 					document: fifty.$loader.module("../../js/document/"),
 					xml: {
 						parseFile: function(file) {

--- a/tools/fifty/documentation.jsh.js
+++ b/tools/fifty/documentation.jsh.js
@@ -16,24 +16,7 @@
 		var $loader = $api.fp.now(
 			jsh.script.world.file,
 			jsh.file.Location.parent(),
-			jsh.file.Location.directory.content.Index,
-			function(store) {
-				return jsh.loader.Store.from.default({
-					store: store,
-					//	TODO	promote to shared
-					adapt: function(t) {
-						return {
-							name: t.pathname,
-							type: function() {
-								return $api.mime.Type.fromName( jsh.file.Location.basename(t) )
-							},
-							read: function() {
-								return jsh.file.Location.file.read.string.simple(t);
-							}
-						}
-					}
-				});
-			}
+			jsh.file.Location.directory.Loader.simple
 		);
 
 		jsh.script.cli.main(

--- a/wf.js
+++ b/wf.js
@@ -397,6 +397,8 @@
 		var test = function(p) {
 			if (!p) p = {};
 			return function(events) {
+				//	This invocation will install the JDK if necessary, and then ensure the version of Rhino is the correct one for
+				//	that JDK
 				jsh.shell.run({
 					command: "bash",
 					arguments: [


### PR DESCRIPTION
* Remove repeated lists of Nashorn dependencies
* Improve top level jsh script model for Nashorn dependencies
* Improve wf.js inline documentation
* Make the jrunscript bootstrap API available as a jsh plugin
* Add Nashorn dependency information to the jrunscript bootstrap API

Also:
* Add minimal TypeScript definition declaring jsh.test and add type checking to its plugin
* Clarify documentation surrounding Rhino install replace property and remove deprecated call from top-level script
* Add .run() method to slime.runtime.loader.Store for now
* Improve definition for internal runtime scripts script
* Create easier way to create a Store loader from a directory