### PR TITLE
#1934: Provide full $api.engine object, replacing embedding export

### DIFF
--- a/jrunscript/README.fifty.ts
+++ b/jrunscript/README.fifty.ts
@@ -13,9 +13,8 @@
  *
  * ## Java stream I/O support: {@link slime.jrunscript.runtime.io.Exports `$api.jrunscript.io`}
  *
- * The module that supports Java stream I/O, {@link slime.jrunscript.runtime.io}, is available as `$api.jrunscript.io`, which provides the
- * {@link slime.runtime.io.Exports} in Java-based
- * embeddings.
+ * The module that supports Java stream I/O, {@link slime.jrunscript.runtime.io}, is available as `$api.jrunscript.io`, which provides
+ * {@link slime.jrunscript.runtime.io.Exports} in Java-based embeddings.
  *
  * ## Other modules
  *

--- a/jrunscript/jsh/test/jsh-data.jsh.js
+++ b/jrunscript/jsh/test/jsh-data.jsh.js
@@ -9,9 +9,10 @@
 	/**
 	 *
 	 * @param { slime.jrunscript.Packages } Packages
+	 * @param { slime.$api.Global } $api
 	 * @param { slime.jsh.Global } jsh
 	 */
-	function(Packages,jsh) {
+	function(Packages,$api,jsh) {
 		var code = {
 			/** @type { slime.jrunscript.bootstrap.Script } */
 			bootstrap: jsh.script.loader.script("../../../rhino/jrunscript/embed.js")
@@ -66,11 +67,14 @@
 		}
 		if (bootstrap && bootstrap.engine.nashorn.isPresent()) {
 			engines.nashorn = true;
+			var isBreakOnExceptions = $api.engine.debugger ? $api.engine.debugger.isBreakOnExceptions() : void(0);
+			if (isBreakOnExceptions) $api.engine.debugger.setBreakOnExceptions(false);
 			if (bootstrap && bootstrap.engine.nashorn.running()) {
 				engines.current = {
 					name: "nashorn"
 				};
 			}
+			if (isBreakOnExceptions) $api.engine.debugger.setBreakOnExceptions(true);
 		}
 
 		if (jsh.shell.jsh.lib && jsh.shell.jsh.lib.getSubdirectory("graal")) {
@@ -126,4 +130,4 @@
 		}, void(0), "    "));
 	}
 //@ts-ignore
-)(Packages,jsh);
+)(Packages,$api,jsh);

--- a/jrunscript/jsh/tools/install/plugin.jsh.js
+++ b/jrunscript/jsh/tools/install/plugin.jsh.js
@@ -9,14 +9,13 @@
 	/**
 	 * @param { slime.jrunscript.Packages } Packages
 	 * @param { slime.jrunscript.JavaAdapter } JavaAdapter
-	 * @param { slime.jsh.plugin.Scope["$slime"] } $slime
 	 * @param { slime.$api.Global } $api
 	 * @param { slime.jsh.Global } jsh
 	 * @param { object } plugins
 	 * @param { slime.jsh.plugin.plugin } plugin
 	 * @param { slime.Loader } $loader
 	 */
