### PR TITLE
Move toward #2083: Make it possible to run Fifty browser tests with f…

### DIFF
--- a/contributor/code/license.jsh.js
+++ b/contributor/code/license.jsh.js
@@ -154,6 +154,7 @@
 			if (files[i].path == "jsh") extension = "bash";
 			if (files[i].path == ".eslintrc.json") extension = "js";
 			if (files[i].path == "jsconfig.json") extension = "js";
+			if (files[i].path == "jsconfig-fifty-browser-test.json") extension = "js";
 			if (files[i].path == "typedoc.json") extension = "js";
 			if (files[i].path == "typedoc-tsconfig.json") extension = "js";
 			if (files[i].path == ".devcontainer/devcontainer.json") extension = "js";

--- a/jsconfig-fifty-browser-test.json
+++ b/jsconfig-fifty-browser-test.json
@@ -1,0 +1,13 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./local/fifty/tsc"
+  }
+}

--- a/loader/$api-fp-impure.fifty.ts
+++ b/loader/$api-fp-impure.fifty.ts
@@ -1184,7 +1184,7 @@ namespace slime.$api.fp.world {
 		}
 
 		Ask: {
-			input: <E,T>(handler?: slime.$api.event.Handlers<E>) => (ask: slime.$api.fp.world.Question<E,T>) => slime.$api.fp.impure.Input<T>
+			input: <E,T>(handler?: slime.$api.event.Handlers<E>) => (ask: slime.$api.fp.world.Question<E,T>) => slime.$api.fp.impure.External<T>
 		}
 	}
 

--- a/loader/browser/$api.fifty.ts
+++ b/loader/browser/$api.fifty.ts
@@ -99,7 +99,7 @@ namespace slime.browser.internal.$api {
 					(function() {
 						var counter = 0;
 
-						return function(handler: slime.external.lib.es5.TypescriptFunction, timeout: number, ...arguments) {
+						return function(handler: slime.external.lib.es5.TypescriptFunction, timeout: number, ...rest) {
 							return counter++;
 						};
 					})()

--- a/loader/browser/client.js
+++ b/loader/browser/client.js
@@ -234,6 +234,24 @@
 								js: fetcher.getCode(bootstrap.relative(path))
 							}
 						}
+					},
+					$engine: {
+						//	The default implementation (used for Node.js, for example) is compliant with strict mode and implements
+						//	this using a new Function(...) call. But the default toString() messes up the line numbers for tools
+						//	when debugging. Not sure whether there's a way to have it both ways, so for now, we return to using
+						//	eval().
+						execute: function(/*script{name,js},scope,target*/) {
+							if (false) throw new Error();
+							return (function() {
+								//@ts-ignore
+								with( arguments[1] ) {
+									return eval(arguments[0]);
+								}
+							}).call(
+								arguments[2],
+								arguments[0].js, arguments[1]
+							);
+						}
 					}
 				};
 

--- a/rhino/tools/node/module.fifty.ts
+++ b/rhino/tools/node/module.fifty.ts
@@ -79,8 +79,8 @@ namespace slime.jrunscript.tools.node {
 		}
 	}
 
