### PR TITLE
#1961: Refactor jrunscript bootstrap launcher

### DIFF
--- a/jrunscript/jsh/etc/build.jsh.js
+++ b/jrunscript/jsh/etc/build.jsh.js
@@ -59,7 +59,6 @@
 						jsh.loader.run(jsh.file.Pathname(url), {}, THIS);
 					}
 				},
-				readFile: void(0),
 				readUrl: void(0),
 				$api: void(0),
 				launcher: void(0),

--- a/jrunscript/jsh/launcher/javac.js
+++ b/jrunscript/jsh/launcher/javac.js
@@ -505,7 +505,7 @@
 						this.getCharContent = function() {
 							var fromArchive = $api.github.archives.getSourceFile(_url);
 							if (fromArchive !== null) return fromArchive;
-							return new Packages.java.lang.String($api.engine.readUrl(_url.toExternalForm()));
+							return new Packages.java.lang.String($api.engine.readUrl(String(_url.toExternalForm())));
 							// throw new Error("getCharContent: " + _url);
 						}
 

--- a/jsh
+++ b/jsh
@@ -258,7 +258,8 @@ install_jdk() {
 }
 
 
-JSH_BOOTSTRAP_RHINO="${JSH_SHELL_LIB}/js.jar"
+#	Possible basis for supporting Rhino as bootstrap engine via JSR-223
+#	JSH_BOOTSTRAP_RHINO="${JSH_SHELL_LIB}/js.jar"
 JSH_BOOTSTRAP_NASHORN="${JSH_SHELL_LIB}/nashorn.jar"
 # @notdry nashorn-dependencies
 JSH_BOOTSTRAP_NASHORN_LIBRARIES_GROUP=org.ow2.asm

