### PR TITLE
Refine GitHub test structure

### DIFF
--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -1,0 +1,33 @@
+#	LICENSE
+#	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+#	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#	END LICENSE
+
+name: test-jdk21
+on:
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Use Docker to create image, and then run the linting and tests
+        env:
+          SLIME_TEST_NO_WF_SUBMODULE_RESET: 1
+        run: contributor/test-docker-clean-command 21 /bin/bash /slime/wf check

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -4,7 +4,7 @@
 #
 #	END LICENSE
 
-name: test-jdk21
+name: check-jdk21
 on:
   pull_request:
     branches:
@@ -27,7 +27,7 @@ jobs:
           docker-images: true
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Use Docker to create image, and then run the linting and tests
+      - name: Use Docker to create image, and then run the linting, type checking, and other checks
         env:
           SLIME_TEST_NO_WF_SUBMODULE_RESET: 1
         run: contributor/test-docker-clean-command 21 /bin/bash /slime/wf check

--- a/contributor/suite-docker-jrunscript
+++ b/contributor/suite-docker-jrunscript
@@ -12,4 +12,4 @@ fi
 
 #	TODO	should fail with multiple arguments
 
-$(dirname $0)/test-docker-clean-command $1 /bin/bash /slime/wf check
+$(dirname $0)/test-docker-clean-command $1 /bin/bash /slime/wf test.jrunscript

--- a/contributor/suite-macos
+++ b/contributor/suite-macos
@@ -5,4 +5,4 @@
 #
 #	END LICENSE
 
-$(dirname $0)/../wf check
+$(dirname $0)/../wf test.jrunscript

--- a/tools/wf/plugin-standard.jsh.fifty.ts
+++ b/tools/wf/plugin-standard.jsh.fifty.ts
@@ -287,7 +287,11 @@ namespace slime.jsh.wf.standard {
 
 		prune: slime.jsh.script.cli.Command<Options>
 
-		test: slime.jsh.script.cli.Command<Options>
+		/**
+		 * A command that is present if the provided {@link slime.jsh.wf.standard.Project Project} had a `test` property supplying
+		 * a {@link slime.jsh.wf.Test Test} implementation, in which case it runs the provided implementation.
+		 */
+		test?: slime.jsh.script.cli.Command<Options>
 
 		precommit: slime.jsh.script.cli.Command<Options>
 

--- a/tools/wf/plugin.jsh.js
+++ b/tools/wf/plugin.jsh.js
@@ -1262,7 +1262,7 @@
 								}
 							}
 						);
-						events.fire("console", "`tsc.jsh.js exited with status: " + result.status);
+						events.fire("console", "tsc.jsh.js exited with status: " + result.status);
 						return (result.status == 0);
 					};
 				}

--- a/tools/wf/plugin.jsh.js
+++ b/tools/wf/plugin.jsh.js
@@ -1262,6 +1262,7 @@
 								}
 							}
 						);
+						events.fire("console", "`tsc.jsh.js exited with status: " + result.status);
 						return (result.status == 0);
 					};
 				}

--- a/wf.js
+++ b/wf.js
@@ -436,15 +436,6 @@
 			return result.status == 0;
 		};
 
