### PR TITLE
#1934: Move file-related ZIP test to rhino/file

### DIFF
--- a/jrunscript/io/zip.fifty.ts
+++ b/jrunscript/io/zip.fifty.ts
@@ -130,40 +130,6 @@ namespace slime.jrunscript.io.zip {
 					}).evaluate(withinTwoSecondsOf(arbitrary_times[property])).is(true);
 				});
 			}
-
-			//	TODO	this will really end up moving as it pertains to files, not streams, so will move to the file module where
-			//			we convert files to entries
-			fifty.tests.exports.decode = function() {
-				var expanded = jsh.shell.TMPDIR.createTemporary({ directory: true });
-				expanded.getRelativePath("a").write("a", { append: false });
-				expanded.getRelativePath("b/c").write("c", { append: false, recursive: true });
-				var zipped = jsh.shell.TMPDIR.createTemporary({ suffix: ".zip" }).pathname;
-				zipped.file.remove();
-				var to = jsh.shell.TMPDIR.createTemporary({ directory: true });
-				var path = jsh.file.Searchpath([jsh.shell.java.home.getRelativePath("bin"),jsh.shell.java.home.parent.getRelativePath("bin")]);
-				jsh.shell.run({
-					command: path.getCommand("jar"),
-					arguments: ["cf", zipped, "a", "b"],
-					directory: expanded
-				});
-				var entries = module.archive.zip.decode(
-					{
-						stream: zipped.file.read(jsh.io.Streams.binary)
-					}
-				);
-				$api.fp.now(
-					entries,
-					$api.fp.impure.Stream.forEach(function(entry) {
-						if (!isFileEntry(entry)) {
-							to.getRelativePath(entry.path).createDirectory();
-						} else {
-							to.getRelativePath(entry.path).write(entry.content);
-						}
-					})
-				);
-				verify(to).getFile("a").is.type("object");
-				verify(to).getFile("aa").is.type("null");
-			}
 		}
 	//@ts-ignore
 	)(fifty);

