### PR TITLE
#1961: WIP to make launcher $api.jsh available in jsh

### DIFF
--- a/jrunscript/jsh/etc/api.js
+++ b/jrunscript/jsh/etc/api.js
@@ -81,7 +81,7 @@
 
 	components.add("jrunscript/jsh/loader/loader.api.html", { jsh: { api: true } });
 	components.add("rhino/shell/plugin.jsh.api.html", { jsh: { api: true } });
-	components.add("jrunscript/jsh/launcher/", { jsh: { api: true } });
+	components.add("jrunscript/jsh/launcher/", { jsh: { api: true, module: true } });
 
 	components.add("jrunscript/jsh/tools/install/", { jsh: { api: true, module: true } });
 

--- a/jrunscript/jsh/launcher/plugin.jsh.js
+++ b/jrunscript/jsh/launcher/plugin.jsh.js
@@ -1,0 +1,39 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+//@ts-check
+(
+	/**
+	 * @param { slime.jrunscript.Packages } Packages
+	 * @param { slime.$api.jrunscript.Global } $api
+	 * @param { slime.jsh.Global } jsh
+	 * @param { slime.jsh.plugin.Scope["plugins"] } plugins
+	 * @param { slime.runtime.loader.Store } $loader
+	 * @param { slime.jsh.plugin.Scope["plugin"] } plugin
+	 */
+	function(Packages,$api,jsh,plugins,$loader,plugin) {
+		plugin({
+			isReady: function() {
+				return Boolean(plugins.launcher);
+			},
+			load: function() {
+				var target = {
+					$api: plugins.launcher,
+					Packages: Packages,
+					embed: true
+				};
+
+				//	#1961: enable
+				//$loader.run("main.js", {}, target);
+
+				jsh.internal = {
+					bootstrap: target.$api
+				};
+			}
+		})
+	}
+//@ts-ignore
+)(Packages,$api,jsh,plugins,$loader,plugin);

--- a/jrunscript/jsh/launcher/test/manual/embed.jsh.js
+++ b/jrunscript/jsh/launcher/test/manual/embed.jsh.js
@@ -1,0 +1,24 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+//@ts-check
+(
+	/**
+	 * @param { slime.$api.jrunscript.Global } $api
+	 * @param { slime.jsh.Global } jsh
+	 */
+	function($api,jsh) {
+		//	#1961: convert to automated test after development?
+		jsh.script.cli.main(function() {
+			jsh.shell.console("Hello, World!");
+
+			jsh.shell.console("keys = " + Object.keys(jsh.internal.bootstrap).join(" "));
+			//	#1961
+			//jsh.shell.console(String(jsh.internal.bootstrap.jsh));
+		})
+	}
+//@ts-ignore
+)($api,jsh);

--- a/jrunscript/jsh/test/tools/run-in-built-shell.jsh.js
+++ b/jrunscript/jsh/test/tools/run-in-built-shell.jsh.js
@@ -15,7 +15,8 @@
 		var parameters = jsh.script.getopts({
 			options: {
 				packaged: false,
-				launcherDebug: false
+				launcherDebug: false,
+				rhinoDebug: false
 			},
 			unhandled: jsh.script.getopts.UNEXPECTED_OPTION_PARSER.SKIP
 		});
@@ -52,7 +53,10 @@
 					jsh.shell.jsh({
 						shell: JSH_HOME,
 						script: jsh.file.Pathname(parameters.arguments[0]).file,
-						arguments: parameters.arguments.slice(1)
+						arguments: parameters.arguments.slice(1),
+						environment: $api.Object.compose(jsh.shell.environment, (parameters.options.rhinoDebug) ? {
+							JSH_DEBUG_SCRIPT: "rhino"
+						} : {})
 					});
 					jsh.shell.console("Ran in built shell.");
 				} else {

--- a/loader/content.fifty.ts
+++ b/loader/content.fifty.ts
@@ -190,12 +190,6 @@ namespace slime.runtime.content {
 	)(fifty);
 }
 
-namespace slime.$api {
-	export interface Global {
-		content: slime.runtime.content.Exports
-	}
-}
-
 namespace slime.runtime.internal.content {
 	export type Context = void
 

--- a/loader/expression.fifty.ts
+++ b/loader/expression.fifty.ts
@@ -976,4 +976,14 @@ namespace slime {
 		//@ts-ignore
 		)( (function() { return this; })().Packages, fifty)
 	}
+
+	export namespace $api {
+		export interface Global {
+			engine: {
+				execute: slime.runtime.Engine["execute"]
+			}
+
+			content: slime.runtime.content.Exports
+		}
+	}
 }

--- a/loader/expression.js
+++ b/loader/expression.js
@@ -267,6 +267,10 @@
 			}
 		);
 
