### PR TITLE
#1961: Massive refactor of Java engine handling

### DIFF
--- a/jrunscript/jsh/launcher/launcher.js
+++ b/jrunscript/jsh/launcher/launcher.js
@@ -148,6 +148,12 @@
 					if (status !== null) {
 						Packages.java.lang.System.exit(status);
 					}
+				},
+				//	TODO	the below is untested
+				graal: function(status) {
+					if (status !== null) {
+						Packages.java.lang.System.exit(status);
+					}
 				}
 			});
 

--- a/jrunscript/jsh/launcher/main.js
+++ b/jrunscript/jsh/launcher/main.js
@@ -99,7 +99,7 @@
 
 		//	If Rhino location not specified, and we are running this script inside Rhino, set that to be the default Rhino location for the
 		//	shell
-		$api.slime.settings.default("jsh.engine.rhino.classpath", $api.rhino.classpath);
+		$api.slime.settings.default("jsh.engine.rhino.classpath", $api.engine.rhino.classpath);
 
 		//	If SLIME source location not specified, and we can determine it, supply it to the shell
 		$api.slime.settings.default("jsh.shell.src", ($api.slime.src) ? String($api.slime.src) : null);

--- a/jrunscript/jsh/launcher/slime.js
+++ b/jrunscript/jsh/launcher/slime.js
@@ -35,9 +35,11 @@
 			})();
 		}
 
