### PR TITLE
Fix open-for-write recursive directory creation and add null guards

### DIFF
--- a/loader/$api-fp-impure.js
+++ b/loader/$api-fp-impure.js
@@ -401,7 +401,7 @@
 						},
 						effector: function(handlers) {
 							return function(means) {
-								if (!means) throw new Error("Required: means to map.");
+								if (typeof(means) != "function") throw new TypeError("Required: means function to map.");
 								return function(output) {
 									$context.events.handle({
 										implementation: means(output),

--- a/loader/$api-fp-impure.js
+++ b/loader/$api-fp-impure.js
@@ -401,6 +401,7 @@
 						},
 						effector: function(handlers) {
 							return function(means) {
+								if (!means) throw new Error("Required: means to map.");
 								return function(output) {
 									$context.events.handle({
 										implementation: means(output),

--- a/rhino/file/wo.js
+++ b/rhino/file/wo.js
@@ -320,9 +320,10 @@
 
 		/** @type { (location: slime.jrunscript.file.Location) => ReturnType<slime.jrunscript.file.location.file.Exports["write"]["open"]>["wo"] } */
 		var Location_write_open_wo = function(location) {
+			if (!location) throw new Error("Required: location to open for writing.");
 			return function(settings) {
 				return function(events) {
-					var recurse = (settings && settings.recursive) ? $api.fp.now(parts.directoryensureParent, $api.fp.world.Means.effector({
+					var recurse = (settings && settings.recursive) ? $api.fp.now(parts.directory.ensureParent, $api.fp.world.Means.effector({
 						created: function(e) {
 							events.fire("createdFolder", e.detail);
 						}

--- a/rhino/file/wo.js
+++ b/rhino/file/wo.js
@@ -320,7 +320,7 @@
 
 		/** @type { (location: slime.jrunscript.file.Location) => ReturnType<slime.jrunscript.file.location.file.Exports["write"]["open"]>["wo"] } */
 		var Location_write_open_wo = function(location) {
-			if (!location) throw new Error("Required: location to open for writing.");
+			if (location == null) throw new TypeError("Required: location to open for writing.");
 			return function(settings) {
 				return function(events) {
 					var recurse = (settings && settings.recursive) ? $api.fp.now(parts.directory.ensureParent, $api.fp.world.Means.effector({


### PR DESCRIPTION
Two related fixes in the fix-open-for-write-recursive branch:
- rhino/file/wo.js: corrects parts.directoryensureParent -> parts.directory.ensureParent (missing dot), and adds a null guard on location
- loader/$api-fp-impure.js: adds a null guard on means in the effector function