### PR TITLE
Refine events in preparation for refactoring jsh worker API

### DIFF
--- a/jrunscript/jsh/loader/test/worker/readfile.jsh.js
+++ b/jrunscript/jsh/loader/test/worker/readfile.jsh.js
@@ -33,11 +33,10 @@
 							detail: asData(event.detail)
 						}
 					});
-				},
-				listeners: void(0)
+				}
 			});
 			jsh.loader.worker.postMessage({ type: "fulfilled", value: rv });
-		}
+		};
 
 		jsh.script.cli.main(function(invocation) {
 			if (invocation.arguments.length == 2 && invocation.arguments[0] == "worker") {
@@ -57,24 +56,29 @@
 					}
 				);
 			} else {
-				var lines = [];
 				var worker = jsh.loader.worker.create({
 					script: jsh.script.file,
 					arguments: ["worker", invocation.arguments[0]],
-					onmessage: function(e) {
-						if (e.detail.type == "event") {
-							//	TODO	only if type is line
-							lines.push(e.detail.value.detail);
-							jsh.shell.console("LINE: " + e.detail.value.detail);
-						} else if (e.detail.type == "fulfilled") {
-							jsh.shell.echo(JSON.stringify({ lines: lines }));
-							jsh.shell.console("END OF FILE");
-							worker.terminate();
-							jsh.shell.console("Worker terminated.");
-						} else {
-							throw new Error();
+					onmessage: (
+						function() {
+							var lines = [];
+
+							return function(e) {
+								if (e.detail.type == "event") {
+									//	TODO	only if type is line
+									lines.push(e.detail.value.detail);
+									jsh.shell.console("LINE: " + e.detail.value.detail);
+								} else if (e.detail.type == "fulfilled") {
+									jsh.shell.echo(JSON.stringify({ lines: lines }));
+									jsh.shell.console("END OF FILE");
+									worker.terminate();
+									jsh.shell.console("Worker terminated.");
+								} else {
+									throw new Error();
+								}
+							}
 						}
-					}
+					)()
 				});
 				jsh.shell.console("Done with main script.");
 			}

--- a/jrunscript/tools/install/downloads.js
+++ b/jrunscript/tools/install/downloads.js
@@ -15,7 +15,7 @@
 	function($api,$context,$export) {
 		/**
 		 * @param { slime.jrunscript.http.client.spi.Implementation } client
-		 * @param { slime.$api.event.Emitter<slime.jrunscript.tools.install.download.Events> } events
+		 * @param { slime.$api.event.Producer<slime.jrunscript.tools.install.download.Events> } events
 		 */
 		var fetcher = function(client,events) {
 			return $api.fp.world.Sensor.old.mapping({

--- a/loader/$api-fp-impure.fifty.ts
+++ b/loader/$api-fp-impure.fifty.ts
@@ -685,7 +685,7 @@ namespace slime.$api.fp.world {
 		)
 	)
 
-	export type Question<E,R> = (events: slime.$api.event.Emitter<E>) => R
+	export type Question<E,R> = (events: slime.$api.event.Producer<E>) => R
 	export type Action<E> = (events: slime.$api.event.Emitter<E>) => void
 
 	/** @deprecated */
@@ -741,7 +741,7 @@ namespace slime.$api.fp.world {
 	export namespace sensor {
 		export interface Exports {
 			from: {
-				flat: <S,E,R>(f: (p: { subject: S, events: slime.$api.event.Emitter<E> }) => R) => Sensor<S,E,R>
+				flat: <S,E,R>(f: (p: { subject: S, events: slime.$api.event.Producer<E> }) => R) => Sensor<S,E,R>
 			}
 		}
 	}

--- a/loader/events.fifty.ts
+++ b/loader/events.fifty.ts
@@ -280,7 +280,18 @@ namespace slime.$api {
 	)(fifty);
 
 	export namespace event {
-		export interface Emitter<D> {
+		export interface Producer<D> {
+			/**
+			 * Causes this object to fire an event to its listeners.
+			 *
+			 * @param type An event _type_.
+			 * @param detail An event _detail_, which can be any type, and will be used as the `detail` property of the created
+			 * event.
+			 */
+			fire: <K extends keyof D>(type: K, detail?: D[K]) => void
+		}
+
+		export interface Emitter<D> extends Producer<D> {
 			listeners: {
 				/**
 				 * Adds an event listener that will be notified about a particular <dfn>type</dfn> of events.
@@ -298,15 +309,6 @@ namespace slime.$api {
 				 */
 				remove: <K extends keyof D>(type: K, handler: event.Handler<D[K]>) => void
 			}
-
-			/**
-			 * Causes this object to fire an event to its listeners.
-			 *
-			 * @param type An event _type_.
-			 * @param detail An event _detail_, which can be any type, and will be used as the `detail` property of the created
-			 * event.
-			 */
-			fire: <K extends keyof D>(type: K, detail?: D[K]) => void
 		}
 	}
 

--- a/rhino/file/java.js
+++ b/rhino/file/java.js
@@ -353,7 +353,7 @@
 			/**
 			 *
 			 * @param { string } pathname
-			 * @param { slime.$api.event.Emitter<{ notFound: void }> } events
+			 * @param { slime.$api.event.Producer<{ notFound: void }> } events
 			 */
 			var openInputStream = function(pathname,events) {
 				var peer = java.newPeer(pathname);
@@ -389,7 +389,7 @@
 			/**
 			 *
 			 * @param { string } pathname
-			 * @param { slime.$api.event.Emitter<{ notFound: void }> } events
+			 * @param { slime.$api.event.Producer<{ notFound: void }> } events
 			 * @returns
 			 */
 			var maybeInputStream = function(pathname,events) {

--- a/rhino/file/wo-directory.fifty.ts
+++ b/rhino/file/wo-directory.fifty.ts
@@ -182,7 +182,7 @@ namespace slime.jrunscript.file.location.directory {
 	export interface Exports {
 		exists: {
 			simple: slime.$api.fp.Mapping<slime.jrunscript.file.Location,boolean>
-			world: () => slime.$api.fp.world.Sensor<slime.jrunscript.file.Location, {}, boolean>
+			world: () => slime.$api.fp.world.Sensor<slime.jrunscript.file.Location, void, boolean>
 		}
 
 		require: {

--- a/rhino/file/wo-directory.js
+++ b/rhino/file/wo-directory.js
@@ -72,7 +72,7 @@
 					 *
 					 * @param { slime.jrunscript.file.Location } location
 					 * @param { slime.$api.fp.Predicate<slime.jrunscript.file.Location> } descend
-					 * @param { slime.$api.event.Emitter<slime.jrunscript.file.location.directory.list.Events> } events
+					 * @param { slime.$api.event.Producer<slime.jrunscript.file.location.directory.list.Events> } events
 					 * @returns { slime.jrunscript.file.Location[] }
 					 */
 					var process = function(location,descend,events) {

--- a/rhino/file/wo.fifty.ts
+++ b/rhino/file/wo.fifty.ts
@@ -771,7 +771,7 @@ namespace slime.jrunscript.file {
 			export interface Exports {
 				exists: {
 					simple: slime.$api.fp.Mapping<slime.jrunscript.file.Location,boolean>
-					world: () => slime.$api.fp.world.Sensor<slime.jrunscript.file.Location, {}, boolean>
+					world: () => slime.$api.fp.world.Sensor<slime.jrunscript.file.Location, void, boolean>
 				}
 
 				read: {

--- a/rhino/ip/module.fifty.ts
+++ b/rhino/ip/module.fifty.ts
@@ -429,7 +429,7 @@ namespace slime.jrunscript.ip {
 			var Mock = function(
 				implementation: (
 					p: Parameters<World["tcp"]["isAvailable"]>[0],
-					events: $api.event.Emitter<{ exception: Error }>
+					events: $api.event.Producer<{ exception: Error }>
 				) => boolean
 			 ) {
 				var isAvailable: World["tcp"]["isAvailable"] = function(p) {

--- a/rhino/shell/run.js
+++ b/rhino/shell/run.js
@@ -57,7 +57,7 @@
 
 				/**
 				 *
-				 * @param { slime.$api.event.Emitter<slime.jrunscript.shell.run.TellEvents> } events
+				 * @param { slime.$api.event.Producer<slime.jrunscript.shell.run.TellEvents> } events
 				 * @param { slime.jrunscript.shell.run.internal.SubprocessOutputStreamIdentity } stream
 				 */
 				var destinationFactory = function(events, stream) {
@@ -75,7 +75,7 @@
 					}
 
 					/**
-					 * @param { slime.$api.event.Emitter<slime.jrunscript.shell.run.TellEvents> } events
+					 * @param { slime.$api.event.Producer<slime.jrunscript.shell.run.TellEvents> } events
 					 * @param { slime.jrunscript.shell.run.internal.SubprocessOutputStreamIdentity } stream
 					 * @returns { slime.jrunscript.shell.internal.run.OutputDestination }
 					 */

--- a/rhino/tools/gcloud/module.fifty.ts
+++ b/rhino/tools/gcloud/module.fifty.ts
@@ -25,7 +25,7 @@ namespace slime.jrunscript.tools.gcloud {
 
 		export type Configuration = <P,R>(command: Command<P,R>) => {
 			intention: (p: P) => slime.jrunscript.shell.run.Intention
-			handler: (events: slime.$api.event.Emitter<Events>) => slime.$api.event.Handlers<slime.jrunscript.shell.run.AskEvents>
+			handler: (events: slime.$api.event.Producer<Events>) => slime.$api.event.Handlers<slime.jrunscript.shell.run.AskEvents>
 			result: (result: slime.jrunscript.shell.run.Exit) => R
 		}
 


### PR DESCRIPTION
* Split event production API into event.Producer (no listeners) and event.Emitter (allows add/remove listener)
* Simplify reference implementation for invoking jsh worker