-	export namespace exports {
-		export interface Installations {
+	export namespace installation {
+		export interface Exports {
 			from: {
 				/**
 				 * Given a Node installation location, returns the Node `Installation` corresponding to that location.
@@ -104,7 +104,7 @@ namespace slime.jrunscript.tools.node {
 		/**
 		 * Functions relating to {@link Installation} types.
 		 */
-		Installation: exports.Installations
+		Installation: installation.Exports
 	}
 
 	export interface Exports {
@@ -165,15 +165,15 @@ namespace slime.jrunscript.tools.node {
 		stdio?: slime.jrunscript.shell.run.Intention["stdio"]
 	}
 
-	export namespace exports {
-		export interface Installations {
+	export namespace installation {
+		export interface Exports {
 			Intention: {
 				shell: (argument: Intention) => (installation: slime.jrunscript.tools.node.Installation) => slime.jrunscript.shell.run.Intention
 				question: (argument: Intention) => slime.$api.fp.world.Sensor<slime.jrunscript.tools.node.Installation,slime.jrunscript.shell.run.AskEvents,slime.jrunscript.shell.run.Exit>
 			}
 
 			/** @deprecated */
-			question: Installations["Intention"]["question"]
+			question: Exports["Intention"]["question"]
 		}
 
 		(
@@ -209,8 +209,8 @@ namespace slime.jrunscript.tools.node {
 
 	}
 
-	export namespace exports {
-		export interface Modules {
+	export namespace modules {
+		export interface Exports {
 			list: () => slime.$api.fp.world.Question<void, Module[]>
 
 			installed: (name: string) => slime.$api.fp.world.Question<void, slime.$api.fp.Maybe<Module>>
@@ -242,9 +242,9 @@ namespace slime.jrunscript.tools.node {
 		}
 	}
 
-	export namespace exports {
-		export interface Installations {
-			modules: (installation: node.Installation) => Modules
+	export namespace installation {
+		export interface Exports {
+			modules: (installation: node.Installation) => modules.Exports
 		}
 	}
 
@@ -303,14 +303,14 @@ namespace slime.jrunscript.tools.node {
 	//@ts-ignore
 	)(fifty);
 
-	export interface Exports {
-		Project: exports.Project
+	export namespace project {
+		export interface Exports {
+			modules: (project: node.Project) => (installation: node.Installation) => modules.Exports
+		}
 	}
 
-	export namespace exports {
-		export interface Project {
-			modules: (project: node.Project) => (installation: node.Installation) => Modules
-		}
+	export interface Exports {
+		Project: project.Exports
 	}
 
 	export namespace object {

--- a/rhino/tools/node/module.js
+++ b/rhino/tools/node/module.js
@@ -106,7 +106,7 @@
 			}
 		)();
 
-		/** @type { slime.jrunscript.tools.node.exports.Installations["getVersion"] } */
+		/** @type { slime.jrunscript.tools.node.installation.Exports["getVersion"] } */
 		function getVersion(installation) {
 			return function(events) {
 				/** @type { slime.jrunscript.shell.run.Intention } */
@@ -199,7 +199,7 @@
 		 * @returns
 		 */
 		var Modules = function(p) {
-			/** @type { slime.jrunscript.tools.node.exports.Modules["list"] } */
+			/** @type { slime.jrunscript.tools.node.modules.Exports["list"] } */
 			var list = function() {
 				return function(events) {
 					// var invocation = toShellInvocation({
@@ -308,7 +308,7 @@
 				}
 			};
 
-			/** @type { slime.jrunscript.tools.node.exports.Modules["installed"] } */
+			/** @type { slime.jrunscript.tools.node.modules.Exports["installed"] } */
 			var installed = function(name) {
 				return function(events) {
 					var ask = list();
@@ -320,7 +320,7 @@
 				}
 			};
 
-			/** @type { slime.jrunscript.tools.node.exports.Modules["install"] } */
+			/** @type { slime.jrunscript.tools.node.modules.Exports["install"] } */
 			var install = function(spec) {
 				return function(events) {
 					var invocation = invokeNpm(
@@ -347,7 +347,7 @@
 				}
 			};
 
-			return /** @type { slime.jrunscript.tools.node.exports.Modules } */({
+			return /** @type { slime.jrunscript.tools.node.modules.Exports } */({
 				list: list,
 				installed: installed,
 				install: install,
@@ -782,7 +782,7 @@
 			},
 			exists: (
 				function() {
-					/** @type { slime.jrunscript.tools.node.exports.Installations["exists"]["wo"] } */
+					/** @type { slime.jrunscript.tools.node.installation.Exports["exists"]["wo"] } */
 					var wo = function(installation) {
 						return function(events) {
 							return $api.fp.now.invoke(

--- a/tools/fifty/test/data/hello.fifty.ts
+++ b/tools/fifty/test/data/hello.fifty.ts
@@ -1,0 +1,29 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+namespace slime.fifty.internal.test {
+	export interface Context {
+	}
+
+	export interface Exports {
+	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			const { verify } = fifty;
+
+			fifty.tests.suite = function() {
+				debugger;
+				verify("a fact").is("a fact");
+			}
+		}
+	//@ts-ignore
+	)($fifty);
+
+	export type Script = slime.loader.Script<Context,Exports>
+}


### PR DESCRIPTION
…ull tsc compilation

Right now, the name of the `fifty` global scope variable conflicts with the slime.fifty namespace, so tests do not pass; might need to switch to $fifty for that purpose.

Also:
* Resolve #2078: Fix new toString() in browser, or restore old code? (Also sourceURL?)

Go back to old code that simply uses eval() on the raw file. Can continue investigating options.