### PR TITLE
Refine runtime organization

### DIFF
--- a/loader/$api.js
+++ b/loader/$api.js
@@ -645,6 +645,15 @@
 			deprecate: flag.deprecate
 		});
 
+		//	TODO	switch implementation to use load()
+		var threads = (function($context) {
+			var $exports = {
+				steps: void(0)
+			};
+			$engine.execute($slime.getRuntimeScript("threads.js"), { $context: $context, $exports: $exports }, null);
+			return $exports;
+		})({ Events: Events });
+
 		/** @type { Omit<slime.$api.Global,"compiler"> } */
 		var $exports = {
 			engine: $engine,
@@ -667,20 +676,9 @@
 			Error: _Error,
 			TODO: TODO,
 			Events: Events,
-			threads: void(0),
+			threads: threads,
 			mime: mime
 		};
-
-		//	TODO	switch implementation to use load()
-		var threads = (function($context) {
-			var $exports = {
-				steps: void(0)
-			};
-			$engine.execute($slime.getRuntimeScript("threads.js"), { $context: $context, $exports: $exports }, null);
-			return $exports;
-		})($exports);
-
-		$exports.threads = threads;
 
 		$export($exports);
 	}

--- a/loader/jrunscript/native.fifty.ts
+++ b/loader/jrunscript/native.fifty.ts
@@ -399,6 +399,12 @@ namespace slime.jrunscript {
 						service: (_request: any, _response: any) => void
 						destroy: () => void
 					}
+
+					export interface HostObject {
+						register: (_script: slime.jrunscript.native.inonit.script.servlet.Servlet.Script) => void
+						getLoader: () => slime.jrunscript.native.inonit.script.engine.Loader
+						getServlet: () => slime.jrunscript.native.inonit.script.servlet.Servlet
+					}
 				}
 
 				export interface Servlet {
@@ -417,6 +423,12 @@ namespace slime.jrunscript {
 					}
 					getServletContext(): any
 				}
+
+				export namespace Rhino {
+					export interface Host extends Servlet.HostObject {
+						getEngine: () => slime.jrunscript.native.inonit.script.rhino.Engine
+					}
+				}
 			}
 
 			export namespace rhino {
@@ -426,9 +438,6 @@ namespace slime.jrunscript {
 				}
 
 				export namespace Engine {
-					export interface Loader {
-						getLoaderCode(path: string): any
-					}
 				}
 
 				export interface Engine {

--- a/loader/scripts.fifty.ts
+++ b/loader/scripts.fifty.ts
@@ -63,8 +63,12 @@ namespace slime.$api {
 			isMimeType: slime.$api.fp.Mapping<string,slime.$api.fp.Predicate<slime.runtime.loader.Code>>
 
 			/**
-			 * Convenience method that uses a code predicate and compiler implementation to create a `Compiler`.
+			 * Convenience method that, given a code predicate and compiler implementation, creates a `Compiler`.
+			 *
+			 * @template R A "resource" type used by some underlying representation of a code source
+			 * @template I Some intermediate representation of the resource which can be used as input to the transpilation process
 			 */
+			//	TODO	can we figure out how to get the above template definitions to render in TypeDoc?
 			getTranspiler: <R,I>(p: {
 				accept: slime.$api.fp.Predicate<R>
 				name: (r: R) => string

--- a/loader/threads.js
+++ b/loader/threads.js
@@ -8,7 +8,7 @@
 (
 	/**
 	 *
-	 * @param { slime.$api.Global } $context
+	 * @param { Pick<slime.$api.Global,"Events"> } $context
 	 * @param { slime.$api.Global["threads"] } $exports
 	 */
 	function($context,$exports) {

--- a/rhino/http/servlet/api.fifty.ts
+++ b/rhino/http/servlet/api.fifty.ts
@@ -127,17 +127,6 @@ namespace slime.servlet {
 		}
 
 		export namespace $host {
-			export interface Java {
-				getClasspath?: slime.jrunscript.native.inonit.script.engine.Loader.Classes.Interface
-				register: (_script: slime.jrunscript.native.inonit.script.servlet.Servlet.Script) => void
-				getLoader(): slime.jrunscript.native.inonit.script.rhino.Engine.Loader
-				getServlet(): slime.jrunscript.native.inonit.script.servlet.Servlet
-			}
-
-			export interface Rhino extends Java {
-				getEngine(): slime.jrunscript.native.inonit.script.rhino.Engine
-			}
-
 			export interface jsh {
 				context: slime.servlet.httpd["context"]
 
@@ -179,7 +168,7 @@ namespace slime.servlet {
 			}
 		}
 
-		export type $host = $host.Java | $host.jsh
+		export type $host = slime.jrunscript.native.inonit.script.servlet.Servlet.HostObject | $host.jsh
 	}
 
 	(

--- a/rhino/http/servlet/api.js
+++ b/rhino/http/servlet/api.js
@@ -12,12 +12,12 @@
 	 * @param { slime.servlet.internal.$host } $host
 	 */
 	function(Packages,JavaAdapter,$host) {
-		/** @type { ($host: slime.servlet.internal.$host) => $host is slime.servlet.internal.$host.Java } */
+		/** @type { ($host: slime.servlet.internal.$host) => $host is slime.jrunscript.native.inonit.script.servlet.Servlet.HostObject } */
 		var isJava = function($host) {
 			return $host["register"];
 		};
 
-		/** @type { ($host: slime.servlet.internal.$host) => $host is slime.servlet.internal.$host.Rhino } */
+		/** @type { ($host: slime.servlet.internal.$host) => $host is slime.jrunscript.native.inonit.script.servlet.Rhino.Host } */
 		var isRhino = function($host) {
 			return isJava($host) && $host["getEngine"];
 		};
@@ -38,7 +38,7 @@
 				//			Need also to identify test case
 				return $host.getEngine().script(
 					"jrunscript/rhino.js",
-					$host.getLoader().getLoaderCode("jrunscript/rhino.js"),
+					String($host.getLoader().getLoaderCode("jrunscript/rhino.js")),
 					{
 						$loader: $host.getLoader(),
 						$rhino: $host.getEngine()
@@ -48,7 +48,7 @@
 			} else if (isJava($host)) {
 				//	TODO	implement along with Graal servlets
 				var $graal;
-				var scripts = eval($host.getLoader().getLoaderCode("jrunscript/nashorn.js"));
+				var scripts = eval(String($host.getLoader().getLoaderCode("jrunscript/nashorn.js")));
 
 				var rv = scripts.script(
 					"jrunscript/nashorn.js",


### PR DESCRIPTION
* Invoke threads.js in standard way within $api.js
* Harmonize jsh and servlet invocations of jrunscript runtime and correct wrong native Java type definitions