### PR TITLE
Fix regression when running under Graal caused by jsh change embeddin…

### DIFF
--- a/contributor/README.html
+++ b/contributor/README.html
@@ -187,7 +187,7 @@ END LICENSE
 						</div>
 					</div>
 					<div>
-						<h4><a href="https://github.com/davidpcaldwell/slime/issues?q=is%3Aissue+is%3Aopen+label%3Agraalvm">GraalVM</a>: get SLIME running on GraalVM</h4>
+						<h4><a href="https://github.com/davidpcaldwell/slime/issues?q=is%3Aissue%20is%3Aopen%20label%3Agraal">GraalVM</a>: get SLIME running on GraalVM</h4>
 						<div>
 							To install: <code>./jsh --install-graalvm</code>.
 						</div>

--- a/contributor/test/manual/graalvm
+++ b/contributor/test/manual/graalvm
@@ -6,4 +6,7 @@
 #	END LICENSE
 
 cd $(dirname $0)/../../..
-rm -Rvf local/jsh/lib/graal; ./jsh --install-graalvm; env JSH_ENGINE=graal /bin/bash ./jsh ./jrunscript/jsh/test/jsh-data.jsh.js
+if [ "$1" == "--clean" ]; then
+	rm -Rvf local/jsh/lib/graal; ./jsh --install-graalvm;
+fi
+env JSH_ENGINE=graal /bin/bash ./jsh ./jrunscript/jsh/test/jsh-data.jsh.js

--- a/jsh
+++ b/jsh
@@ -156,11 +156,15 @@ install_graalvm() {
 	local TO=$(clean_destination "$2")
 	local MAJOR=$(get_major_version_from_jdk_version ${VERSION})
 	local JDK_TARBALL_URL=""
+	local GRAAL_ARCH=${ARCH}
+	if [ "${GRAAL_ARCH}" = "arm64" ]; then
+		GRAAL_ARCH=aarch64
+	fi
 	#	See https://www.oracle.com/java/technologies/downloads/archive/#GraalVM for information about versions
 	if [ "${UNAME}" == "Darwin" ]; then
-		JDK_TARBALL_URL="https://download.oracle.com/graalvm/${MAJOR}/archive/graalvm-jdk-${VERSION}_macos-${ARCH}_bin.tar.gz"
+		JDK_TARBALL_URL="https://download.oracle.com/graalvm/${MAJOR}/archive/graalvm-jdk-${VERSION}_macos-${GRAAL_ARCH}_bin.tar.gz"
 	elif [ "${UNAME}" == "Linux" ]; then
-		JDK_TARBALL_URL="https://download.oracle.com/graalvm/${MAJOR}/archive/graalvm-jdk-${VERSION}_linux-${ARCH}_bin.tar.gz"
+		JDK_TARBALL_URL="https://download.oracle.com/graalvm/${MAJOR}/archive/graalvm-jdk-${VERSION}_linux-${GRAAL_ARCH}_bin.tar.gz"
 	fi
 	if [ -z "${JDK_TARBALL_URL}" ]; then
 		>&2 echo "Unsupported OS/architecture: ${UNAME} ${ARCH}"


### PR DESCRIPTION
…g the bootstrap API

Also:
* Fix download URL for GraalVM
* Fix broken link caused by renaming GitHub label
* In GraalVM manual test, do not automatically re-install Graal each time it is run; only reinstall when --clean is passed