### PR TITLE
#2006: Fix namespaces in loader/document

### DIFF
--- a/README.fifty.ts
+++ b/README.fifty.ts
@@ -93,6 +93,12 @@
  * low-level {@link slime.runtime.Platform | `$platform`} object is also provided to all code loaded; `$platform` may provide access
  * to engine-specific capabilities.
  *
+ * #### HTML / XML document codec
+ *
+ * SLIME provides a pure JavaScript parser and serializer for HTML and XML that is lossless; unlike a standard DOM parser, it will
+ * output the same string of characters on serialization that it read on parse. The implementation provides a DOM-like API for
+ * manipulating parsed documents. See the {@link slime.runtime.document} namespace.
+ *
  * ### SLIME definitions (documentation and testing): the `fifty` tool
  *
  * SLIME has the concept of a _definition_, which is a construct that provides both documentation and a test suite for a particular
@@ -128,7 +134,7 @@
  *
  * ### Bundled tools and examples
  *
- * SLIME has several potentially useful programs bundled in its distribution
+ * SLIME has several potentially useful programs bundled in its distribution.
  *
  * #### Serve a directory (and optionally open a Chrome browser to browse it)
  *

--- a/loader/document/module.fifty.ts
+++ b/loader/document/module.fifty.ts
@@ -10,6 +10,10 @@
  * {@link slime.runtime.document.exports.Document | `Document.codec.string`} and
  * {@link slime.runtime.document.Exports | `Fragment.codec.string`}.
  *
+ * For `jsh`, the {@link Exports} are available as `jsh.document` (along with other, older exports from other modules). For the
+ * browser and servlet environments, the `loader/document/module.js` module can be loaded in order to receive the
+ * platform-independent parser.
+ *
  * Note that the "objects" returned by this parser are "dumb" objects, and are not really designed to be used by the application.
  * Rather, the application should use the functional interfaces provided for operating on these objects. For example:
  *
@@ -22,6 +26,13 @@
  * information about them.
  */
 namespace slime.runtime.document {
+	export interface Context {
+		/**
+		 * If present, its `java` property allows the use of the older JSoup-based Java document parsing.
+		 */
+		$slime?: Pick<old.Context["$slime"],"java">
+	}
+
 	export namespace test {
 		export const subject = (function(fifty: slime.fifty.test.Kit) {
 			var script: Script = fifty.$loader.script("module.js");
@@ -35,13 +46,6 @@ namespace slime.runtime.document {
 		})(fifty);
 	}
 
-	export interface Context {
-		/**
-		 * If present, its `java` property allows the use of the older JSoup-based Java document parsing.
-		 */
-		$slime?: Pick<old.Context["$slime"],"java">
-	}
-
 	/**
 	 * @experimental
 	 */
@@ -49,8 +53,8 @@ namespace slime.runtime.document {
 		xml?: boolean
 	}
 
-	export namespace exports {
-		export interface Document {
+	export namespace document {
+		export interface Exports {
 			codec: {
 				string: slime.Codec<slime.runtime.document.Document,string>
 			}
@@ -93,17 +97,21 @@ namespace slime.runtime.document {
 	}
 
 	export interface Exports {
+		Document: document.Exports
+	}
+
+	export interface Exports {
 		load: old.Exports["load"]
 	}
 
-	export namespace exports {
-		export interface Node {
-			isElementNamed: (name: string) => slime.$api.fp.TypePredicate<document.Node,document.Element>
+	export namespace node {
+		export interface Exports {
+			isElementNamed: (name: string) => slime.$api.fp.TypePredicate<runtime.document.Node,runtime.document.Element>
 		}
 	}
 
 	export interface Exports {
-		Node: exports.Node
+		Node: node.Exports
 	}
 
 	export interface Exports {
@@ -216,8 +224,6 @@ namespace slime.runtime.document {
 	)(fifty);
 
 	export interface Exports {
-		Document: exports.Document
-
 		Fragment: {
 			codec: {
 				string: slime.Codec<slime.runtime.document.Fragment,string>
@@ -225,16 +231,16 @@ namespace slime.runtime.document {
 		}
 	}
 
-	export namespace exports {
-		export interface Element {
-			isName: (name: string) => (element: document.Element) => boolean
-			getAttribute: (name: string) => (element: document.Element) => slime.$api.fp.Maybe<string>
+	export namespace element {
+		export interface Exports {
+			isName: (name: string) => (element: runtime.document.Element) => boolean
+			getAttribute: (name: string) => (element: runtime.document.Element) => slime.$api.fp.Maybe<string>
 			from: element.From
 		}
 	}
 
 	export interface Exports {
-		Element: exports.Element
+		Element: element.Exports
 	}
 
 	export type Script = slime.loader.Script<Context | void,Exports>

--- a/loader/document/module.js
+++ b/loader/document/module.js
@@ -450,7 +450,7 @@
 			},
 			Node: $api.Object.compose(
 				source.Node,
-				/** @type { Pick<slime.runtime.document.exports.Node,"isElementNamed"> } */({
+				/** @type { Pick<slime.runtime.document.node.Exports,"isElementNamed"> } */({
 					isElementNamed: function(name) {
 						return $api.fp.Predicate.and([
 							source.Node.isElement,

--- a/loader/document/source.fifty.ts
+++ b/loader/document/source.fifty.ts
@@ -90,16 +90,16 @@ namespace slime.runtime.document {
 		}
 	}
 
-	export namespace exports {
-		export interface Node {
+	export namespace node {
+		export interface Exports {
 			isComment: (node: slime.runtime.document.Node) => node is slime.runtime.document.Comment
 			isText: (node: slime.runtime.document.Node) => node is slime.runtime.document.Text
 			isDoctype: (node: slime.runtime.document.Node) => node is slime.runtime.document.Doctype
 			isDocument: (node: slime.runtime.document.Node) => node is slime.runtime.document.Document
 			isElement: (node: slime.runtime.document.Node) => node is slime.runtime.document.Element
 			isFragment: (node: slime.runtime.document.Node) => node is slime.runtime.document.Fragment
-			isParent: (node: document.Node) => node is document.Parent
-			isString: (node: document.Node) => node is document.String
+			isParent: (node: runtime.document.Node) => node is runtime.document.Parent
+			isString: (node: runtime.document.Node) => node is runtime.document.String
 		}
 	}
 


### PR DESCRIPTION
Also:
* Add existence of loader/document to top-level README and document usage in namespace comment