--- a/loader/Loader.js
+++ b/loader/Loader.js
@@ -41,7 +41,7 @@
 							)
 						),
 						$loader: Store.content({
-							store: $api.content.Store.path({
+							store: $api.content.Store.at({
 								store: p.store,
 								path: elements.slice(0, elements.length-1)
 							}),

--- a/loader/content.js
+++ b/loader/content.js
@@ -19,8 +19,8 @@
 			return Boolean(store["list"]);
 		}
 
-		/** @type { slime.runtime.content.Exports["Store"]["map"] } */
-		var map = function(p) {
+		/** @type { slime.runtime.content.Exports["Store"]["set"] } */
+		var set = function(p) {
 			return function(store) {
 				/** @type { Store } */
 				var rv = {
@@ -42,8 +42,8 @@
 			}
 		};
 
-		/** @type { slime.runtime.content.Exports["Store"]["path"] } */
-		var path = function(p) {
+		/** @type { slime.runtime.content.Exports["Store"]["at"] } */
+		var at = function(p) {
 			/** @type { Store } */
 			var rv = {
 				get: function(path) {
@@ -53,10 +53,33 @@
 			return rv;
 		};
 
+		/** @type { slime.runtime.content.Exports["Store"]["map"] } */
+		var map = function(map) {
+			return function(store) {
+				return {
+					get: function(path) {
+						var delegate = store.get(path);
+						//	TODO	as of now, $api.fp.Maybe is not available here. Perhaps we could rearrange things
+						if (delegate.present) {
+							return {
+								present: true,
+								value: map(delegate.value)
+							}
+						} else {
+							return {
+								present: false
+							}
+						}
+					}
+				}
+			};
+		};
+
 		$export({
 			Store: {
-				map: map,
-				path: path
+				set: set,
+				at: at,
+				map: map
 			},
 			Entry: {
 				is: {

--- a/rhino/file/archive.js
+++ b/rhino/file/archive.js
@@ -13,7 +13,38 @@
 	 * @param { slime.loader.Export<slime.jrunscript.file.internal.archive.Exports> } $export
 	 */
 	function($api,$context,$export) {
-
+		$export({
+			zip: {
+				map: function(base) {
+					var paths = $context.library.file.Location.directory.relativeTo(base);
+					var read = $api.fp.now(
+						$context.library.file.Location.file.read.stream(),
+						$api.fp.world.Sensor.mapping(),
+						function(mapping) {
+							return function(location) {
+								var rv = mapping(location);
+								if (!rv.present) throw new Error();
+								return rv.value;
+							}
+						}
+					);
+					return function(location) {
+						$api.TODO()();
+						var dir = $context.library.file.Location.directory.exists.simple(location);
+						return {
+							path: paths(location),
+							comment: void(0),
+							time: {
+								modified: $api.fp.Maybe.from.nothing(),
+								created: $api.fp.Maybe.from.nothing(),
+								accessed: $api.fp.Maybe.from.nothing()
+							},
+							content: (dir) ? void(0) : read(location)
+						}
+					}
+				}
+			}
+		})
 	}
 //@ts-ignore
 )($api,$context,$export);

--- a/rhino/file/java.fifty.ts
+++ b/rhino/file/java.fifty.ts
@@ -232,7 +232,7 @@ namespace slime.jrunscript.file.internal.java {
 
 				var removeUnixSlashes = subject.test.trailingSeparatorRemover(subject.test.unix);
 				verify(removeUnixSlashes("/foo/bar/")).is("/foo/bar");
-				verify(removeUnixSlashes("/foo/bar/")).is("/foo/bar");
+				verify(removeUnixSlashes("/foo/bar")).is("/foo/bar");
 
 				var removeWindowsSlashes = subject.test.trailingSeparatorRemover(subject.test.windows);
 				verify(removeWindowsSlashes("C:\\foo\\bar\\")).is("C:\\foo\\bar");

--- a/rhino/file/module.js
+++ b/rhino/file/module.js
@@ -100,7 +100,13 @@
 			Streams: oo.Streams,
 			java: oo.java,
 
-			archive: code.archive({})
+			archive: code.archive({
+				library: {
+					file: {
+						Location: wo.Location
+					}
+				}
+			})
 		});
 	}
 //@ts-ignore

--- a/rhino/file/oo/file.fifty.ts
+++ b/rhino/file/oo/file.fifty.ts
@@ -1234,12 +1234,13 @@ namespace slime.jrunscript.file.internal.file {
 	export interface Exports {
 		Pathname: new (parameters: {
 			provider: slime.jrunscript.file.internal.java.FilesystemProvider
+			filesystem: slime.jrunscript.file.world.Filesystem
 			path: string
 		}) => Pathname
 
 		Searchpath: new (parameters: {
-			fs?: slime.jrunscript.file.world.Filesystem
 			provider: slime.jrunscript.file.internal.java.FilesystemProvider
+			filesystem: slime.jrunscript.file.world.Filesystem
 			array: slime.jrunscript.file.Pathname[]
 		}) => any
 

--- a/rhino/file/oo/file.js
+++ b/rhino/file/oo/file.js
@@ -13,7 +13,7 @@
 	 * @param { slime.jrunscript.file.internal.file.Context } $context
 	 * @param { slime.loader.Export<slime.jrunscript.file.internal.file.Exports> } $export
 	 */
-	function (Packages, $api, $context, $export) {
+	function (Packages,$api,$context,$export) {
 		if (!$context.Resource) throw new Error();
 
 		var constant = $api.fp.impure.Input.memoized;
@@ -89,7 +89,7 @@
 
 			var getParent = constant(function () {
 				var parent = provider.getParent(_peer);
-				return (parent) ? new Pathname({ provider: provider, path: String(parent.getScriptPath()) }) : null;
+				return (parent) ? new Pathname({ provider: provider, filesystem: parameters.filesystem, path: String(parent.getScriptPath()) }) : null;
 			});
 			this.parent = void(0);
 			this.__defineGetter__("parent", getParent);
@@ -108,7 +108,7 @@
 			var getDirectory = function () {
 				if (!provider.exists(_peer)) return null;
 				if (!provider.isDirectory(_peer)) return null;
-				var pathname = new Pathname({ provider: provider, path: String(_peer.getScriptPath()) });
+				var pathname = new Pathname({ provider: provider, filesystem: parameters.filesystem, path: String(_peer.getScriptPath()) });
 				return new Directory(pathname, _peer);
 			}
 			this.directory = void (0);
@@ -278,7 +278,7 @@
 				 * @returns
 				 */
 				var getRelativePath = function (pathString) {
-					return new Pathname({ provider: provider, path: pathname.toString() + relativePathPrefix + pathString });
+					return new Pathname({ provider: provider, filesystem: parameters.filesystem, path: pathname.toString() + relativePathPrefix + pathString });
 				}
 				this.getRelativePath = getRelativePath;
 
@@ -517,13 +517,13 @@
 				this.directory = true;
 
 				this.getFile = function (name) {
-					return new Pathname({ provider: provider, path: this.getRelativePath(name).toString() }).file;
+					return new Pathname({ provider: provider, filesystem: parameters.filesystem, path: this.getRelativePath(name).toString() }).file;
 				}
 
 				this.getSubdirectory = function (name) {
 					if (typeof (name) == "string" && !name.length) return this;
 					if (!name) throw new TypeError("Missing: subdirectory name.");
-					return new Pathname({ provider: provider, path: this.getRelativePath(name).toString() }).directory;
+					return new Pathname({ provider: provider, filesystem: parameters.filesystem, path: this.getRelativePath(name).toString() }).directory;
 				}
 
 				var toFilter = function (regexp) {
@@ -613,7 +613,7 @@
 							/** @type { slime.jrunscript.file.Node[] } */
 							var rv = [];
 							for (var i = 0; i < peers.length; i++) {
-								var pathname = new Pathname({ provider: provider, path: String(peers[i].getScriptPath()) });
+								var pathname = new Pathname({ provider: provider, filesystem: parameters.filesystem, path: String(peers[i].getScriptPath()) });
 								if (pathname.directory) {
 									rv.push(pathname.directory);
 								} else if (pathname.file) {
@@ -646,7 +646,7 @@
 				if (provider.temporary) {
 					this.createTemporary = function (parameters) {
 						var _peer = provider.temporary(peer, parameters);
-						var pathname = new Pathname({ provider: provider, path: String(_peer.getScriptPath()) });
+						var pathname = new Pathname({ provider: provider, filesystem: parameters.filesystem, path: String(_peer.getScriptPath()) });
 						if (pathname.directory) return pathname.directory;
 						if (pathname.file) return pathname.file;
 						throw new Error();
@@ -717,13 +717,13 @@
 						debugger;
 					}
 					var peer = provider.java.adapt(pathname.java.adapt());
-					var mapped = new Pathname({ provider: provider, path: String(peer.getScriptPath()) });
+					var mapped = new Pathname({ provider: provider, filesystem: parameters.filesystem, path: String(peer.getScriptPath()) });
 					return mapped.toString();
 				}).join(provider.separators.searchpath);
 			}
 		}
 		Searchpath.createEmpty = function () {
-			return new Searchpath({ provider: void(0), array: [] });
+			return new Searchpath({ provider: void(0), filesystem: void(0), array: [] });
 		}
 		Searchpath.prototype = $context.prototypes.Searchpath;
 

--- a/rhino/file/oo/file.js
+++ b/rhino/file/oo/file.js
@@ -58,6 +58,7 @@
 		 */
 		function Pathname(parameters) {
 			var provider = parameters.provider;
+			var filesystem = parameters.filesystem;
 			var _peer = provider.newPeer(parameters.path);
 
 			var toString = constant(function () {
@@ -644,9 +645,9 @@
 				});
 
 				if (provider.temporary) {
-					this.createTemporary = function (parameters) {
+					this.createTemporary = function(parameters) {
 						var _peer = provider.temporary(peer, parameters);
-						var pathname = new Pathname({ provider: provider, filesystem: parameters.filesystem, path: String(_peer.getScriptPath()) });
+						var pathname = new Pathname({ provider: provider, filesystem: filesystem, path: String(_peer.getScriptPath()) });
 						if (pathname.directory) return pathname.directory;
 						if (pathname.file) return pathname.file;
 						throw new Error();

--- a/rhino/file/oo/filesystem.js
+++ b/rhino/file/oo/filesystem.js
@@ -14,10 +14,11 @@
 	function($context,$exports) {
 		/**
 		 * @param { slime.jrunscript.file.internal.java.FilesystemProvider } system
+		 * @param { slime.jrunscript.file.world.Filesystem } filesystem
 		 * @param { string } string
 		 */
-		function newPathname(system, string) {
-			return new $context.Pathname({ provider: system, path: string });
+		function newPathname(system, filesystem, string) {
+			return new $context.Pathname({ provider: system, filesystem: filesystem, path: string });
 		}
 
 		/**
@@ -33,7 +34,7 @@
 
 			//	TODO	we add createEmpty below, but do not seem to define it. Is it defined elsewhere, maybe?
 			this.Searchpath = Object.assign(function(array) {
-				return new $context.Searchpath({ provider: provider, array: array });
+				return new $context.Searchpath({ provider: provider, filesystem: fs, array: array });
 			}, { parse: void(0), createEmpty: void(0) });
 			this.Searchpath.prototype = $context.Searchpath.prototype;
 			this.Searchpath.parse = function(string) {
@@ -42,14 +43,14 @@
 				}
 				var elements = string.split(provider.separators.searchpath);
 				var array = elements.map(function(element) {
-					return newPathname(provider, element);
+					return newPathname(provider, fs, element);
 				});
-				return new $context.Searchpath({ provider: provider, array: array });
+				return new $context.Searchpath({ provider: provider, filesystem: fs, array: array });
 			}
 
 			/** @type { slime.jrunscript.file.internal.filesystem.Filesystem["Pathname"] } */
 			this.Pathname = function(string) {
-				return newPathname(provider, string);
+				return newPathname(provider, fs, string);
 			}
 
 			this.$unit = new function() {
@@ -62,13 +63,13 @@
 				}
 				this.temporary = function(parent,parameters) {
 					var peer = provider.temporary(parent,parameters);
-					var pathname = new $context.Pathname({ provider: provider, path: String(peer.getScriptPath()) });
+					var pathname = new $context.Pathname({ provider: provider, filesystem: fs, path: String(peer.getScriptPath()) });
 					if (pathname.directory) return pathname.directory;
 					if (pathname.file) return pathname.file;
 					throw new Error();
 				}
 				this.Pathname = function(peer) {
-					return new $context.Pathname({ provider: provider, path: String(peer.getScriptPath()) });
+					return new $context.Pathname({ provider: provider, filesystem: fs, path: String(peer.getScriptPath()) });
 				}
 			}
 
@@ -77,7 +78,7 @@
 			this.java = {
 				adapt: function(_file) {
 					var peer = provider.java.adapt(_file);
-					return new $context.Pathname({ provider: provider, path: String(peer.getScriptPath()) });
+					return new $context.Pathname({ provider: provider, filesystem: fs, path: String(peer.getScriptPath()) });
 				}
 			};
 

--- a/rhino/file/wo-directory.fifty.ts
+++ b/rhino/file/wo-directory.fifty.ts
@@ -46,9 +46,105 @@ namespace slime.jrunscript.file.location.directory {
 
 	export interface Exports {
 		base: (base: slime.jrunscript.file.Location) => (relative: string) => slime.jrunscript.file.Location
+	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			const { verify } = fifty;
+			const subject = fifty.global.jsh.file;
+			const filesystem = subject.world.filesystems.mock();
+
+			const at = (path: string): slime.jrunscript.file.Location => {
+				return {
+					filesystem: filesystem,
+					pathname: path
+				}
+			}
+
+			fifty.tests.exports.Location.directory.base = function() {
+				var directory = subject.Location.directory.base(at("/a/b/c"));
+
+				var one = directory("d");
+				verify(one).pathname.is("/a/b/c/d");
+				var two = directory("./d");
+				verify(two).pathname.is("/a/b/c/d");
+				var three = directory("../d");
+				verify(three).pathname.is("/a/b/d");
+			};
+		}
+	//@ts-ignore
+	)(fifty);
+
+	export interface Exports {
 		relativePath: (path: string) => (p: slime.jrunscript.file.Location) => slime.jrunscript.file.Location
+	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			const { verify } = fifty;
+			const subject = fifty.global.jsh.file;
+			const filesystem = subject.world.filesystems.mock();
+
+			const at = (path: string): slime.jrunscript.file.Location => {
+				return {
+					filesystem: filesystem,
+					pathname: path
+				}
+			}
+
+			fifty.tests.exports.Location.directory.relativePath = function() {
+				var d = subject.Location.directory.relativePath("d");
+				var target = d(at("/a/b/c"));
+				verify(target).pathname.is("/a/b/c/d");
+			};
+		}
+	//@ts-ignore
+	)(fifty);
+
+	export interface Exports {
+		/**
+		 * Given a base (directory) location, returns a function that converts a filesystem location to a path relative to the base
+		 * loation.
+		 */
 		relativeTo: (location: slime.jrunscript.file.Location) => (p: slime.jrunscript.file.Location) => string
 	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			const { verify } = fifty;
+			const subject = fifty.global.jsh.file;
+			const filesystem = subject.world.filesystems.mock();
+
+			const at = (path: string): slime.jrunscript.file.Location => {
+				return {
+					filesystem: filesystem,
+					pathname: path
+				}
+			}
+
+			fifty.tests.exports.Location.directory.relativeTo = function() {
+				var target = at("/a/b/c");
+				var relativeOf = subject.Location.directory.relativeTo(target);
+				var one = relativeOf(at("/a/b/d"));
+				verify(one).is("../d");
+				var oneA = relativeOf(at("/a/c"));
+				verify(oneA).is("../../c");
+				var two = relativeOf(at("/b"));
+				verify(two).is("../../../b");
+				var three = relativeOf(at("/a/b/c/d"));
+				verify(three).is("d");
+				var four = relativeOf(at("/a/b/c"));
+				verify(four).is("");
+			};
+		}
+	//@ts-ignore
+	)(fifty);
 
 	(
 		function(
@@ -66,40 +162,6 @@ namespace slime.jrunscript.file.location.directory {
 					pathname: path
 				}
 			}
-
-			//	TODO	these tests might not pass on Windows
-
-			fifty.tests.exports.Location.directory.relativePath = function() {
-				var d = subject.Location.directory.relativePath("d");
-				var target = d(at("/a/b/c"));
-				verify(target).pathname.is("/a/b/c/d");
-			};
-
-			fifty.tests.exports.Location.directory.base = function() {
-				var directory = subject.Location.directory.base(at("/a/b/c"));
-
-				var one = directory("d");
-				verify(one).pathname.is("/a/b/c/d");
-				var two = directory("./d");
-				verify(two).pathname.is("/a/b/c/d");
-				var three = directory("../d");
-				verify(three).pathname.is("/a/b/d");
-			};
-
-			fifty.tests.exports.Location.directory.relativeTo = function() {
-				var target = at("/a/b/c");
-				var relativeOf = subject.Location.directory.relativeTo(target);
-				var one = relativeOf(at("/a/b/d"));
-				verify(one).is("../d");
-				var oneA = relativeOf(at("/a/c"));
-				verify(oneA).is("../../c");
-				var two = relativeOf(at("/b"));
-				verify(two).is("../../../b");
-				var three = relativeOf(at("/a/b/c/d"));
-				verify(three).is("d");
-				var four = relativeOf(at("/a/b/c"));
-				verify(four).is("");
-			};
 
 			fifty.tests.exports.Location.directory.harvested = function() {
 				//	TODO	Not a very good test for Windows filesystem


### PR DESCRIPTION
Also:
* #2036: Begin providing world filesystem argument to oo filesystem constructs* Improve naming for slime.runtime.content.Store functions
* Implement slime.runtime.content.Store.map function
* Improve file-based ZIP encoding WIP test slightly
* Begin writing unused mapping from file to ZipEntry
* Fix bug in Java filesystem provider test that caused test to be redundant
* Tidy code in Java filesystem implementation