### PR TITLE
#2006: Deprecate old loader/document load() correctly

### DIFF
--- a/loader/api/old/jsh/html.js
+++ b/loader/api/old/jsh/html.js
@@ -57,7 +57,7 @@
 								return new JsapiHtml(file.parent,doc);
 							} else {
 								var doc = (function() {
-									return jsh.document.load({
+									return /** @type { slime.jsh.Global }*/(jsh).document.load({
 										//	TODO	there is a loader/path version of this instead of string
 										string: file.read(String)
 									});

--- a/loader/document/module.fifty.ts
+++ b/loader/document/module.fifty.ts
@@ -116,6 +116,9 @@ namespace slime.runtime.document {
 	}
 
 	export interface Exports {
+		/**
+		 * @deprecated
+		 */
 		load: old.Exports["load"]
 	}
 

--- a/loader/document/old.fifty.ts
+++ b/loader/document/old.fifty.ts
@@ -21,10 +21,7 @@ namespace slime.runtime.document.old {
 	export interface Exports {
 		//	TODO	one remaining use of this, in loader/api/old/jsh/html.js. Is that code dead?
 		//			looks like it is probably used as part of running JSAPI tests
-		/**
-		 * @deprecated
-		 */
-		load: any
+		load: (p: { string: string }) => any
 	}
 
 	export namespace test {
@@ -71,18 +68,9 @@ namespace slime.runtime.document.old {
 					fifty.verify(missing).is.type("null");
 				});
 
-				fifty.run(function parse() {
-					var page = api.load({
-						loader: fifty.$loader,
-						path: "test/data/1.html"
-					});
-					testsFor1(page,fifty.verify,true);
-				});
-
 				fifty.run(function codec() {
 					var page = api.load({
-						loader: fifty.$loader,
-						path: "test/data/1.html"
+						string: fifty.$loader.get("test/data/1.html").read(String)
 					});
 					var string: string = page.serialize();
 					var reparsed = api.load({

--- a/loader/document/old.js
+++ b/loader/document/old.js
@@ -316,14 +316,7 @@
 
 		$export({
 			load: (parser) ? function(p) {
-				if (p.loader && p.path) {
-					var html = p.loader.get(p.path).read(String);
-					return parser(html);
-				} else if (p.string) {
-					return parser(p.string);
-				} else {
-					throw new TypeError();
-				}
+				return parser(p.string);
 			} : void(0)
 		})
 	}


### PR DESCRIPTION
* Remove unused (outside tests) overload of loader/document load()
* Add a bit of type checking to JSAPI processor