### PR TITLE
#1961: Continue implementing jsh API embedding

### DIFF
--- a/jrunscript/jsh/launcher/main.js
+++ b/jrunscript/jsh/launcher/main.js
@@ -19,7 +19,8 @@
 		var $api = this.$api;
 
 		if ($api.embed) {
-			$api.script = $api.embed.jsh;
+			var current = new $api.Script({ caller: true });
+			$api.script = current;
 		}
 
 		if (!$api.slime) {
@@ -42,7 +43,11 @@
 				}
 				setProperty($api, "slime", slimeConfiguration);
 			}
-			$api.script.resolve("slime.js").load();
+			var slimeScript = $api.script.resolve("slime.js");
+			if (slimeScript == null) {
+				throw new Error("Cound not resolve `slime.js` from " + $api.script);
+			}
+			slimeScript.load();
 		}
 
 		$api.debug.on = Boolean($api.slime.settings.get("jsh.launcher.debug"));

--- a/jrunscript/jsh/launcher/plugin.jsh.js
+++ b/jrunscript/jsh/launcher/plugin.jsh.js
@@ -25,8 +25,10 @@
 					Packages: Packages
 				};
 
-				//	#1961 enable
-				//	$loader.run("main.js", {}, target);
+				//	#1961
+				if (Packages.java.lang.System.getenv("SLIME_ISSUE_1961")) {
+					$loader.run("main.js", {}, target);
+				}
 
 				jsh.internal = {
 					bootstrap: target.$api

--- a/jrunscript/jsh/loader/java/inonit/script/jsh/Nashorn.java
+++ b/jrunscript/jsh/loader/java/inonit/script/jsh/Nashorn.java
@@ -59,7 +59,7 @@ public class Nashorn extends Shell.Engine {
 				try {
 					return Class.forName("org.openjdk.nashorn." + name);
 				} catch (ClassNotFoundException e2) {
-					throw new RuntimeException(e2);
+					throw new RuntimeException("Java version: " + System.getProperty("java.version"), e2);
 				}
 			}
 		}

--- a/loader/jrunscript/native.fifty.ts
+++ b/loader/jrunscript/native.fifty.ts
@@ -51,6 +51,11 @@ namespace slime.jrunscript {
 				export interface Thread {
 				}
 
+				export interface ThreadLocal<T> extends slime.jrunscript.native.java.lang.Object {
+					get(): T
+					set: (t: T) => void
+				}
+
 				export namespace reflect {
 					export interface Field {
 						setAccessible(flag: boolean): void
@@ -208,13 +213,16 @@ namespace slime.jrunscript {
 
 				export interface Properties extends native.java.lang.Object {
 					load(value: any): void
-					get(name: string): any
 					propertyNames(): any
 					getProperty(name: string): string
 					setProperty(name: string, value: string): void
 					keySet(): any
 					entrySet(): any
 					store: (out: slime.jrunscript.native.java.io.OutputStream, comments: string) => void
+
+					//	Map, should actually just extend
+					get(name: string): any
+					put(name: string, value: any): void
 				}
 
 				export interface Enumeration<T> {
@@ -500,6 +508,7 @@ namespace slime.jrunscript {
 					TYPE: any
 				}
 				Number: JavaClass
+				ThreadLocal: JavaClass<slime.jrunscript.native.java.lang.ThreadLocal<any>>
 			}
 			io: {
 				ByteArrayInputStream: new (bytes: any) => slime.jrunscript.native.java.io.ByteArrayInputStream

--- a/rhino/jrunscript/api.fifty.ts
+++ b/rhino/jrunscript/api.fifty.ts
@@ -225,6 +225,8 @@ namespace slime.internal.jrunscript.bootstrap {
 			 */
 			runCommand: (...arguments: any[]) => number
 
+			getCallingScript: () => string
+
 			rhino: {
 				/**
 				 * The location from which Rhino was loaded, specifically the `org.mozilla.javascript.Context` class.
@@ -264,6 +266,7 @@ namespace slime.internal.jrunscript.bootstrap {
 		}
 
 		Script: {
+			new (p: { caller: true }): Script
 			new (p: { string: string }): Script
 			new (p: { file: slime.jrunscript.native.java.io.File }): Script
 			new (p: { url: slime.jrunscript.native.java.net.URL }): Script


### PR DESCRIPTION
Feature-flagging behind environment variable; still does not work in remote shells. Will need to store GitHub download in filesystem, probably

* Implement ability to obtain current script name for any script in bootstrap
* Use current script name in main.js in jsh plugin to find other scripts

Also:
* Add type definition for ThreadLocal (but learned it would not work)