### PR TITLE
#2036: Implement consistent handling for file timestamps

### DIFF
--- a/contributor/test-docker-clean-start
+++ b/contributor/test-docker-clean-start
@@ -5,4 +5,4 @@
 #
 #	END LICENSE
 
-docker compose -f docker-compose.yaml -f docker-compose.clean.yaml up local
+docker compose -f docker-compose.yaml -f docker-compose.clean.yaml up --force-recreate --renew-anon-volumes local

--- a/jrunscript/io/zip.fifty.ts
+++ b/jrunscript/io/zip.fifty.ts
@@ -35,9 +35,9 @@ namespace slime.jrunscript.io.zip {
 	export type Entry = {
 		comment: slime.$api.fp.Maybe<string>
 		time: {
-			modified: slime.$api.fp.Maybe<number>
-			created: slime.$api.fp.Maybe<number>
-			accessed: slime.$api.fp.Maybe<number>
+			modified: slime.$api.fp.Maybe<slime.external.lib.es5.TimeValue>
+			created: slime.$api.fp.Maybe<slime.external.lib.es5.TimeValue>
+			accessed: slime.$api.fp.Maybe<slime.external.lib.es5.TimeValue>
 		}
 	}
 

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -154,7 +154,7 @@ namespace slime.time {
 			/**
 			 * Returns the current <dfn>time value</dfn>.
 			 */
-			now: slime.$api.fp.impure.External<number>
+			now: slime.$api.fp.impure.External<slime.external.lib.es5.TimeValue>
 		}
 
 		(

--- a/loader/browser/test/plugin.jsh.js
+++ b/loader/browser/test/plugin.jsh.js
@@ -58,11 +58,22 @@
 							jsh.file.Location.file.size,
 							$api.fp.world.Sensor.mapping()
 						);
+						var modified = $api.fp.pipe(
+							jsh.file.Location.attributes,
+							function(attributes) {
+								return attributes.times.modified.get;
+							},
+							function(q) {
+								return $api.fp.world.Question.now({
+									question: q
+								});
+							}
+						)
 						/** @type { slime.servlet.response.Properties } */
 						var properties = $api.fp.now(
 							location,
 							$api.fp.Mapping.properties({
-								modified: $api.fp.pipe(jsh.file.Location.lastModified.simple, function(tv) { return new Date(tv); }),
+								modified: $api.fp.pipe(modified, function(tv) { return new Date(tv); }),
 								length: length,
 								type: $api.fp.pipe( jsh.file.Location.basename, $api.mime.Type.fromName )
 							})

--- a/loader/jrunscript/native.fifty.ts
+++ b/loader/jrunscript/native.fifty.ts
@@ -132,7 +132,7 @@ namespace slime.jrunscript {
 					}
 
 					export namespace attribute {
-						export interface FileTime {
+						export interface FileTime extends slime.jrunscript.native.java.lang.Object {
 							toMillis: () => number
 						}
 
@@ -606,7 +606,16 @@ namespace slime.jrunscript {
 			}
 			nio: {
 				file: {
-					Files: any
+					Files: {
+						setAttribute(path: slime.jrunscript.native.java.nio.file.Path, attribute: string, value: slime.jrunscript.native.java.lang.Object)
+						getAttribute(path: slime.jrunscript.native.java.nio.file.Path, attribute: string): slime.jrunscript.native.java.lang.Object
+
+						getPosixFilePermissions(path: slime.jrunscript.native.java.nio.file.Path): slime.jrunscript.native.java.util.Set<slime.jrunscript.native.java.nio.file.attribute.PosixFilePermission>
+						setPosixFilePermissions(path: slime.jrunscript.native.java.nio.file.Path, set: slime.jrunscript.native.java.util.Set<slime.jrunscript.native.java.nio.file.attribute.PosixFilePermission>)
+
+						setLastModifiedTime(path: slime.jrunscript.native.java.nio.file.Path, time: slime.jrunscript.native.java.nio.file.attribute.FileTime)
+						getLastModifiedTime(path: slime.jrunscript.native.java.nio.file.Path): slime.jrunscript.native.java.nio.file.attribute.FileTime
+					}
 					FileSystems: any
 					attribute: {
 						FileTime: any

--- a/rhino/file/java.fifty.ts
+++ b/rhino/file/java.fifty.ts
@@ -78,10 +78,6 @@ namespace slime.jrunscript.file.internal.java {
 			binary: (peer: Peer, append: boolean) => slime.jrunscript.runtime.io.OutputStream
 		}
 
-		getLastModified: (peer: Peer) => Date
-
-		setLastModified: (peer: Peer, date: Date) => void
-
 		remove: (peer: Peer) => void
 
 		move: (peer: Peer, to: Peer) => void

--- a/rhino/file/mock.js
+++ b/rhino/file/mock.js
@@ -150,6 +150,10 @@
 					}
 				},
 				fileSize: $api.TODO(),
+				attributes: {
+					size: void(0),
+					times: void(0)
+				},
 				fileLastModified: $api.TODO(),
 				listDirectory: function(p) {
 					return function(events) {

--- a/rhino/file/oo.fifty.ts
+++ b/rhino/file/oo.fifty.ts
@@ -276,7 +276,7 @@ namespace slime.jrunscript.file.internal.oo {
 				jsh.shell.console(String(nio));
 				Packages.java.nio.file.Files.setLastModifiedTime(nio, Packages.java.nio.file.attribute.FileTime.fromMillis(MODIFIED_TIME.unix));
 				var _modified = Packages.java.nio.file.Files.getLastModifiedTime(nio);
-				jsh.shell.console(_modified.toMillis());
+				jsh.shell.console(String(_modified.toMillis()));
 			}
 
 			fifty.tests.exports.navigate = function() {

--- a/rhino/file/oo/file.js
+++ b/rhino/file/oo/file.js
@@ -316,12 +316,26 @@
 
 				this.__defineGetter__("parent", getParent);
 
+				var attributes = $context.library.Location.attributes(location);
+
 				var getLastModified = function () {
-					return parameters.provider.getLastModified(_peer);
+					var f = $api.fp.now(
+						attributes.times.modified.get,
+						function(q) {
+							return function() {
+								return $api.fp.world.Question.now({ question: q })
+							}
+						}
+					);
+					return f();
 				}
 
-				var setLastModified = function (date) {
-					parameters.provider.setLastModified(_peer, date);
+				var setLastModified = function(date) {
+					var set = $api.fp.now(
+						parameters.filesystem.attributes.times.modified.set({ pathname: location.pathname }),
+						$api.fp.world.Means.effect()
+					)
+					set(date);
 				}
 
 				Object.defineProperty(this, "modified", {

--- a/rhino/file/oo/file.js
+++ b/rhino/file/oo/file.js
@@ -318,6 +318,7 @@
 
 				var attributes = $context.library.Location.attributes(location);
 
+				/** @type { () => Date } */
 				var getLastModified = function () {
 					var f = $api.fp.now(
 						attributes.times.modified.get,
@@ -327,15 +328,16 @@
 							}
 						}
 					);
-					return f();
+					return $api.fp.now(f(), function(tv) { return new Date(tv); });
 				}
 
+				/** @type { (date: Date) => void } */
 				var setLastModified = function(date) {
 					var set = $api.fp.now(
 						parameters.filesystem.attributes.times.modified.set({ pathname: location.pathname }),
 						$api.fp.world.Means.effect()
 					)
-					set(date);
+					set(date.getTime());
 				}
 
 				Object.defineProperty(this, "modified", {

--- a/rhino/file/wo.fifty.ts
+++ b/rhino/file/wo.fifty.ts
@@ -98,15 +98,195 @@ namespace slime.jrunscript.file {
 			/** @deprecated Replaced by `directory.relativePath`. */
 			relative: (path: string) => (p: slime.jrunscript.file.Location) => slime.jrunscript.file.Location
 		}
+	}
 
-		export interface Exports {
-			/**
-			 * See {@link slime.jrunscript.file.world.Filesystem.fileLastModified} for the semantics of this number.
-			 */
-			lastModified: {
-				simple: slime.$api.fp.Mapping<slime.jrunscript.file.Location,slime.external.lib.es5.TimeValue>
-			}
+	export type Attribute<T, Writable extends boolean> = {
+		get: slime.$api.fp.world.Question<void,T>;
+	} & (
+		Writable extends true
+		? {
+			set: slime.$api.fp.world.Means<T,void>
 		}
+		: {
+		}
+	);
+
+	export interface Attributes {
+		size: Attribute<number,false>
+		times: {
+			created: Attribute<slime.external.lib.es5.TimeValue,true>
+			modified: Attribute<slime.external.lib.es5.TimeValue,true>
+			accessed: Attribute<slime.external.lib.es5.TimeValue,true>
+		}
+	}
+
+	export namespace location {
+		export interface Exports {
+			attributes: (location: Location) => Attributes
+		}
+
+		(
+			function(
+				fifty: slime.fifty.test.Kit
+			) {
+				const { verify } = fifty;
+				const { jsh } = fifty.global;
+				const $api = fifty.global.$api as slime.$api.jrunscript.Global;
+				const { Location } = fifty.global.jsh.file;
+
+				fifty.tests.exports.Location.attributes = function() {
+					var date: slime.time.Datetime = {
+						year: 2021,
+						month: 1,
+						day: 20,
+						hour: 12,
+						minute: 0,
+						second: 0
+					};
+
+					var eastern = jsh.time.Timezone["America/New_York"];
+
+					var file = fifty.jsh.file.temporary.location();
+
+					var attributes = Location.attributes(file);
+
+					var size = $api.fp.now(
+						attributes.size.get,
+						function(q) {
+							return function() {
+								return $api.fp.world.Question.now({ question: q });
+							}
+						}
+					);
+
+					//	TODO	what if we call lastModified before file exists?
+
+					jsh.file.Location.file.write.open(file).simple().pipe.simple($api.jrunscript.io.InputStream.string.default("hey"));
+
+					verify(size()).is(3);
+
+					//	TODO	provide simple API for this
+					var lastModified = $api.fp.now(
+						attributes.times.modified.get,
+						function(q) {
+							return function() {
+								return $api.fp.world.Question.now({ question: q })
+							}
+						}
+					);
+
+					//	TODO	provide simple API for this
+					var created = $api.fp.now(
+						attributes.times.created.get,
+						function(q) {
+							return function() {
+								return $api.fp.world.Question.now({ question: q })
+							}
+						}
+					);
+
+					//	TODO	provide simple API for this
+					var accessed = $api.fp.now(
+						attributes.times.accessed.get,
+						function(q) {
+							return function() {
+								return $api.fp.world.Question.now({ question: q })
+							}
+						}
+					);
+
+					//	TODO	provide simple API for this
+					var setLastModified = $api.fp.now(
+						attributes.times.modified.set,
+						$api.fp.world.Means.effect()
+					);
+
+					//	TODO	provide simple API for this
+					var setCreated = $api.fp.now(
+						attributes.times.created.set,
+						$api.fp.world.Means.effect()
+					);
+
+					//	TODO	provide simple API for this
+					var setAccessed = $api.fp.now(
+						attributes.times.accessed.set,
+						$api.fp.world.Means.effect()
+					);
+
+					var initialLastModified = lastModified();
+
+					jsh.java.Thread.sleep(100);
+
+					jsh.file.Location.file.write.open(file).simple().pipe.simple($api.jrunscript.io.InputStream.string.default("now"));
+
+					var secondLastModified = lastModified();
+
+					verify(secondLastModified - initialLastModified >= 100).is(true);
+
+					//	TODO	time API?
+					var HOUR = 60 * 60 * 1000;
+
+					setLastModified(eastern.unix(date));
+					setCreated(eastern.unix(date) - HOUR);
+					setAccessed(eastern.unix(date) + HOUR);
+
+					verify(eastern.local(lastModified()), "thirdLastModified", function(it) {
+						it.year.is(date.year);
+						it.month.is(date.month);
+						it.day.is(date.day);
+						it.hour.is(date.hour);
+						it.minute.is(date.minute);
+						it.second.is(date.second);
+					});
+
+					verify(eastern.local(created()), "thirdCreated", function(it) {
+						it.year.is(date.year);
+						it.month.is(date.month);
+						it.day.is(date.day);
+						it.hour.is(date.hour - 1);
+						it.minute.is(date.minute);
+						it.second.is(date.second);
+					});
+
+					verify(eastern.local(accessed()), "thirdAccessed", function(it) {
+						it.year.is(date.year);
+						it.month.is(date.month);
+						it.day.is(date.day);
+						it.hour.is(date.hour + 1);
+						it.minute.is(date.minute);
+						it.second.is(date.second);
+					});
+				}
+
+				fifty.tests.manual.Location = {};
+
+				fifty.tests.manual.Location.attributes = function() {
+					var target = fifty.jsh.file.relative("./wo.js");
+					var attributes = Location.attributes(target);
+					var size = $api.fp.now(
+						attributes.size.get,
+						function(q) {
+							return function() {
+								return $api.fp.world.Question.now({ question: q })
+							}
+						}
+					);
+					jsh.shell.console("size of " + target.pathname + " = " + size());
+
+					var lastModified = $api.fp.now(
+						attributes.times.modified.get,
+						function(q) {
+							return function() {
+								return $api.fp.world.Question.now({ question: q })
+							}
+						}
+					);
+
+					jsh.shell.console("lastModified of " + target.pathname + " = " + new Date(lastModified()));
+				}
+			}
+		//@ts-ignore
+		)(fifty);
 	}
 
 	export namespace posix {

--- a/rhino/file/wo.fifty.ts
+++ b/rhino/file/wo.fifty.ts
@@ -239,14 +239,20 @@ namespace slime.jrunscript.file {
 						it.second.is(date.second);
 					});
 
-					verify(eastern.local(created()), "thirdCreated", function(it) {
-						it.year.is(date.year);
-						it.month.is(date.month);
-						it.day.is(date.day);
-						it.hour.is(date.hour - 1);
-						it.minute.is(date.minute);
-						it.second.is(date.second);
-					});
+					if (jsh.shell.os.name == "Mac OS X") {
+						verify(eastern.local(created()), "thirdCreated", function(it) {
+							it.year.is(date.year);
+							it.month.is(date.month);
+							it.day.is(date.day);
+							it.hour.is(date.hour - 1);
+							it.minute.is(date.minute);
+							it.second.is(date.second);
+						});
+					} else if (jsh.shell.os.name == "Linux") {
+						//	do nothing; cannot update created time so it will be the value given by the system clock
+					} else {
+						//	who knows
+					}
 
 					verify(eastern.local(accessed()), "thirdAccessed", function(it) {
 						it.year.is(date.year);

--- a/rhino/file/wo.fifty.ts
+++ b/rhino/file/wo.fifty.ts
@@ -163,6 +163,7 @@ namespace slime.jrunscript.file {
 
 					jsh.file.Location.file.write.open(file).simple().pipe.simple($api.jrunscript.io.InputStream.string.default("hey"));
 
+					debugger;
 					verify(size()).is(3);
 
 					//	TODO	provide simple API for this
@@ -215,13 +216,18 @@ namespace slime.jrunscript.file {
 
 					var initialLastModified = lastModified();
 
-					jsh.java.Thread.sleep(100);
+					var major = jsh.internal.bootstrap.java.getMajorVersion();
+
+					//	Under JDK 8, filesystem timestamp resolution appears to be to the second (or two seconds?)
+					var GAP = (major == 8) ? 2000 : 100;
+
+					jsh.java.Thread.sleep(GAP);
 
 					jsh.file.Location.file.write.open(file).simple().pipe.simple($api.jrunscript.io.InputStream.string.default("now"));
 
 					var secondLastModified = lastModified();
 
-					verify(secondLastModified - initialLastModified >= 100).is(true);
+					verify(secondLastModified - initialLastModified >= GAP).is(true);
 
 					//	TODO	time API?
 					var HOUR = 60 * 60 * 1000;

--- a/rhino/file/wo.js
+++ b/rhino/file/wo.js
@@ -199,10 +199,6 @@
 		var Location = {
 			relative: Location_relative,
 			basename: Location_basename,
-			/** @type { slime.jrunscript.file.location.Exports["lastModified"] } */
-			lastModified: {
-				simple: lastModifiedSimple
-			},
 			file: {
 				exists: {
 					simple: $api.fp.world.mapping(Location_file_exists),
@@ -388,7 +384,6 @@
 					}
 				},
 				relative: $api.deprecate(parts.directory.relativePath),
-				lastModified: Location.lastModified,
 				parent: Location_parent,
 				basename: Location_basename,
 				canonicalize: function(location) {
@@ -400,6 +395,26 @@
 					}
 				},
 				Function: Location_Function,
+				attributes: function(location) {
+					/** @type { (world: slime.jrunscript.file.world.Attribute<number, true>) => slime.jrunscript.file.Attribute<number, true> } */
+					var fromWorldAttribute = function(world) {
+						return {
+							get: world.get({ pathname: location.pathname }),
+							set: world.set({ pathname: location.pathname })
+						}
+					}
+
+					return {
+						size: {
+							get: location.filesystem.attributes.size.get({ pathname: location.pathname })
+						},
+						times: {
+							modified: fromWorldAttribute(location.filesystem.attributes.times.modified),
+							created: fromWorldAttribute(location.filesystem.attributes.times.created),
+							accessed: fromWorldAttribute(location.filesystem.attributes.times.accessed)
+						}
+					}
+				},
 				posix: {
 					//	TODO	this implementation assumes the filesystem supports POSIX; all of those .posix properties below are
 					//			actually optional

--- a/rhino/file/world.fifty.ts
+++ b/rhino/file/world.fifty.ts
@@ -97,6 +97,37 @@ namespace slime.jrunscript.file {
 			}
 		}
 
+		export type Attribute<T, Writable extends boolean> = {
+			get: slime.$api.fp.world.Sensor<{ pathname: string },void,T>;
+		} & (
+			Writable extends true
+			? {
+				set: (p: { pathname: string }) => slime.$api.fp.world.Means<T,void>
+			}
+			: {
+			}
+		);
+
+		export interface Attributes {
+			size: Attribute<number,false>
+			times: {
+				created: Attribute<slime.external.lib.es5.TimeValue,true>
+				modified: Attribute<slime.external.lib.es5.TimeValue,true>
+				accessed: Attribute<slime.external.lib.es5.TimeValue,true>
+			}
+		}
+
+		export interface Filesystem {
+			attributes: {
+				size: Attribute<number,false>
+				times: {
+					created: Attribute<slime.external.lib.es5.TimeValue,true>
+					modified: Attribute<slime.external.lib.es5.TimeValue,true>
+					accessed: Attribute<slime.external.lib.es5.TimeValue,true>
+				}
+			}
+		}
+
 		export interface Filesystem {
 			posix?: {
 				attributes: {


### PR DESCRIPTION
* Use consistent handling for file last-modified

Also:
* Impove type deinitions that rely on time values to use slime.external.lib.es5.TimeValue