-		var checks = $api.fp.now(
-			jsh.wf.checks.precommit({ lint: lint }),
-			$api.fp.world.Question.thunk({
-				console: function(e) {
-					jsh.shell.console(e.detail);
-				}
-			})
-		);
-
 		var project = (
 			/**
 			 *
@@ -467,6 +458,15 @@
 							success = false;
 						}
 
+						var checks = $api.fp.now(
+							jsh.wf.checks.precommit({ lint: lint }),
+							$api.fp.world.Question.thunk({
+								console: function(e) {
+									jsh.shell.console(e.detail);
+								}
+							})
+						);
+
 						success = success && checks();
 
 						return success;
@@ -485,7 +485,21 @@
 		);
 
 		$exports.check = $api.fp.pipe(
-			checks,
+			function(p) {
+				var lint = $api.fp.now(project.lint.check, $api.fp.world.Question.thunk({
+					console: function(e) {
+						jsh.shell.console(e.detail);
+					}
+				}));
+
+				var tsc = $api.fp.now(jsh.wf.checks.tsc(), $api.fp.world.Question.thunk({
+					console: function(e) {
+						jsh.shell.console(e.detail);
+					}
+				}));
+
+				return lint() && tsc();
+			},
 			function(result) {
 				return (result) ? 0 : 1;
 			}

--- a/wf.js
+++ b/wf.js
@@ -436,6 +436,15 @@
 			return result.status == 0;
 		};
 
+		var checks = $api.fp.now(
+			jsh.wf.checks.precommit({ lint: lint }),
+			$api.fp.world.Question.thunk({
+				console: function(e) {
+					jsh.shell.console(e.detail);
+				}
+			})
+		);
+
 		var project = (
 			/**
 			 *
@@ -458,17 +467,7 @@
 							success = false;
 						}
 
-						success = success && $api.fp.world.Sensor.now({
-							sensor: jsh.wf.checks.precommit,
-							subject: {
-								lint: lint
-							},
-							handlers: {
-								console: function(e) {
-									events.fire("console", e.detail);
-								}
-							}
-						});
+						success = success && checks();
 
 						return success;
 					}
@@ -486,11 +485,7 @@
 		);
 
 		$exports.check = $api.fp.pipe(
-			$api.fp.now(project.precommit, $api.fp.world.Question.thunk({
-				console: function(e) {
-					jsh.shell.console(e.detail);
-				}
-			})),
+			checks,
 			function(result) {
 				return (result) ? 0 : 1;
 			}

--- a/wf.js
+++ b/wf.js
@@ -486,7 +486,11 @@
 		);
 
 		$exports.check = $api.fp.pipe(
-			$api.fp.now(project.precommit, $api.fp.world.Question.thunk({})),
+			$api.fp.now(project.precommit, $api.fp.world.Question.thunk({
+				console: function(e) {
+					jsh.shell.console(e.detail);
+				}
+			})),
 			function(result) {
 				return (result) ? 0 : 1;
 			}
@@ -494,7 +498,7 @@
 
 		$exports.test = {
 			jrunscript: function() {
-				var runTeats = $api.fp.now(test_jrunscript, $api.fp.world.Question.thunk({
+				var runTests = $api.fp.now(test_jrunscript, $api.fp.world.Question.thunk({
 					console: function(e) {
 						jsh.shell.console(e.detail);
 					},
@@ -502,7 +506,9 @@
 						jsh.shell.echo(e.detail);
 					}
 				}));
-				return runTeats();
+				var success = runTests();
+				if (!success) jsh.shell.console("jrunscript tests failed.");
+				return (success) ? 0 : 1;
 			}
 		}
 

--- a/wf.js
+++ b/wf.js
@@ -12,7 +12,7 @@
 	 * @param { slime.jsh.Global } jsh
 	 * @param { slime.jsh.wf.cli.Context } $context
 	 * @param { slime.runtime.loader.Store } $loader
-	 * @param { slime.project.wf.Interface } $exports
+	 * @param { Omit<slime.project.wf.Interface,"test"> & { test: { jrunscript: any } } } $exports
 	 */
 	function(Packages,$api,jsh,$context,$loader,$exports) {
 		function synchronizeEclipseSettings() {
@@ -394,50 +394,46 @@
 		/**
 		 * Runs the test suite, first installing Java, and Rhino.
 		 *
-		 * Exits the VM with exit status 1 on failure; otherwise, returns `true`.
-		 *
-		 * @returns { slime.jsh.wf.Test }
+		 * @type { slime.jsh.wf.Test }
 		 */
-		var test = function() {
-			return function(events) {
-				//	This invocation will install the JDK if necessary, and then ensure the version of Rhino is the correct one for
-				//	that JDK
-				jsh.shell.run({
+		var test_jrunscript = function(events) {
+			//	This invocation will install the JDK if necessary, and then ensure the version of Rhino is the correct one for
+			//	that JDK
+			jsh.shell.run({
+				command: "bash",
+				arguments: [
+					$context.base.getRelativePath("jsh"),
+					$context.base.getRelativePath("jrunscript/jsh/tools/install/rhino.jsh.js"),
+					"--replace"
+				]
+			});
+
+			//	Inserted to try to deal with issue #896. May not be needed; TypeScript may be installed when needed anyway. But with
+			//	tsc blipping in and out of existence, it seemed prudent to try simplifying the TypeScript life cycle.
+			jsh.wf.typescript.require();
+
+			var result = $api.fp.world.now.question(
+				jsh.shell.subprocess.question,
+				{
 					command: "bash",
-					arguments: [
-						$context.base.getRelativePath("jsh"),
-						$context.base.getRelativePath("jrunscript/jsh/tools/install/rhino.jsh.js"),
-						"--replace"
-					]
-				});
-
-				//	Inserted to try to deal with issue #896. May not be needed; TypeScript may be installed when needed anyway. But with
-				//	tsc blipping in and out of existence, it seemed prudent to try simplifying the TypeScript life cycle.
-				jsh.wf.typescript.require();
-
-				var result = $api.fp.world.now.question(
-					jsh.shell.subprocess.question,
-					{
-						command: "bash",
-						arguments: $api.Array.build(function(rv) {
-							rv.push(jsh.shell.jsh.src.getFile("jsh").toString());
-							rv.push($context.base.getRelativePath("contributor/jrunscript.jsh.js"));
-						})
+					arguments: $api.Array.build(function(rv) {
+						rv.push(jsh.shell.jsh.src.getFile("jsh").toString());
+						rv.push($context.base.getRelativePath("contributor/jrunscript.jsh.js"));
+					})
+				},
+				{
+					stdout: function(e) {
+						events.fire("output", e.detail.line);
 					},
-					{
-						stdout: function(e) {
-							events.fire("output", e.detail.line);
-						},
-						stderr: function(e) {
-							events.fire("console", e.detail.line);
-						}
+					stderr: function(e) {
+						events.fire("console", e.detail.line);
 					}
-				)
-				if (result.status != 0) {
-					jsh.shell.console("Failing because tests failed.");
 				}
-				return result.status == 0;
+			)
+			if (result.status != 0) {
+				jsh.shell.console("Failing because tests failed.");
 			}
+			return result.status == 0;
 		};
 
 		var project = (
@@ -451,8 +447,6 @@
 						check: lint,
 						fix: jsh.wf.checks.lint().fix
 					},
-					//	TODO	arguably this should now run browser tests?
-					test: test(),
 					precommit: function(events) {
 						var success = true;
 
@@ -485,46 +479,32 @@
 		jsh.wf.project.initialize(
 			$context,
 			project,
+			//	This object ends up having a test.jrunscript property, which $exports does not expect. Can think about better ways
+			//	to fix this, but this seems fine for now.
+			//@ts-ignore
 			$exports
 		);
 
 		$exports.check = $api.fp.pipe(
-			function(p) {
-				jsh.shell.console("Linting ...");
-				var lintingPassed = $api.fp.world.now.ask(lint, {
-					console: function(e) {
-						jsh.shell.console(e.detail);
-					}
-				});
-				if (!lintingPassed) {
-					jsh.shell.console("Linting failed.");
-					return 1;
-				}
-				jsh.shell.console("Running TypeScript compiler ...");
-				jsh.wf.checks.tsc();
-				jsh.shell.console("Running tests ...");
-
-				var runTests = $api.fp.now(test(), $api.fp.world.Question.thunk(
-					{
-						console: function(e) {
-							jsh.shell.console(e.detail);
-						},
-						output: function(e) {
-							jsh.shell.echo(e.detail);
-						}
-					}
-				));
-
-				var testsPassed = runTests();
-
-				if (!testsPassed) {
-					jsh.shell.console("Tests failed.");
-					return 1;
-				}
-
-				jsh.shell.console("Passed.");
+			$api.fp.now(project.precommit, $api.fp.world.Question.thunk({})),
+			function(result) {
+				return (result) ? 0 : 1;
 			}
 		);
+
+		$exports.test = {
+			jrunscript: function() {
+				var runTeats = $api.fp.now(test_jrunscript, $api.fp.world.Question.thunk({
+					console: function(e) {
+						jsh.shell.console(e.detail);
+					},
+					output: function(e) {
+						jsh.shell.echo(e.detail);
+					}
+				}));
+				return runTeats();
+			}
+		}
 
 		if (jsh.tools.git.oo.Repository) {
 			(


### PR DESCRIPTION
* Remove linting, type checking, and other checks to a separate GitHub workflow
* Rename jrunscript testing workflow to wf task test.jrunscript
* Document standard test property for projects