### PR TITLE
#2329: Remove the namespace property from runtime

### DIFF
--- a/loader/$api.fifty.ts
+++ b/loader/$api.fifty.ts
@@ -16,16 +16,28 @@ interface Function {
 	construct: any
 }
 
-namespace slime.runtime {
-	(
-		function(
-			fifty: slime.fifty.test.Kit
-		) {
-			fifty.tests.runtime = fifty.test.Parent();
-			fifty.tests.runtime.exports = fifty.test.Parent();
-		}
-	//@ts-ignore
-	)(fifty);
+/**
+ *
+ * The `$api` object is provided to all code loaded by the platform loader. It represents the SLIME APIs available on all platforms.
+ * (Some platform-specific APIs are available through properties of the `$api` object, sucn as `$api.jrunscript` and `$api.browser`.)
+ *
+ * ## Functional programming: {@link slime.$api.fp `$api.fp`}
+ *
+ * The `$api.fp` namespace provides functional programming constructs. See {@link slime.$api.fp}.
+ *
+ * ## Handling content: {@link slime.runtime.content `$api.content`}
+ *
+ * The `$api.content` namespace provides the ability to handle _content_. *Content* is defined in SLIME as a hierarchical structure
+ * with a root and containing paths. It can represent a filesystem, a URL space, a ZIP/TAR file, or any other logically hierarchical
+ * structure.
+ *
+ * ## Handling deprecation and API usage
+ *
+ * Various `$api` methods can "flag" APIs for callers, causing a configurable callback to be executed when they are invoked, to warn
+ * the users that the APIs are deprecated or experimental. See the `deprecate` and `experimental` functions of {@link slime.$api.Global |
+ * `$api`}.
+ */
+namespace slime.$api {
 	/**
 	 * An object that gives access to functionality for the current JavaScript engine. Created by combining the `$engine`
 	 * property provided as part of {@link slime.runtime.Scope} with default implementations provided by the SLIME runtime.
@@ -89,9 +101,9 @@ namespace slime.runtime {
 			const { verify } = fifty;
 			const { $api } = fifty.global;
 
-			fifty.tests.runtime.exports.engine = fifty.test.Parent();
+			fifty.tests.exports.engine = fifty.test.Parent();
 
-			fifty.tests.runtime.exports.engine.MetaObject = function() {
+			fifty.tests.exports.engine.MetaObject = function() {
 				const test = function(b: boolean) {
 					verify(b).is(true);
 				};
@@ -133,6 +145,11 @@ namespace slime.runtime {
 	//@ts-ignore
 	)(fifty);
 
+	export interface Global {
+		engine: Engine
+	}
+
+
 	/**
 	 * Provides information about and capabilities of the underlying JavaScript platform; loaded code can use this information
 	 * in its implementation.
@@ -162,6 +179,13 @@ namespace slime.runtime {
 		}
 	}
 
+	export interface Global {
+		/**
+		 * Provides information about the underlying JavaScript platform; see the {@link slime.runtime.Platform} type for details.
+		 */
+		platform: Platform
+	}
+
 	(
 		function(
 			fifty: slime.fifty.test.Kit
@@ -169,9 +193,9 @@ namespace slime.runtime {
 			const { verify } = fifty;
 			const { $api } = fifty.global;
 
-			fifty.tests.runtime.exports.platform = fifty.test.Parent();
+			fifty.tests.exports.platform = fifty.test.Parent();
 
-			fifty.tests.runtime.exports.platform.java = function() {
+			fifty.tests.exports.platform.java = function() {
 				var o: { x: number } = { x: void(0) };
 				o.x = 3;
 				verify(o).x.is(3);
@@ -184,40 +208,6 @@ namespace slime.runtime {
 		}
 	//@ts-ignore
 	)(fifty);
-}
-
-/**
- *
- * The `$api` object is provided to all code loaded by the platform loader. It represents the SLIME APIs available on all platforms.
- * (Some platform-specific APIs are available through properties of the `$api` object, sucn as `$api.jrunscript` and `$api.browser`.)
- *
- * ## Functional programming: {@link slime.$api.fp `$api.fp`}
- *
- * The `$api.fp` namespace provides functional programming constructs. See {@link slime.$api.fp}.
- *
- * ## Handling content: {@link slime.runtime.content `$api.content`}
- *
- * The `$api.content` namespace provides the ability to handle _content_. *Content* is defined in SLIME as a hierarchical structure
- * with a root and containing paths. It can represent a filesystem, a URL space, a ZIP/TAR file, or any other logically hierarchical
- * structure.
- *
- * ## Handling deprecation and API usage
- *
- * Various `$api` methods can "flag" APIs for callers, causing a configurable callback to be executed when they are invoked, to warn
- * the users that the APIs are deprecated or experimental. See the `deprecate` and `experimental` functions of {@link slime.$api.Global |
- * `$api`}.
- */
-namespace slime.$api {
-	export interface Global {
-		engine: slime.runtime.Engine
-	}
-
-	export interface Global {
-		/**
-		 * Provides information about the underlying JavaScript platform; see the {@link slime.runtime.Platform} type for details.
-		 */
-		platform: slime.runtime.Platform
-	}
 
 	export interface Global {
 		/**
@@ -279,11 +269,64 @@ namespace slime.$api {
 			 * @returns The value given, for convenience.
 			 */
 			at: {
-				<T>(path: string[]): object
+				(path: string[]): any
 				<T>(path: string[], create: () => T): T
 			}
 		}
 	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			fifty.tests.exports.global = fifty.test.Parent();
+
+			fifty.tests.exports.global.at = function() {
+				const { verify } = fifty;
+				const { $api } = fifty.global;
+
+				var global: object & { crypto: any, Packages?: slime.jrunscript.Packages } = (function() { return this; })();
+
+				const Packages = (function() {
+					if (global.Packages) return global.Packages;
+					return null;
+				})();
+
+				var empty: object = $api.global.at([]);
+				verify(empty).is(global);
+
+				var uuid: () => string = (
+					function() {
+						if (global.crypto && global.crypto.randomUUID) {
+							return function() {
+								return global.crypto.randomUUID();
+							}
+						} else if (fifty.global.jsh) {
+							return function() {
+								return String(Packages.java.util.UUID.randomUUID().toString());
+							}
+						}
+					}
+				)();
+
+				var first = uuid();
+
+				var namespaced = $api.global.at([first]);
+
+				verify(namespaced).is.type("object");
+				verify(global).evaluate.property(first).is(namespaced);
+
+				var second = uuid();
+
+				var namespacedTwo = $api.global.at([second, "foo"]);
+
+				verify(namespacedTwo).is.type("object");
+				verify(global).evaluate.property(second).evaluate.property("foo").is.type("object");
+				verify(global).evaluate.property(second).evaluate.property("bar").is.type("undefined");
+			}
+		}
+	//@ts-ignore
+	)(fifty);
 
 	export interface Global {
 		debug: {
@@ -1524,7 +1567,7 @@ namespace slime.$api {
 
 				var api = test.subject;
 
-				fifty.tests.runtime.exports.Resource = function() {
+				fifty.tests.exports.Resource = function() {
 					fifty.run(function type() {
 						var toString = function(p): string { return p.toString(); };
 
@@ -1873,10 +1916,6 @@ namespace slime.$api {
 
 				fifty.run(fifty.tests.jsapi);
 				fifty.run(fifty.tests.exports);
-
-				//	TODO	these should be merged into exports, probably, but were brought over from the runtime so retain some
-				//			of the names they had there
-				fifty.run(fifty.tests.runtime);
 			}
 
 			fifty.test.platforms();
@@ -1889,7 +1928,7 @@ namespace slime.$api.internal {
 	export type script = <C,E>(name: string) => slime.runtime.loader.Scoped<C,E>
 
 	export interface Scope {
-		$engine: Pick<slime.runtime.Engine,"execute"|"debugger">
+		$engine: Pick<slime.$api.Engine,"execute"|"debugger">
 		$slime: Pick<slime.runtime.scope.Deployment,"getRuntimeScript">
 		Packages: slime.jrunscript.Packages
 	}

--- a/loader/$api.fifty.ts
+++ b/loader/$api.fifty.ts
@@ -297,6 +297,8 @@ namespace slime.$api {
 
 				var uuid: () => string = (
 					function() {
+						var counter = 0;
+
 						if (global.crypto && global.crypto.randomUUID) {
 							return function() {
 								return global.crypto.randomUUID();
@@ -304,6 +306,11 @@ namespace slime.$api {
 						} else if (fifty.global.jsh) {
 							return function() {
 								return String(Packages.java.util.UUID.randomUUID().toString());
+							}
+						} else {
+							//	TODO	we really need something better than this for anything more than our first test.
+							return function() {
+								return "uuid:" + String(++counter);
 							}
 						}
 					}

--- a/loader/$api.fifty.ts
+++ b/loader/$api.fifty.ts
@@ -256,6 +256,32 @@ namespace slime.$api {
 	export interface Global {
 		global: {
 			get: <T>(propertyName: string) => T
+
+			/**
+			 * Returns a value rooted to the global object (`globalThis` in modern JavaScript). An optional function can be supplied
+			 * which will create the value if it does not exist; if the value is absent and no function is provided, an empty object
+			 * will be created and returned.
+			 *
+			 * The given path is interpreted as a series of property names. So if the path is `["inonit", "foo", "bar"]`, the object
+			 * will be rooted at `window` (or `globalThis`) and assigned to the `bar` property of the `foo` property of
+			 * `window.inonit`, and so would be available as `window.inonit.foo.bar`, or simply `inonit.foo.bar`, since properties
+			 * of the global object are visible by default.
+			 *
+			 * In the event portions of the sequence of rooting objects do not exist, they will be created. So, for example, in the
+			 * browser-based example above, if the `window.inonit` object exists, but the `window.inonit` object does not have a
+			 * property named `foo`, an object will be created and assigned to the `foo` property of `window.inonit`, and then that
+			 * object will be assigned a `bar` property.
+			 *
+			 * @param path The name/location of the namespace to create (or return if it exists).
+			 * @param create A function that will create the value to attach to the root object if it does not already exist. If
+			 * this parameter is not provided, an empty object will be created and used as the value.
+			 *
+			 * @returns The value given, for convenience.
+			 */
+			at: {
+				<T>(path: string[]): object
+				<T>(path: string[], create: () => T): T
+			}
 		}
 	}
 

--- a/loader/$api.js
+++ b/loader/$api.js
@@ -700,14 +700,14 @@
 			return $exports;
 		})({ Events: Events });
 
-		/** @type { slime.runtime.Platform } */
+		/** @type { slime.$api.Platform } */
 		var platform = (
 			/**
 			 *
-			 * @param { slime.runtime.Engine } $engine
+			 * @param { slime.$api.Engine } $engine
 			 */
 			function($engine) {
-				/** @type { slime.runtime.Platform } */
+				/** @type { slime.$api.Platform } */
 				var $exports = {};
 
 				var global = (function() { return this; })();
@@ -719,7 +719,7 @@
 
 				(
 					/**
-					 * @this { slime.runtime.Platform }
+					 * @this { slime.$api.Platform }
 					 */
 					function() {
 						var getJavaClass = function(name) {

--- a/loader/$api.js
+++ b/loader/$api.js
@@ -253,11 +253,40 @@
 
 		var fp = functions.fp;
 
+		/** @type { slime.$api.Global["global"] } */
 		var global = {
 			get: function(name) {
 				//	TODO	note  that modern JavaScript also has `globalThis`
 				var global = (function() { return this; })();
 				return global[name];
+			},
+			/**
+			 *
+			 * @param { string[] } path
+			 * @param { () => any } [create]
+			 * @returns
+			 */
+			at: function(path,create) {
+				//	This construct returns the top-level global object, e.g., window in the browser
+				var global = function() { return this; }();
+
+				var rv = global;
+
+				var factory = create || function() { return {}; };
+
+				for (var i=0; i<path.length; i++) {
+					if (i != path.length-1) {
+						if (typeof(rv[path[i]]) == "undefined") {
+							rv[path[i]] = {};
+						}
+					} else {
+						var existing = rv[path[i]];
+						rv[path[i]] = (typeof(existing) == "undefined" ) ? factory() : rv[path[i]];
+					}
+					rv = rv[path[i]];
+				}
+
+				return rv;
 			}
 		};
 

--- a/loader/browser/client.fifty.ts
+++ b/loader/browser/client.fifty.ts
@@ -297,6 +297,7 @@ namespace slime {
 			function(
 				fifty: slime.fifty.test.Kit
 			) {
+				const { verify } = fifty;
 				const inonit: Runtime = fifty.global.window["inonit"];
 				const window = fifty.global.window as Window & { testNamespaces: any }
 
@@ -305,6 +306,11 @@ namespace slime {
 				};
 
 				fifty.tests.exports.namespace = fifty.test.Parent();
+
+				fifty.tests.exports.namespace.empty = function() {
+					var top = inonit.loader.namespace("");
+					verify(top).is(window);
+				}
 
 				fifty.tests.exports.namespace.happy = function() {
 					test(typeof(window.testNamespaces) == "undefined");

--- a/loader/browser/client.fifty.ts
+++ b/loader/browser/client.fifty.ts
@@ -290,10 +290,7 @@ namespace slime {
 		)(fifty);
 
 		export interface Exports {
-			/**
-			 * See {@link slime.runtime.Exports.namespace}.
-			 */
-			namespace: slime.runtime.Exports["namespace"]
+			namespace: (path: string) => object
 		}
 
 		(
@@ -302,11 +299,12 @@ namespace slime {
 			) {
 				const inonit: Runtime = fifty.global.window["inonit"];
 				const window = fifty.global.window as Window & { testNamespaces: any }
-				fifty.tests.exports.namespace = {};
 
 				const test = function(value: boolean) {
 					fifty.verify(value).is(true);
 				};
+
+				fifty.tests.exports.namespace = fifty.test.Parent();
 
 				fifty.tests.exports.namespace.happy = function() {
 					test(typeof(window.testNamespaces) == "undefined");

--- a/loader/browser/client.js
+++ b/loader/browser/client.js
@@ -416,7 +416,8 @@
 						),
 						script: runtime.$api.deprecate(loaderMethods.file),
 						namespace: function(name) {
-							return runtime.$api.global.at(name.split("."));
+							var tokens = (name) ? name.split(".") : [];
+							return runtime.$api.global.at(tokens);
 						},
 						Base: {
 							script: getCurrentScriptBase,

--- a/loader/browser/client.js
+++ b/loader/browser/client.js
@@ -416,7 +416,7 @@
 						),
 						script: runtime.$api.deprecate(loaderMethods.file),
 						namespace: function(name) {
-							return runtime.namespace(name);
+							return runtime.$api.global.at(name.split("."));
 						},
 						Base: {
 							script: getCurrentScriptBase,

--- a/loader/code.fifty.ts
+++ b/loader/code.fifty.ts
@@ -76,7 +76,7 @@ namespace slime.$api {
 namespace slime.runtime.internal.code {
 	export interface Scope {
 		Packages: slime.runtime.Scope["Packages"]
-		$engine: slime.runtime.Engine
+		$engine: slime.$api.Engine
 		fp: slime.$api.fp.Exports
 	}
 

--- a/loader/document/old.js
+++ b/loader/document/old.js
@@ -8,7 +8,7 @@
 (
 	/**
 	 *
-	 * @param { slime.runtime.Platform } $platform
+	 * @param { slime.$api.Platform } $platform
 	 * @param { slime.$api.Global } $api
 	 * @param { slime.runtime.document.old.Context } $context
 	 * @param { slime.loader.Export<slime.runtime.document.old.Exports> } $export

--- a/loader/expression.fifty.ts
+++ b/loader/expression.fifty.ts
@@ -40,7 +40,7 @@ namespace slime {
 			/**
 			 * An object that overrides properties of {@link slime.runtime.Engine} with embedding-specific replacements.
 			 */
-			$engine?: Partial<slime.runtime.Engine>
+			$engine?: Partial<slime.$api.Engine>
 		}
 
 		export namespace scope {

--- a/loader/expression.fifty.ts
+++ b/loader/expression.fifty.ts
@@ -231,28 +231,6 @@ namespace slime {
 	export namespace runtime {
 		export interface Exports {
 			/**
-			 * Creates a *namespace*. A namespace is an object which is globally visible because it is rooted to the global object
-			 * (e.g., `window` in the browser). So, in the browser, the namespace `inonit.foo.bar` would be an object that is the
-			 * `bar` property of an object that is the `foo` property of an object that is the `inonit` property of `window`. It
-			 * could be referenced as `inonit.foo.bar` in JavaScript code, or alternatively as `window.inonit.foo.bar` in the
-			 * browser.
-			 *
-			 * In the event portions of the sequence of rooting objects do not exist, they will be created. So, for example, in the
-			 * browser-based example above, if the `window.inonit` object exists, but the `window.inonit` object does not have a
-			 * property named `foo`, an object will be created and assigned to the `foo` property of `window.inonit`, and then an
-			 * object will be created and assigned to that object's `bar` property.
-			 *
-			 * If the full sequence of rooting objects exists, the object at the given location will be returned.
-			 *
-			 * @param name The name/location of the namespace to create (or return if it exists).
-			 *
-			 * @returns The object at the specified location. The object (and its parents) will be created if it does not exist.
-			 */
-			namespace: (name: string) => object
-		}
-
-		export interface Exports {
-			/**
 			 * A global script compiler provided by the overall SLIME runtime, which operates on {@link slime.runtime.loader.Code}
 			 * instances and can be updated with additional transpilers that also operate on those instances.
 			 */

--- a/loader/expression.js
+++ b/loader/expression.js
@@ -19,7 +19,7 @@
 			/**
 			 *
 			 * @param { slime.runtime.Scope["$engine"] } $engine
-			 * @returns { slime.runtime.Engine }
+			 * @returns { slime.$api.Engine }
 			 */
 			function($engine) {
 				return {

--- a/loader/expression.js
+++ b/loader/expression.js
@@ -139,30 +139,6 @@
 				}
 			}),
 			$api.Object.defineProperty({
-				name: "namespace",
-				descriptor: {
-					value: function(string) {
-						//	This construct returns the top-level global object, e.g., window in the browser
-						var global = function() {
-							return this;
-						}();
-
-						var scope = global;
-						if (string) {
-							var tokens = string.split(".");
-							for (var i=0; i<tokens.length; i++) {
-								if (typeof(scope[tokens[i]]) == "undefined") {
-									scope[tokens[i]] = {};
-								}
-								scope = scope[tokens[i]];
-							}
-						}
-						return scope;
-					},
-					enumerable: true
-				}
-			}),
-			$api.Object.defineProperty({
 				name: "compiler",
 				descriptor: {
 					value: api.code.runtime.compiler,

--- a/loader/jrunscript/expression.fifty.ts
+++ b/loader/jrunscript/expression.fifty.ts
@@ -374,9 +374,9 @@ namespace slime.jrunscript.runtime {
 	}
 
 	export interface $javahost {
-		debugger: slime.runtime.Engine["debugger"]
+		debugger: slime.$api.Engine["debugger"]
 		script: any
-		MetaObject: slime.runtime.Engine["MetaObject"]
+		MetaObject: slime.$api.Engine["MetaObject"]
 		noEnvironmentAccess: any
 		eval(a: any, b: any, c: any, d: any): any
 	}

--- a/loader/jrunscript/expression.js
+++ b/loader/jrunscript/expression.js
@@ -1113,7 +1113,6 @@
 					{
 						compiler: slime.compiler,
 						loader: slime.$api.loader,
-						namespace: slime.namespace,
 						$api: $api,
 						$platform: $api.platform,
 

--- a/loader/jrunscript/expression.js
+++ b/loader/jrunscript/expression.js
@@ -52,7 +52,7 @@
 			 * @returns { slime.runtime.Exports }
 			 */
 			function() {
-				/** @type { slime.runtime.Engine } */
+				/** @type { slime.$api.Engine } */
 				var $engine = {
 					debugger: $javahost.debugger,
 					execute: function(script,scope,target) {

--- a/loader/jrunscript/rhino.js
+++ b/loader/jrunscript/rhino.js
@@ -21,7 +21,7 @@
 			 * @returns { slime.jrunscript.runtime.$javahost }
 			 */
 			function() {
-				/** @type { slime.runtime.Engine["MetaObject"] } */
+				/** @type { slime.$api.Engine["MetaObject"] } */
 				var MetaObject = function(p) {
 					var delegate = (p.delegate) ? p.delegate : {};
 					var get = (p.get) ? p.get : function(name){ return void(0); };

--- a/tools/fifty/test.fifty.ts
+++ b/tools/fifty/test.fifty.ts
@@ -59,10 +59,10 @@
  *
  * ### Running Fifty tests in both `jsh` and a browser
  *
- * To run a test suite that runs the same definition in both `jsh` and a browser, just invoke the `fifty.test.platforms()` method,
- * which will create a test named `platforms` that runs the `suite` test in both `jsh` and a browser.
+ * To create a test that runs the same definition in both `jsh` and a browser, just invoke the `fifty.test.platforms()` method,
+ * which will create a test for that definition named `platforms` that runs the `suite` test in both `jsh` and a browser.
  *
- * Then, the suite can be run via:
+ * Thus, the suite can be run on both platforms via:
  *
  * `./fifty test.jsh file.fifty.ts --part platforms`.
  *
@@ -106,7 +106,7 @@ namespace slime.fifty.test {
 		 * to a particular custom element name.
 		 */
 		global: {
-			$platform: slime.runtime.Platform
+			$platform: slime.$api.Platform
 			$api: slime.$api.Global
 
 			jsh?: slime.jsh.Global


### PR DESCRIPTION
* Replace with $api.global.at, which optionally can create a namespace in the same way.
* Add namespace to the browser runtime for compatibility and implement it in terms of $api.global.at