### PR TITLE
Global script compiler: fix browser CoffeeScript

### DIFF
--- a/loader/browser/client.fifty.ts
+++ b/loader/browser/client.fifty.ts
@@ -271,7 +271,12 @@ namespace slime {
 					relative: (path: string) => string
 				}
 			}
+
 			$api: slime.$api.Global
+
+			test: {
+				run: slime.runtime.Exports["run"]
+			}
 
 			//	(undocumented) According to very old documentation, used to support development-related functions.
 			$sdk: any

--- a/loader/browser/client.js
+++ b/loader/browser/client.js
@@ -222,19 +222,23 @@
 						//	Can set breakpoint here to pop into debugger on experimental accesses
 						var breakpoint = null;
 					}
-					if (window.CoffeeScript) {
-						rv.compiler.update(function(was) {
-							return rv.$api.fp.switch([
-								was,
-								rv.$api.scripts.Compiler.from.simple({
-									accept: rv.$api.scripts.Code.isMimeType("application/vnd.coffeescript"),
-									name: function(code) { return code.name; },
-									read: function(code) { return code.read(); },
-									compile: window.CoffeeScript.compile
-								})
-							])
-						})
-					}
+					rv.compiler.update(function(was) {
+						return rv.$api.fp.switch([
+							was,
+							rv.$api.scripts.Compiler.from.simple({
+								accept: rv.$api.fp.Predicate.and(
+									rv.$api.scripts.Code.isMimeType("application/vnd.coffeescript"),
+									//	TODO	is there a way to create a Mapping from a Thunk?
+									rv.$api.fp.Mapping.from.thunk(function() { return Boolean(window.CoffeeScript); })
+								),
+								name: function(code) { return code.name; },
+								read: function(code) { return code.read(); },
+								compile: function(script) {
+									return window.CoffeeScript.compile(script);
+								}
+							})
+						])
+					});
 					return rv;
 				})(scope);
 
@@ -384,6 +388,9 @@
 						base: bootstrap.base,
 						//	For use in scripts that are loaded directly by the browser rather than via this loader
 						$api: runtime.$api,
+						test: {
+							run: runtime.run
+						},
 						//	(Possibly obsolete comment to follow) Used by loader/browser/tools/offline.html, which may be obsolete
 						$sdk: new function() {
 							//	Used via inonit.loader.$sdk.fetch call in loader/browser/test somehow

--- a/loader/expression.fifty.ts
+++ b/loader/expression.fifty.ts
@@ -916,7 +916,9 @@ namespace slime {
 								return v === String;
 							}
 
-							subject.run(
+							var exports: slime.browser.Exports = w["inonit"].loader;
+
+							exports.test.run(
 								{
 									name: "it",
 									type: {
@@ -942,6 +944,8 @@ namespace slime {
 							);
 
 							verify(w).evaluate.property("foo").is("FOO");
+						}).catch(function(it) {
+							verify(it).evaluate(String).is("Should not be error.");
 						});
 					});
 				};


### PR DESCRIPTION
* Always install the CoffeeScript compiler, but do not accept files if CoffeeScript has not been loaded
* Fix bug in CoffeeScript test which caused test not to fail even when it threw an exception
* Fix bug in browser CoffeeScript test which loaded separate standalone copy of runtime rather than using browser's
* Provide test API to access runtime run() in browser for CoffeeScript test