### PR TITLE
Resolve #1968: Set GIT_EDITOR in devcontainer

### DIFF
--- a/.devcontainer/docker-compose.extend.yaml
+++ b/.devcontainer/docker-compose.extend.yaml
@@ -8,3 +8,5 @@ version: '3.9'
 services:
   local:
     command: sleep infinity
+    environment:
+      GIT_EDITOR=code --wait


### PR DESCRIPTION
Value will be code --wait, which makes it possible to commit from the devcontainer and use VSCode as the commit message editor.