-	function(Packages,JavaAdapter,$slime,$api,jsh,plugins,plugin,$loader) {
+	function(Packages,JavaAdapter,$api,jsh,plugins,plugin,$loader) {
 		plugin({
 			isReady: function() {
 				return Boolean(
@@ -517,7 +516,7 @@
 					var load = function(code) {
 						return $api.debug.disableBreakOnExceptionsFor(function() {
 							//	TODO	possibly there is an easier way to invoke the script; unclear.
-							$slime.engine.execute(
+							$api.engine.execute(
 								{
 									name: "<jsyaml.js>",
 									js: code
@@ -990,4 +989,4 @@
 		});
 	}
 //@ts-ignore
-)(Packages,JavaAdapter,$slime,$api,jsh,plugins,plugin,$loader)
+)(Packages,JavaAdapter,$api,jsh,plugins,plugin,$loader)

--- a/loader/$api.js
+++ b/loader/$api.js
@@ -8,7 +8,7 @@
 (
 //	TODO	get rid of the wildcarded properties in $exports by adding all properties to $api.d.ts
 	/**
-	 * @param { slime.runtime.Engine } $engine
+	 * @param { Pick<slime.runtime.Engine,"execute"|"debugger"> } $engine
 	 * @param { slime.runtime.internal.Code } $slime
 	 * @param { slime.loader.Export<slime.$api.Global> } $export
 	 */
@@ -21,7 +21,6 @@
 			$engine.execute(
 				$slime.getRuntimeScript(name),
 				{
-					$platform: $engine,
 					$context: $context,
 					$exports: $exports,
 					$export: function(v) {

--- a/loader/browser/client.js
+++ b/loader/browser/client.js
@@ -196,9 +196,7 @@
 								arguments[2],
 								arguments[0].js, arguments[1]
 							);
-						},
-						//	TODO	make optional?
-						MetaObject: void(0)
+						}
 					},
 					$slime: {
 						getRuntimeScript: function(path) {

--- a/loader/expression.js
+++ b/loader/expression.js
@@ -18,7 +18,7 @@
 		var $engine = (
 			/**
 			 *
-			 * @param { slime.runtime.scope.Engine } $engine
+			 * @param { slime.runtime.Scope["$engine"] } $engine
 			 * @returns { slime.runtime.Engine }
 			 */
 			function($engine) {
@@ -130,33 +130,33 @@
 
 		/**
 		 *
-		 * @param { { name: string, js: string } } code
-		 * @param { { [x: string]: any } } scope
-		 * @returns
-		 */
-		var execute = function(code,scope) {
-			/** @type { any } */
-			var exported;
-
-			$engine.execute(
-				code,
-				Object.assign(scope, {
-					$export: function(value) {
-						exported = value;
-					}
-				}),
-				null
-			);
-
-			return exported;
-		}
-
-		/**
-		 *
 		 * @param { string } path
 		 * @returns { slime.old.loader.Script<any,any> }
 		 */
 		var script = function(path) {
+			/**
+			 *
+			 * @param { { name: string, js: string } } code
+			 * @param { { [x: string]: any } } scope
+			 * @returns
+			 */
+			var execute = function(code,scope) {
+				/** @type { any } */
+				var exported;
+
+				$engine.execute(
+					code,
+					Object.assign(scope, {
+						$export: function(value) {
+							exported = value;
+						}
+					}),
+					null
+				);
+
+				return exported;
+			}
+
 			/**
 			 *
 			 * @param { string } path
@@ -264,9 +264,7 @@
 			}
 		);
 
-		$api.engine = {
-			execute: $engine.execute
-		};
+		$api.engine = $engine;
 
 		$api.content = code.content();
 
@@ -337,13 +335,6 @@
 					return scope;
 				}
 			},
-			$api.Object.defineProperty({
-				name: "engine",
-				descriptor: {
-					value: $engine,
-					enumerable: true
-				}
-			}),
 			//	TODO	currently only used by jsapi in loader/api/old/jsh via jsh.js
 			//	TODO	also used by client.html unit tests
 			$api.Object.defineProperty({

--- a/loader/jrunscript/expression.fifty.ts
+++ b/loader/jrunscript/expression.fifty.ts
@@ -354,7 +354,7 @@ namespace slime.jrunscript.runtime {
 	}
 
 	export interface $javahost {
-		debugger: slime.runtime.scope.Engine["debugger"]
+		debugger: slime.runtime.Engine["debugger"]
 		script: any
 		MetaObject: any
 		noEnvironmentAccess: any

--- a/loader/jrunscript/expression.js
+++ b/loader/jrunscript/expression.js
@@ -52,7 +52,7 @@
 			 * @returns { slime.runtime.Exports }
 			 */
 			function() {
-				/** @type { slime.runtime.scope.Engine } */
+				/** @type { slime.runtime.Engine } */
 				var $engine = {
 					debugger: $javahost.debugger,
 					execute: function(script,scope,target) {
@@ -1083,7 +1083,6 @@
 						file: slime.file,
 						value: slime.value,
 						namespace: slime.namespace,
-						engine: slime.engine,
 						$platform: slime.$platform,
 						$api: $api,
 

--- a/rhino/jrunscript/embed.js
+++ b/rhino/jrunscript/embed.js
@@ -73,7 +73,10 @@
 			Java: void(0)
 		};
 
+		var isBreakOnExceptions = $api.engine.debugger ? $api.engine.debugger.isBreakOnExceptions : void(0);
+		if (isBreakOnExceptions) $api.engine.debugger.setBreakOnExceptions(false);
 		$loader.run("api.js", {}, jrunscript);
+		if (isBreakOnExceptions) $api.engine.debugger.setBreakOnExceptions(true);
 		$export(after(jrunscript.$api));
 	}
 //@ts-ignore


### PR DESCRIPTION
* Clean up and document slime.runtime.Engine API
* Remove spurious access to Engine passed as $platform

Also:
* Fix spurious breakpoints caused by designed exceptions
* Fix documentation broken link in jrunscript documentation