### PR TITLE
Clarify AGENTS branch naming convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ When refactoring, always run `./wf tsc` after the refactor to make sure type-che
 
 ## Branch naming
 
-When naming branches, if working on an issue, respect the convention specified in the [`VSCode githubIssues.issueBranchTitle setting`](.vscode/settings.json). Otherwise, name the branch with the same format ${GitHub username}/{description}.
+When naming branches, if working on an issue, respect the convention specified in the [`VSCode githubIssues.issueBranchTitle setting`](.vscode/settings.json). Otherwise, name the branch with the format `<github-username>/<description>`.
 
 # Code Quality
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,10 @@ coverage should receive the `project` label.
 
 When refactoring, always run `./wf tsc` after the refactor to make sure type-checking passed. If it does not, something is wrong.
 
+## Branch naming
+
+When naming branches, if working on an issue, respect the convention specified in the [`VSCode githubIssues.issueBranchTitle setting`](.vscode/settings.json). Otherwise, name the branch with the same format ${GitHub username}/{description}.
+
 # Code Quality
 
 If you are asked for suggestions on how to improve the project, please use the information in this section.


### PR DESCRIPTION
## Summary
- add a dedicated "Branch naming" section to AGENTS
- clarify that issue branches should follow `githubIssues.issueBranchTitle`
- clarify that non-issue branches should use `${GitHub username}/{description}`

## Notes
- branch renamed to use GitHub username prefix (`davidpcaldwell/...`)