### PR TITLE
#1740: Begin transitioning Tomcat API to more wo version

### DIFF
--- a/jrunscript/jsh/tools/install/test/tomcat-hello.jsh.js
+++ b/jrunscript/jsh/tools/install/test/tomcat-hello.jsh.js
@@ -1,0 +1,69 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+//@ts-check
+(
+	/**
+	 * @param { slime.jrunscript.Packages } Packages
+	 * @param { slime.$api.jrunscript.Global } $api
+	 * @param { slime.jsh.Global } jsh
+	 */
+	function(Packages,$api,jsh) {
+		jsh.shell.console("Requiring Tomcat ...");
+		var start = jsh.time.Value.now();
+		jsh.shell.tools.tomcat.jsh.require.simple();
+		var end = jsh.time.Value.now();
+		jsh.shell.console("Requiring Tomcat took " + ((end-start)/1000).toFixed(3) + " seconds.");
+		jsh.shell.console("Creating Tomcat ...");
+		var tomcat = jsh.httpd.tomcat.Server.from.configuration({
+			servlet: {
+				load: function(scope) {
+					scope.$exports.handle = function(request) {
+						try {
+							return {
+								status: { code: 200 },
+								body: {
+									type: "application/json",
+									string: JSON.stringify({
+										method: request.method,
+										path: request.path,
+										java: jsh.shell.properties.get("java.version"),
+										//	TODO	make this an official part of the servlet request
+										tomcat: String(request["java"].adapt().getServletContext().getServerInfo())
+										//tomcatp: jsh.shell.properties.get("org.apache.catalina.startup.Catalina.VERSION")//,
+										//tomcatv: String(Packages.org.apache.catalina.startup.Catalina.VERSION)
+									})
+								}
+							};
+						} catch (e) {
+							jsh.shell.console(e);
+							jsh.shell.console(e.stack);
+						}
+					}
+				}
+			}
+		});
+
+		jsh.shell.console("Starting Tomcat ...");
+		tomcat.start();
+
+		var client = jsh.http.World.question(jsh.http.Implementation.from.java.urlconnection);
+		var mapping = $api.fp.now(client, $api.fp.world.Sensor.mapping());
+		jsh.shell.console("Making request ...");
+		var answer = mapping({
+			url: "http://127.0.0.1:" + tomcat.port + "/foo"
+		});
+		var string = answer.stream.content.string.simple($api.jrunscript.io.Charset.default);
+		//jsh.shell.console(string);
+		jsh.shell.echo(JSON.stringify({
+			status: answer.status,
+			headers: answer.headers,
+			body: JSON.parse(string)
+		},void(0),4));
+		tomcat.stop();
+	}
+//@ts-ignore
+)(Packages,$api,jsh);

--- a/jrunscript/jsh/tools/install/tomcat.js
+++ b/jrunscript/jsh/tools/install/tomcat.js
@@ -26,13 +26,11 @@
 			11: "11.0.7" // JDK 17+
 		};
 