--- a/loader/jrunscript/native.fifty.ts
+++ b/loader/jrunscript/native.fifty.ts
@@ -525,6 +525,7 @@ namespace slime.jrunscript {
 				URI: any
 				URL: {
 					new (base: slime.jrunscript.native.java.net.URL, relative: string): slime.jrunscript.native.java.net.URL
+					new (url: slime.jrunscript.native.java.lang.String): slime.jrunscript.native.java.net.URL
 					new (url: string): slime.jrunscript.native.java.net.URL
 				}
 				URLEncoder: any

--- a/rhino/jrunscript/api.fifty.ts
+++ b/rhino/jrunscript/api.fifty.ts
@@ -114,9 +114,14 @@ namespace slime.internal.jrunscript.bootstrap {
 		Packages: slime.jrunscript.Packages
 		JavaAdapter?: any
 
-		//	Rhino-provided
-		readFile?: any
-		readUrl?: any
+		/**
+		 * Reads a URL in a way compatible with the Rhino shell. See the
+		 * [Rhino documentation](https://rhino.github.io/tools/shell/).
+		 *
+		 * If provided in the global scope (the Rhino engine provides it), the existing implementation will be used. Otherwise, a
+		 * compatible implementation will be supplied.
+		 */
+		readUrl?: (url: string) => string
 
 		//	Nashorn-provided
 		//	Used to provide debug output before Packages is loaded
@@ -186,8 +191,8 @@ namespace slime.internal.jrunscript.bootstrap {
 		engine: {
 			toString: () => string
 			resolve: any
-			readFile: any
-			readUrl: any
+
+			readUrl: Environment["readUrl"]
 
 			/**
 			 * Attempts to be compatible with the old Rhino shell `runCommand` implementation.
@@ -270,7 +275,11 @@ namespace slime.internal.jrunscript.bootstrap {
 			running: () => slime.jrunscript.native.jdk.nashorn.internal.runtime.Context
 		}
 
-		shell: any
+		shell: {
+			environment: any
+			HOME: any
+			exec: any
+		}
 	}
 
 	(

--- a/rhino/jrunscript/api.html
+++ b/rhino/jrunscript/api.html
@@ -17,45 +17,6 @@ END LICENSE
 		<div>
 		</div>
 		<div>
-			<h1>Context</h1>
-			<ul>
-				<li class="function">
-					<div class="name">readFile</div>
-					<span>
-						If provided in the global scope (the Rhino engine provides it), the existing implementation will be used.
-						Otherwise, a compatible implementation will be supplied.
-					</span>
-					<div class="arguments">
-						<div class="label">Arguments</div>
-						<ol>
-						</ol>
-					</div>
-					<div class="returns">
-						<div class="label">Returns</div>
-						<span class="type">__TYPE__</span>
-						<span>__DESCRIPTION__</span>
-					</div>
-				</li>
-				<li class="function">
-					<div class="name">readUrl</div>
-					<span>
-						If provided in the global scope (the Rhino engine provides it), the existing implementation will be used.
-						Otherwise, a compatible implementation will be supplied.
-					</span>
-					<div class="arguments">
-						<div class="label">Arguments</div>
-						<ol>
-						</ol>
-					</div>
-					<div class="returns">
-						<div class="label">Returns</div>
-						<span class="type">__TYPE__</span>
-						<span>__DESCRIPTION__</span>
-					</div>
-				</li>
-			</ul>
-		</div>
-		<div>
 			<h1>Exports</h1>
 			<div>
 				The <code>this</code> object will contain the following properties after the script executes:
@@ -93,20 +54,6 @@ END LICENSE
 											<code>rhino</code>, <code>nashorn</code>, or <code>jdkrhino</code> property of
 											the given object will be returned.
 										</span>
-									</div>
-								</li>
-								<li class="function">
-									<div class="name">readFile</div>
-									<span>__DESCRIPTION__</span>
-									<div class="arguments">
-										<div class="label">Arguments</div>
-										<ol>
-										</ol>
-									</div>
-									<div class="returns">
-										<div class="label">Returns</div>
-										<span class="type">__TYPE__</span>
-										<span>__DESCRIPTION__</span>
 									</div>
 								</li>
 								<li class="function">
@@ -307,41 +254,6 @@ END LICENSE
 								</li>
 								<li class="function">
 									<div class="name">unzip</div>
-									<span>__DESCRIPTION__</span>
-									<div class="arguments">
-										<div class="label">Arguments</div>
-										<ol>
-										</ol>
-									</div>
-									<div class="returns">
-										<div class="label">Returns</div>
-										<span class="type">__TYPE__</span>
-										<span>__DESCRIPTION__</span>
-									</div>
-								</li>
-							</ul>
-						</li>
-						<li class="object">
-							<div class="name">bitbucket</div>
-							<span>__DESCRIPTION__</span>
-							<div class="label">has properties:</div>
-							<ul>
-								<li class="function">
-									<div class="name">get</div>
-									<span>__DESCRIPTION__</span>
-									<div class="arguments">
-										<div class="label">Arguments</div>
-										<ol>
-										</ol>
-									</div>
-									<div class="returns">
-										<div class="label">Returns</div>
-										<span class="type">__TYPE__</span>
-										<span>__DESCRIPTION__</span>
-									</div>
-								</li>
-								<li class="function">
-									<div class="name">script</div>
 									<span>__DESCRIPTION__</span>
 									<div class="arguments">
 										<div class="label">Arguments</div>

--- a/rhino/jrunscript/api.js
+++ b/rhino/jrunscript/api.js
@@ -369,16 +369,6 @@
 			resolve: function(p) {
 				return $engine.resolve(p);
 			},
-			readFile: (this.readFile) ? this.readFile : function(path) {
-				var rv = "";
-				var reader = new Packages.java.io.FileReader(path);
-				var c;
-				while((c = reader.read()) != -1) {
-					var _character = new Packages.java.lang.Character(c);
-					rv += _character.toString();
-				}
-				return rv;
-			},
 			readUrl: (this.readUrl) ? this.readUrl : function(path) {
 				var rv = "";
 				var connection = new Packages.java.net.URL(path).openConnection();
@@ -1322,7 +1312,11 @@
 
 		$api.nashorn = nashorn;
 
-		$api.shell = {};
+		$api.shell = {
+			environment: void(0),
+			HOME: void(0),
+			exec: void(0)
+		};
 		$api.shell.environment = (function() {
 			var rv = {};
 			var _map = Packages.java.lang.System.getenv();
@@ -1415,34 +1409,6 @@
 			});
 			return result;
 		}
-		$api.shell.rhino = function(p) {
-			//	p:
-			//		rhino (Packages.java.io.File): Rhino js.jar
-			//		script (Packages.java.io.File): main script to run
-			//		arguments (Array): arguments to send to script
-			//		directory (optional Packages.java.io.File): working directory in which to run it
-			//		properties: (Object): keys are keys, values are values
-			var dashD = [];
-			if (p.properties) {
-				for (var x in p.properties) {
-					dashD.push("-D" + x + "=" + p.properties[x]);
-				}
-			}
-			var args = []
-				.concat(dashD)
-				.concat([
-					"-jar", p.rhino.getCanonicalPath(),
-					"-opt", "-1",
-					p.script.getCanonicalPath()
-				]).concat((p.arguments) ? p.arguments : [])
-			;
-
-			$api.shell.exec({
-				command: $api.java.install.launcher.getCanonicalPath(),
-				arguments: args,
-				directory: p.directory
-			});
-		};
 
 		this.$api = $api;
 	}


### PR DESCRIPTION
* Remove unused dependency on Rhino readFile
* Document readUrl
* Migrate documentation JSAPI -> Fifty
* Remove references to removed boostrap $api.bitbucket
* Remove unused $api.shell.rhino and $api.shell.exec