### PR TITLE
Resolve #2236: Configure Fifty to emit timing data for tests

### DIFF
--- a/tools/fifty/test-browser.js
+++ b/tools/fifty/test-browser.js
@@ -85,16 +85,16 @@
 				start: function(scope, name) {
 					scope.children[0].innerHTML = name;
 				},
-				test: function(scope, message, result) {
+				test: function(/** @type { HTMLElement } */scope, /** @type { string } */message, /** @type { boolean } */result) {
 					var test = templates.test();
 					test.children[0].innerHTML = "";
 					test.children[0].appendChild(document.createTextNode(message));
 					addHtmlClass(test, getHtmlClass(result));
 					scope.children[1].appendChild(test);
 				},
-				end: function(scope, name, result) {
+				end: function(scope, name, result, /** @type { number } */elapsed) {
 					scope.children[2].innerHTML = "";
-					scope.children[2].appendChild(document.createTextNode(name));
+					scope.children[2].appendChild(document.createTextNode(name + " (" + elapsed + " ms)"));
 					addHtmlClass(scope, getHtmlClass(result));
 				}
 			}
@@ -109,7 +109,7 @@
 				document.body.appendChild(top);
 				scopes.start(top, "foo");
 				scopes.test(top, "foo is foo", true);
-				scopes.end(top, "bar", true);
+				scopes.end(top, "bar", true, 123);
 				return;
 			}
 
@@ -141,7 +141,7 @@
 							delegate.log("START", depth(e.source), e.detail.name);
 						},
 						end: function(e) {
-							scopes.end(target, e.detail.name, e.detail.result);
+							scopes.end(target, e.detail.name, e.detail.result, e.detail.elapsed);
 							target = target.parentElement.parentElement;
 							delegate.log("END", depth(e.source), e.detail.name, e.detail.result);
 						},

--- a/tools/fifty/test.fifty.ts
+++ b/tools/fifty/test.fifty.ts
@@ -269,7 +269,7 @@ namespace slime.fifty.test.internal {
 	export interface Events {
 		start: { name: string }
 		test: { message: string, success: boolean }
-		end: { name: string, result: boolean }
+		end: { name: string, result: boolean, elapsed: number }
 	}
 
 	/**

--- a/tools/fifty/test.js
+++ b/tools/fifty/test.js
@@ -65,12 +65,15 @@
 						on: p.listener
 					});
 
+					var started;
+
 					this.start = function(name) {
+						started = new Date().getTime();
 						emitter.fire("start", { name: name });
 					};
 
 					this.end = function(name,result) {
-						emitter.fire("end", { name: name, result: result });
+						emitter.fire("end", { name: name, result: result, elapsed: new Date().getTime() - started });
 					};
 
 					/** @type { slime.definition.verify.Context } */
@@ -115,6 +118,8 @@
 				/** @type { slime.definition.verify.Verify } */
 				var verify;
 
+				var started;
+
 				/**
 				 * @param { string } name
 				 */
@@ -122,6 +127,7 @@
 					if (scope) {
 						scope.start(name);
 					} else {
+						started = new Date().getTime();
 						emitter.fire("start", { name: name });
 					}
 				};
@@ -134,7 +140,7 @@
 					if (scope) {
 						scope.end(name,result);
 					} else {
-						emitter.fire("end", { name: name, result: result });
+						emitter.fire("end", { name: name, result: result, elapsed: new Date().getTime() - started });
 					}
 				}
 

--- a/tools/fifty/test.jsh.js
+++ b/tools/fifty/test.jsh.js
@@ -110,20 +110,15 @@
 					jsh.shell.console(prefix + string);
 				};
 
-				var map = new Map();
-
 				/** @type { slime.fifty.test.internal.Listener } */
 				var rv = {
 					start: function(event) {
 						write(event.source, "Running: " + event.detail.name);
-						map.set(event.source, new Date().getTime());
 					},
 
 					end: function(event) {
-						var elapsed = new Date().getTime() - map.get(event.source);
 						var resultString = (event.detail.result) ? "PASSED" : "FAILED"
-						write(event.source, resultString + ": " + event.detail.name + " (" + elapsed + " ms)");
-						map.delete(event.source);
+						write(event.source, resultString + ": " + event.detail.name + " (" + event.detail.elapsed + " ms)");
 					},
 
 					test: function(event) {


### PR DESCRIPTION
* Add elapsed, in milliseconds, to event indicating completion of a section
* Adjust test.jsh to output the elapsed value, removing previous code that computed it
* Adjust test.browser to output the elapsed value