-		/** @type { slime.jsh.shell.tools.tomcat.World } */
+		/** @type { slime.jsh.shell.tools.tomcat.old.World } */
 		var world = {
 			findApache: $context.library.install.apache.find,
 			getLatestVersion: function(major) {
 				return function(events) {
-					//	Work around regression under JDK 17; see https://www.mail-archive.com/users@tomcat.apache.org/msg144624.html
-					if (major == 9) return $api.fp.Maybe.from.some("9.0.98");
 					try {
 						//	This step would fail for Tomcat 7
 						var downloadRawHtml = new $context.library.http.Client().request({
@@ -98,7 +96,7 @@
 		/**
 		 *
 		 * @param { slime.jsh.shell.tools.tomcat.Mock } mock
-		 * @returns { slime.jsh.shell.tools.tomcat.World }
+		 * @returns { slime.jsh.shell.tools.tomcat.old.World }
 		 */
 		var getWorld = function(mock) {
 			return {
@@ -299,11 +297,6 @@
 		};
 
 		$export({
-			input: {
-				getDefaultMajorVersion: function() {
-					return MAJOR_VERSION;
-				}
-			},
 			Installation: Installation,
 			jsh: (Installation_from_jsh()) ? (
 				function() {
@@ -342,6 +335,18 @@
 					);
 					$api.events.Handlers.detach(listener);
 				}
+			},
+			world: {
+				getDefaultMajorVersion: function() {
+					return MAJOR_VERSION;
+				},
+				getLatestVersion: world.getLatestVersion,
+				findApache: world.findApache
+			},
+			api: function(world) {
+				return {
+					world: world
+				};
 			},
 			test: {
 				getVersionFromReleaseNotes: getVersion,

--- a/jrunscript/tools/install/apache.fifty.ts
+++ b/jrunscript/tools/install/apache.fifty.ts
@@ -1,0 +1,91 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+namespace slime.jrunscript.tools.install.apache {
+	export interface Context {
+		client: slime.jrunscript.http.client.object.Client
+		downloads: slime.jrunscript.file.Directory
+		get: slime.jrunscript.tools.install.Exports["get"]
+	}
+
+	export interface Exports {
+		find: slime.jrunscript.tools.install.Exports["apache"]["find"]
+	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			fifty.tests.suite = function() {
+
+			}
+		}
+	//@ts-ignore
+	)(fifty);
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			const { $api, jsh } = fifty.global;
+
+			fifty.tests.manual = {};
+
+			fifty.tests.manual.tomcat = function() {
+				var downloads = fifty.jsh.file.object.temporary.directory();
+
+				const module = (() => {
+					const script: slime.jrunscript.tools.install.Script = fifty.$loader.script("module.js");
+
+					//	TODO	a lot of copy-paste from module.fifty.ts in fixtures; probably should go to separate fixtures.ts
+
+					var defaults: slime.jrunscript.tools.install.Context = {
+						library: {
+							shell: jsh.shell,
+							http: jsh.http,
+							file: jsh.file,
+							web: jsh.web,
+							install: jsh.java.tools
+						},
+						downloads: downloads
+					};
+
+					const api = script(defaults);
+
+					return api;
+				})();
+
+				const subject = (() => {
+					const script: Script = fifty.$loader.script("apache.js");
+					return script({
+						client: new jsh.http.Client(),
+						get: module.get,
+						downloads: downloads
+					})
+				})();
+
+				const majorVersion = 9;
+				const version = "9.0.105";
+				//	TODO	better API for displaying current date
+				var start = jsh.time.Value.now();
+				jsh.shell.console("Downloading to " + downloads + " at " + String(new Date(start)) + " ...");
+				var found = $api.fp.world.Question.now({
+					question: subject.find({
+						path: "tomcat/tomcat-" + majorVersion + "/v" + version + "/bin/apache-tomcat-" + version + ".zip"
+					}),
+					handlers: {
+						console: $api.fp.pipe($api.fp.property("detail"), jsh.shell.console)
+					}
+				});
+				var end = jsh.time.Value.now();
+				jsh.shell.console("Done with download to " + found.pathname.toString() + " after " + ( (end - start) / 1000 ).toFixed(3) + " seconds.");
+			}
+		}
+	//@ts-ignore
+	)(fifty);
+
+	export type Script = slime.runtime.loader.Module<Context,Exports>
+}

--- a/jrunscript/tools/install/apache.js
+++ b/jrunscript/tools/install/apache.js
@@ -10,8 +10,8 @@
 	 *
 	 * @param { slime.jrunscript.Packages } Packages
 	 * @param { slime.$api.Global } $api
-	 * @param { { client: slime.jrunscript.http.client.object.Client, downloads: slime.jrunscript.file.Directory, get: slime.jrunscript.tools.install.Exports["get"] } } $context
-	 * @param { { find: slime.jrunscript.tools.install.Exports["apache"]["find"] } } $exports
+	 * @param { slime.jrunscript.tools.install.apache.Context } $context
+	 * @param { slime.jrunscript.tools.install.apache.Exports } $exports
 	 */
 	function(Packages,$api,$context,$exports) {
 		var getMirror = function() {
@@ -40,6 +40,7 @@
 						return mirror + p.path
 					})
 				});
+				events.fire("console", "Downloading from " + argument.url + " ...");
 				return $context.get(argument);
 			};
 		};

--- a/rhino/http/servlet/server.js
+++ b/rhino/http/servlet/server.js
@@ -199,6 +199,12 @@
 					}
 				}
 				log.FINE("Created request body.");
+
+				this.java = {
+					adapt: function() {
+						return _request;
+					}
+				}
 			}
 		);
 


### PR DESCRIPTION
Also:
* Remove Tomcat 9 version lock for point release problems
* Remove dead Tomcat installation code
* Add manual test for Tomcat installation and run
* Create definition around Apache download script
* Create API for accessing Java HttpServletRequest from servlet request