### PR TITLE
When closing devcontainer, stop all Docker Compose services

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,8 +42,8 @@
 		}
 	},
 	"service": "local",
-	"runServices": ["local"],
 	"workspaceFolder": "/slime",
 	"initializeCommand": ".devcontainer/initializeCommand",
-	"postCreateCommand": ".devcontainer/postCreateCommand"
+	"postCreateCommand": ".devcontainer/postCreateCommand",
+	"shutdownAction": "stopCompose"
 }


### PR DESCRIPTION
This should help when using host script to discover appropriate VNC port for a given devcontainer