+		$api.engine = {
+			execute: $engine.execute
+		};
+
 		$api.content = code.content();
 
 		var scripts = code.scripts(

--- a/loader/jrunscript/native.fifty.ts
+++ b/loader/jrunscript/native.fifty.ts
@@ -91,6 +91,7 @@ namespace slime.jrunscript {
 					close: () => void
 				}
 				export interface PrintStream extends OutputStream {
+					print: (string: string) => void
 					println: (line: string) => void
 				}
 				export interface File {
@@ -455,10 +456,7 @@ namespace slime.jrunscript {
 					slime.jrunscript.native.java.lang.Object,
 					{
 						err: slime.jrunscript.native.java.io.PrintStream
-						out: {
-							print: any
-							println: any
-						}
+						out: slime.jrunscript.native.java.io.PrintStream
 						console: () => any
 						currentTimeMillis(): number
 						setProperty(name: string, value: string)

--- a/rhino/jrunscript/api.js
+++ b/rhino/jrunscript/api.js
@@ -1520,7 +1520,10 @@
 				return rv;
 			})();
 			if ($query == "api") {
-				if (!$api.script) throw new Error("No $api.script");
+				if (!$api.script) {
+					//	TODO	#1961
+					$api.embed = {};
+				}
 				if ($api.script.resolve("main.js")) {
 					//	built shell
 					$api.embed = {

--- a/rhino/jrunscript/api.js
+++ b/rhino/jrunscript/api.js
@@ -1521,10 +1521,9 @@
 			})();
 			if ($query == "api") {
 				if (!$api.script) {
-					//	TODO	#1961
+					//	TODO	#1961 Embedding in built shell
 					$api.embed = {};
-				}
-				if ($api.script.resolve("main.js")) {
+				} else if ($api.script.resolve("main.js")) {
 					//	built shell
 					$api.embed = {
 						jsh: $api.script.resolve("main.js")

--- a/rhino/jrunscript/embed.js
+++ b/rhino/jrunscript/embed.js
@@ -16,6 +16,7 @@
 	function(Packages,JavaAdapter,$api,$context,$loader,$export) {
 		/** @type { slime.js.Cast<slime.jrunscript.bootstrap.Exports> } */
 		var after = $api.fp.cast.unsafe;
+
 		var jrunscript = {
 			$api: {
 				debug: ($context.debug) ? function(message) {
@@ -24,9 +25,21 @@
 				script: $context.script,
 				arguments: ["api"]
 			},
-			load: function() {
-				//	TODO	we can probably implement load() using $loader ...
-				//jsh.shell.console("load(" + Array.prototype.slice.call(arguments) + ")");
+			load: function(script) {
+				//	for unbuilt / built, script is an absolute path to a file
+				var _file = new Packages.java.io.File(script);
+				if (_file.exists()) {
+					$api.engine.execute(
+						{
+							name: script,
+							js: new Packages.java.lang.String(Packages.java.nio.file.Files.readAllBytes(_file.toPath()))
+						},
+						{},
+						jrunscript
+					)
+				} else {
+					throw new Error("load(" + script + ")");
+				}
 			},
 			Packages: Packages,
 			JavaAdapter: JavaAdapter,
@@ -34,6 +47,7 @@
 			readUrl: void(0),
 			Java: void(0)
 		};
+
 		$loader.run("api.js", {}, jrunscript);
 		$export(after(jrunscript.$api));
 	}

--- a/rhino/jrunscript/embed.js
+++ b/rhino/jrunscript/embed.js
@@ -26,6 +26,7 @@
 				arguments: ["api"]
 			},
 			load: function(script) {
+				if (script == "nashorn:mozilla_compat.js") return;
 				//	for unbuilt / built, script is an absolute path to a file
 				var _file = new Packages.java.io.File(script);
 				if (_file.exists()) {

--- a/rhino/jrunscript/plugin.jsh.fifty.ts
+++ b/rhino/jrunscript/plugin.jsh.fifty.ts
@@ -8,6 +8,8 @@ namespace slime.jsh {
 	export interface Global {
 		internal: {
 			bootstrap: slime.internal.jrunscript.bootstrap.Api<{}>
+			//	#1961
+			//bootstrap: slime.jsh.internal.launcher.Global["$api"]
 		}
 	}
 

--- a/rhino/jrunscript/plugin.jsh.js
+++ b/rhino/jrunscript/plugin.jsh.js
@@ -10,23 +10,23 @@
 	 *
 	 * @param { slime.$api.Global } $api
 	 * @param { slime.jsh.Global } jsh
+	 * @param { slime.jsh.plugin.Scope["plugins"] } plugins
 	 * @param { slime.Loader } $loader
 	 * @param { slime.jsh.plugin.Scope["plugin"] } plugin
 	 */
-	function($api,jsh,$loader,plugin) {
+	function($api,jsh,plugins,$loader,plugin) {
 		plugin({
 			load: function() {
+
 				/** @type { slime.jrunscript.bootstrap.Script } */
 				var jrunscriptBootstrap = $loader.script("embed.js");
 				var jrunscriptBootstrapApis = jrunscriptBootstrap({
 					debug: false,
 					script: {}
 				});
-				jsh.internal = {
-					bootstrap: jrunscriptBootstrapApis
-				};
+				plugins.launcher = jrunscriptBootstrapApis;
 			}
 		})
 	}
 //@ts-ignore
-)($api,jsh,$loader,plugin);
+)($api,jsh,plugins,$loader,plugin);


### PR DESCRIPTION
* Add Java major version calculation to jsh launcher $api.java
* Implement load() from Rhino/Nashorn shells in embedding

Also:
* Make JavaScript execution engine available as $api.engine.execute
* Tidy up Java version handling in jrunscript/jsh/launcher/main.js
* Add Rhino debugger to jrunscript/jsh/test/tools/run-in-built-shell.jsh.js