### PR TITLE
Refine APIs

### DIFF
--- a/loader/$api-Function.fifty.ts
+++ b/loader/$api-Function.fifty.ts
@@ -444,7 +444,12 @@ namespace slime.$api.fp {
 			split: (delimiter: string) => (string: string) => string[]
 			repeat: (count: number) => (string: string) => string
 			toUpperCase: (string: string) => string
+
+			/**
+			 * @deprecated Replaced by `RegExp.exec`, which has slightly different semantics (uses `Maybe`).
+			 */
 			match: (pattern: RegExp) => (string: string) => RegExpMatchArray
+
 			trim: Transform<string>
 
 			startsWith: (searchString: string, startPosition?: number) => Predicate<string>
@@ -1391,6 +1396,8 @@ namespace slime.$api.fp {
 			modify: (modifier: (pattern: string) => string) => (original: RegExp) => RegExp
 
 			exec: (regexp: RegExp) => Partial<string,RegExpExecArray>
+
+			test: (regexp: RegExp) => Mapping<string,boolean>
 		}
 	}
 
@@ -1436,6 +1443,19 @@ namespace slime.$api.fp {
 
 				var two = matcher("ac");
 				verify(two).present.is(false);
+			}
+
+
+			fifty.tests.exports.RegExp.test = function() {
+				var pattern = /a(b+)c/;
+
+				var tester = subject.test(pattern);
+
+				var one = tester("abbc");
+				verify(one).is(true);
+
+				var two = tester("ac");
+				verify(two).is(false);
 			}
 		}
 	//@ts-ignore

--- a/loader/$api-Function.js
+++ b/loader/$api-Function.js
@@ -693,6 +693,13 @@
 						var copy = new RegExp(regexp.source);
 						return Maybe.from.value(copy.exec(string));
 					}
+				},
+				test: function(regexp) {
+					return function(string) {
+						//	We copy the RegExp to deal with possibilities of multithreaded access
+						var copy = new RegExp(regexp.source);
+						return copy.test(string);
+					}
 				}
 			},
 			now: Object.assign(now_map, {

--- a/rhino/file/wo.fifty.ts
+++ b/rhino/file/wo.fifty.ts
@@ -49,6 +49,26 @@ namespace slime.jrunscript.file {
 
 	export namespace location {
 		export interface Exports {
+			pathname: (p: slime.jrunscript.file.Location) => string
+		}
+
+		(
+			function(
+				fifty: slime.fifty.test.Kit
+			) {
+				const { verify } = fifty;
+				const subject = fifty.global.jsh.file;
+
+				fifty.tests.exports.Location.pathname = function() {
+					var pathname = "/a/b/c";
+					var location = subject.Location.from.os(pathname);
+					verify(location).evaluate(subject.Location.pathname).is(pathname);
+				}
+			}
+		//@ts-ignore
+		)(fifty);
+
+		export interface Exports {
 			parent: () => (p: slime.jrunscript.file.Location) => slime.jrunscript.file.Location
 		}
 

--- a/rhino/file/wo.js
+++ b/rhino/file/wo.js
@@ -384,6 +384,7 @@
 					}
 				},
 				relative: $api.deprecate(parts.directory.relativePath),
+				pathname: $api.fp.property("pathname"),
 				parent: Location_parent,
 				basename: Location_basename,
 				canonicalize: function(location) {

--- a/rhino/tools/node/module.js
+++ b/rhino/tools/node/module.js
@@ -73,9 +73,11 @@
 					url.value,
 					$api.fp.string.split("/"),
 					function(array) { return array[array.length-1]; },
-					$api.fp.string.match(/(.*)\.tar.gz$/),
+					$api.fp.RegExp.exec(/(.*)\.tar.gz$/),
 					function(match) {
-						return match[1];
+						if (!url.present) throw new Error("Unreachable; asserted outside pipeline.");
+						if (!match.present) throw new Error("Unexpected URL format: " + url.value);
+						return match.value[1];
 					}
 				)
 				return {


### PR DESCRIPTION
* Deprecate $api.fp.string.match in favor of $api.fp.RegExp.exec
* Remove internal calls to $api.fp.string.match
* Add $api.fp.RegExp.test
* Add rhino/file Location.pathname function to assist with type inference