+		//	TODO	not sure this makes any sense at all; why are we replacing the classpath from which Rhino can be loaded in this
+		//			circumstance? How is this used?
 		if (Packages.java.lang.System.getProperty("jsh.engine.rhino.classpath")) {
 			//	TODO	hard-coded assumption that this is file
-			$$api.rhino.classpath = function() {
+			$$api.engine.rhino.classpath = function() {
 				return new Packages.java.io.File(Packages.java.lang.System.getProperty("jsh.engine.rhino.classpath"))
 			};
 		}

--- a/jrunscript/jsh/launcher/slime.js
+++ b/jrunscript/jsh/launcher/slime.js
@@ -37,7 +37,9 @@
 
 		if (Packages.java.lang.System.getProperty("jsh.engine.rhino.classpath")) {
 			//	TODO	hard-coded assumption that this is file
-			$$api.rhino.classpath = new Packages.java.io.File(Packages.java.lang.System.getProperty("jsh.engine.rhino.classpath"));
+			$$api.rhino.classpath = function() {
+				return new Packages.java.io.File(Packages.java.lang.System.getProperty("jsh.engine.rhino.classpath"))
+			};
 		}
 
 		$$api.slime = (function(was) {

--- a/jrunscript/jsh/test/jsh-data.jsh.js
+++ b/jrunscript/jsh/test/jsh-data.jsh.js
@@ -54,19 +54,19 @@
 		};
 
 		var engines = {};
-		if (bootstrap && bootstrap.rhino.isPresent()) {
+		if (bootstrap && bootstrap.engine.rhino.isPresent()) {
 			engines.rhino = true;
-			if (bootstrap && bootstrap.rhino.running()) {
+			if (bootstrap && bootstrap.engine.rhino.running()) {
 				engines.current = {
 					name: "rhino",
-					version: String(bootstrap.rhino.running().getImplementationVersion()),
-					optimization: bootstrap.rhino.running().getOptimizationLevel()
+					version: String(bootstrap.engine.rhino.running().getImplementationVersion()),
+					optimization: bootstrap.engine.rhino.running().getOptimizationLevel()
 				};
 			}
 		}
-		if (bootstrap && bootstrap.nashorn.isPresent()) {
+		if (bootstrap && bootstrap.engine.nashorn.isPresent()) {
 			engines.nashorn = true;
-			if (bootstrap && bootstrap.nashorn.running()) {
+			if (bootstrap && bootstrap.engine.nashorn.running()) {
 				engines.current = {
 					name: "nashorn"
 				};

--- a/loader/jrunscript/native.fifty.ts
+++ b/loader/jrunscript/native.fifty.ts
@@ -94,7 +94,7 @@ namespace slime.jrunscript {
 					print: (string: string) => void
 					println: (line: string) => void
 				}
-				export interface File {
+				export interface File extends slime.jrunscript.native.java.lang.Object {
 					exists(): boolean
 					isDirectory(): boolean
 					toPath(): slime.jrunscript.native.java.nio.file.Path

--- a/loader/jrunscript/native.fifty.ts
+++ b/loader/jrunscript/native.fifty.ts
@@ -38,6 +38,7 @@ namespace slime.jrunscript {
 					getMethod(name: string): reflect.Method
 					getSuperclass(): Class
 					getInterfaces(): Class[]
+					getProtectionDomain(): any
 				}
 
 				export interface ClassLoader {

--- a/loader/polyfill.fifty.ts
+++ b/loader/polyfill.fifty.ts
@@ -122,9 +122,13 @@ interface Array<T> {
 
         //  Rhino 1.8.0: natively supports all
         //  Rhino 1.7.15: untested
-        //  Nashorn 15.6: lacks all
+        //  Nashorn 15.6: supports only Object.defineProperty, but does support it all the way back to Java 8
 
         fifty.tests.manual.engine = function() {
+            if (fifty.global.jsh) {
+                fifty.global.jsh.shell.console("java version = " + fifty.global.jsh.shell.java.version);
+            }
+            console("Object.defineProperty: " + Object.defineProperty);
             console("Object.assign: " + Object.assign);
             console("Object.fromEntries: " + Object.fromEntries);
             console("Object.entries: " + Object.entries);

--- a/rhino/http/servlet/tools/plugin.jsh.js
+++ b/rhino/http/servlet/tools/plugin.jsh.js
@@ -172,9 +172,9 @@
 									nextInitParamIndex = i+1;
 								}
 							}
-							jsh.shell.console("Rhino? " + Boolean(jsh.internal.bootstrap.rhino.running()));
-							if (jsh.internal.bootstrap.rhino.running()) {
-								jsh.shell.console("Rhino version " + jsh.internal.bootstrap.rhino.running().getImplementationVersion());
+							jsh.shell.console("Rhino? " + Boolean(jsh.internal.bootstrap.engine.rhino.running()));
+							if (jsh.internal.bootstrap.engine.rhino.running()) {
+								jsh.shell.console("Rhino version " + jsh.internal.bootstrap.engine.rhino.running().getImplementationVersion());
 							}
 							jsh.shell.console("nextInitParamIndex = " + nextInitParamIndex);
 							var initParamLines = [];

--- a/rhino/jrunscript/api.fifty.ts
+++ b/rhino/jrunscript/api.fifty.ts
@@ -191,7 +191,23 @@ namespace slime.internal.jrunscript.bootstrap {
 
 		engine: {
 			toString: () => string
-			resolve: any
+
+			/**
+			 * A method which, given values for each potential JavaScript engine, returns the value for the engine that is actually
+			 * running.
+			 *
+			 * @param option An object with a property for each potential JavaScript engine
+			 *
+			 * @returns The value of the property representing the JavaScript engine which is running.
+			 */
+			resolve: <T>(option: {
+				rhino: T
+				nashorn: T
+				graal: T
+
+				//	legacy compatibility with pre-JDK 8 Rhino; now unsupported
+				jdkrhino?: T
+			}) => T
 
 			readUrl: Environment["readUrl"]
 
@@ -318,7 +334,7 @@ namespace slime.internal.jrunscript.bootstrap {
 			/**
 			 * The location from which Rhino was loaded, specifically the `org.mozilla.javascript.Context` class.
 			 */
-			classpath: slime.jrunscript.native.java.io.File
+			classpath: () => slime.jrunscript.native.java.io.File
 
 			/**
 			 * Whether Rhino is currently available on the classpath.
@@ -326,7 +342,7 @@ namespace slime.internal.jrunscript.bootstrap {
 			isPresent: () => boolean
 
 			/**
-			 * Whether Rhino is the engine currently executing JavaScript.
+			 * If Rhino is currently running this script, the current Rhino script context.
 			 */
 			running: () => slime.jrunscript.native.org.mozilla.javascript.Context
 		}

--- a/rhino/jrunscript/api.fifty.ts
+++ b/rhino/jrunscript/api.fifty.ts
@@ -80,6 +80,12 @@ namespace slime.internal.jrunscript.bootstrap {
 		debug?: boolean
 	}
 
+	export interface JavaClasspath {
+		liveconnect: (name: string) => slime.jrunscript.JavaClass<any,any>
+		nativeClass: (name: string) => slime.jrunscript.native.java.lang.Class
+		update: () => void
+	}
+
 	/**
 	 * Refers to the currently executing script.
 	 */
@@ -129,7 +135,7 @@ namespace slime.internal.jrunscript.bootstrap {
 		//	Used in jsh/launcher/main.js
 		Java?: {
 			type: (name: string) => slime.jrunscript.JavaClass & {
-				class: any
+				class: slime.jrunscript.native.java.lang.Class
 			}
 		}
 
@@ -218,6 +224,29 @@ namespace slime.internal.jrunscript.bootstrap {
 			 * @returns The exit status of the command
 			 */
 			runCommand: (...arguments: any[]) => number
+
+			rhino: {
+				/**
+				 * The location from which Rhino was loaded, specifically the `org.mozilla.javascript.Context` class.
+				 */
+				classpath: () => slime.jrunscript.native.java.io.File
+
+				/**
+				 * Whether Rhino is currently available on the classpath.
+				 */
+				isPresent: () => boolean
+
+				/**
+				 * If Rhino is currently running this script, the current Rhino script context.
+				 */
+				running: () => slime.jrunscript.native.org.mozilla.javascript.Context
+			}
+
+			nashorn: {
+				isPresent: () => boolean
+				//	TODO	Add org.openjdk.nashorn equivalent? Or is the fact that the types are equivalent enough?
+				running: () => slime.jrunscript.native.jdk.nashorn.internal.runtime.Context
+			}
 		}
 
 		github: {
@@ -330,23 +359,6 @@ namespace slime.internal.jrunscript.bootstrap {
 			readJavaString: (from: slime.jrunscript.native.java.io.InputStream) => slime.jrunscript.native.java.lang.String
 		}
 
-		rhino: {
-			/**
-			 * The location from which Rhino was loaded, specifically the `org.mozilla.javascript.Context` class.
-			 */
-			classpath: () => slime.jrunscript.native.java.io.File
-
-			/**
-			 * Whether Rhino is currently available on the classpath.
-			 */
-			isPresent: () => boolean
-
-			/**
-			 * If Rhino is currently running this script, the current Rhino script context.
-			 */
-			running: () => slime.jrunscript.native.org.mozilla.javascript.Context
-		}
-
 		nashorn: {
 			dependencies: {
 				maven: {
@@ -359,10 +371,6 @@ namespace slime.internal.jrunscript.bootstrap {
 
 				jarNames: string[]
 			}
-
-			isPresent: () => boolean
-			//	TODO	Add org.openjdk.nashorn equivalent
-			running: () => slime.jrunscript.native.jdk.nashorn.internal.runtime.Context
 
 			getDeprecationArguments: (javaMajorVersion: number) => string[]
 		}

--- a/rhino/jrunscript/api.html
+++ b/rhino/jrunscript/api.html
@@ -27,51 +27,6 @@ END LICENSE
 					<span>__DESCRIPTION__</span>
 					<div class="label">has properties:</div>
 					<ul>
-						<li class="object">
-							<div class="name">engine</div>
-							<span>__DESCRIPTION__</span>
-							<div class="label">has properties:</div>
-							<ul>
-								<li class="function">
-									<div class="name">resolve</div>
-									<span>__DESCRIPTION__</span>
-									<div class="arguments">
-										<div class="label">Arguments</div>
-										<ol>
-											<li class="value">
-												<span class="type">object</span>
-												<span>
-													An object.
-												</span>
-											</li>
-										</ol>
-									</div>
-									<div class="returns">
-										<div class="label">Returns</div>
-										<span class="type">(any)</span>
-										<span>
-											Depending on the JavaScript engine being executed, either the
-											<code>rhino</code>, <code>nashorn</code>, or <code>jdkrhino</code> property of
-											the given object will be returned.
-										</span>
-									</div>
-								</li>
-								<li class="function">
-									<div class="name">runCommand</div>
-									<span>__DESCRIPTION__</span>
-									<div class="arguments">
-										<div class="label">Arguments</div>
-										<ol>
-										</ol>
-									</div>
-									<div class="returns">
-										<div class="label">Returns</div>
-										<span class="type">__TYPE__</span>
-										<span>__DESCRIPTION__</span>
-									</div>
-								</li>
-							</ul>
-						</li>
 						<li class="constructor">
 							<div class="name">Script</div>
 							<span>__DESCRIPTION__</span>

--- a/rhino/jrunscript/api.js
+++ b/rhino/jrunscript/api.js
@@ -127,19 +127,43 @@
 			}
 		).call(this);
 
+		/**
+		 * Returns information about Rhino as it pertains to the currently running script.
+		 */
 		var rhino = (
 			function(global) {
+				var isPresent = function() {
+					return typeof(global.Packages.org.mozilla.javascript.Context.getCurrentContext) == "function";
+				};
+				var isRunning = function() {
+					return global.Packages.org.mozilla.javascript.Context.getCurrentContext();
+				}
 				return {
-					isPresent: function() {
-						return typeof(global.Packages.org.mozilla.javascript.Context.getCurrentContext) == "function";
-					},
-					running: function() {
-						return global.Packages.org.mozilla.javascript.Context.getCurrentContext();
+					/**
+					 * Whether Rhino is available on the current classpath.
+					 */
+					isPresent: isPresent,
+					/**
+					 * If Rhino is executing the current script, the Rhino `org.mozilla.javascript.Context` in which this script is
+					 * executing.
+					 */
+					running: isRunning,
+					/**
+					 * If Rhino is on the classpath, the file from which it can be loaded.
+					 */
+					classpath: function() {
+						return (isPresent()) ? new global.Packages.java.io.File(
+							global.Packages.java.lang.Class.forName("org.mozilla.javascript.Context")
+								.getProtectionDomain().getCodeSource().getLocation().toURI()
+						) : null;
 					}
 				}
 			}
 		)(this);
 
+		/**
+		 * The currently executing JavaScript engine.
+		 */
 		var $engine = (function(global) {
 			var Nashorn = function() {
 				this.toString = function() {
@@ -1392,11 +1416,7 @@
 		$api.io.readJavaString = io.readJavaString;
 
 		$api.rhino = {
-			classpath: $engine.resolve({
-				jdkrhino: null,
-				nashorn: null,
-				rhino: $engine.classpath
-			}),
+			classpath: rhino.classpath,
 			isPresent: rhino.isPresent,
 			running: rhino.running
 		};

--- a/rhino/jrunscript/embed.fifty.ts
+++ b/rhino/jrunscript/embed.fifty.ts
@@ -26,7 +26,7 @@ namespace slime.jrunscript.bootstrap {
 					script: void(0)
 				});
 				jsh.shell.console(Object.keys(bootstrap).toString());
-				var rhino = bootstrap.rhino.running();
+				var rhino = bootstrap.engine.rhino.running();
 				jsh.shell.console("Rhino context: " + String(rhino));
 				if (rhino) jsh.shell.console("Rhino optimization: " + String(rhino.getOptimizationLevel()));
 			}


### PR DESCRIPTION
* Improve bootstrapping process by generalize LiveConnect handling (perhaps mostly unnecessarily, as Nashorn seems to support Packages during testing)
* Separate Rhino and Nashorn APIs into $api.[engine] (for the engine) and $api.engine.[engine] (for the current script environment) in preparation for multiversion Rhino support
* Establish that Nashorn supports defineProperty for all supported Nashorn versions
* Improve type definitions for Java classes in bootstrap launcher
* Revamp bootstrap launcher debugging setup