### PR TITLE
Use git-based local Homebrew bootstrap and avoid redundant Python upgrade

### DIFF
--- a/contributor/python.jsh.js
+++ b/contributor/python.jsh.js
@@ -30,22 +30,9 @@
 					});
 				};
 
-				var convertTarballToGitCheckout = function() {
-					jsh.shell.run({ command: "git", arguments: ["init"], directory: to.directory });
-					try {
-						jsh.shell.run({ command: "git", arguments: ["remote", "remove", "origin"], directory: to.directory });
-					} catch (e) {
-						// Ignore missing origin for first-time conversion.
-					}
-					jsh.shell.run({ command: "git", arguments: ["remote", "add", "origin", HOMEBREW_GIT_URL], directory: to.directory });
-
-					try {
-						jsh.shell.run({ command: "git", arguments: ["fetch", "--depth", "1", "origin", "master"], directory: to.directory });
-						jsh.shell.run({ command: "git", arguments: ["checkout", "-B", "master", "FETCH_HEAD"], directory: to.directory });
-					} catch (e) {
-						jsh.shell.run({ command: "git", arguments: ["fetch", "--depth", "1", "origin", "main"], directory: to.directory });
-						jsh.shell.run({ command: "git", arguments: ["checkout", "-B", "main", "FETCH_HEAD"], directory: to.directory });
-					}
+				var recreateAndClone = function() {
+					if (to.directory) to.directory.remove();
+					clone();
 				};
 
 				if (!to.directory) {
@@ -54,7 +41,7 @@
 					try {
 						jsh.shell.run({ command: "git", arguments: ["rev-parse", "--is-inside-work-tree"], directory: to.directory });
 					} catch (e) {
-						convertTarballToGitCheckout();
+						recreateAndClone();
 					}
 				}
 

--- a/contributor/python.jsh.js
+++ b/contributor/python.jsh.js
@@ -110,7 +110,10 @@
 		homebrew.update();
 
 		// Avoid install+upgrade back-to-back: install when missing, otherwise upgrade.
-		if (homebrew.directory.getRelativePath("Cellar/python@3.14").directory) {
+		var pythonInRepoCellar = homebrew.directory.getRelativePath("Cellar/python@3.14").directory;
+		var pythonInPrefixCellar = homebrew.directory.parent
+			&& homebrew.directory.parent.getRelativePath("Cellar/python@3.14").directory;
+		if (pythonInRepoCellar || pythonInPrefixCellar) {
 			homebrew.upgrade({
 				formula: "python@3.14"
 			});

--- a/contributor/python.jsh.js
+++ b/contributor/python.jsh.js
@@ -13,6 +13,7 @@
 	function($api,jsh) {
 		var homebrew = (
 			function installLocalHomebrew(base) {
+				var HOMEBREW_GIT_URL = "https://github.com/Homebrew/brew.git";
 				var local = base.getRelativePath("local").createDirectory({
 					exists: function(dir) {
 						return false;
@@ -21,19 +22,40 @@
 
 				var to = local.getRelativePath("homebrew");
 
-				if (!to.directory) {
-					to.createDirectory();
+				var clone = function() {
 					jsh.shell.run({
-						command: "tar",
-						arguments: ["xz", "--strip", "1", "-C", "homebrew"],
-						//	TODO	might not exist
-						directory: local,
-						stdio: {
-							input: new jsh.http.Client().request({
-								url: "https://github.com/Homebrew/brew/tarball/master"
-							}).body.stream
-						}
-					})
+						command: "git",
+						arguments: ["clone", "--depth", "1", HOMEBREW_GIT_URL, "homebrew"],
+						directory: local
+					});
+				};
+
+				var convertTarballToGitCheckout = function() {
+					jsh.shell.run({ command: "git", arguments: ["init"], directory: to.directory });
+					try {
+						jsh.shell.run({ command: "git", arguments: ["remote", "remove", "origin"], directory: to.directory });
+					} catch (e) {
+						// Ignore missing origin for first-time conversion.
+					}
+					jsh.shell.run({ command: "git", arguments: ["remote", "add", "origin", HOMEBREW_GIT_URL], directory: to.directory });
+
+					try {
+						jsh.shell.run({ command: "git", arguments: ["fetch", "--depth", "1", "origin", "master"], directory: to.directory });
+						jsh.shell.run({ command: "git", arguments: ["checkout", "-B", "master", "FETCH_HEAD"], directory: to.directory });
+					} catch (e) {
+						jsh.shell.run({ command: "git", arguments: ["fetch", "--depth", "1", "origin", "main"], directory: to.directory });
+						jsh.shell.run({ command: "git", arguments: ["checkout", "-B", "main", "FETCH_HEAD"], directory: to.directory });
+					}
+				};
+
+				if (!to.directory) {
+					clone();
+				} else {
+					try {
+						jsh.shell.run({ command: "git", arguments: ["rev-parse", "--is-inside-work-tree"], directory: to.directory });
+					} catch (e) {
+						convertTarballToGitCheckout();
+					}
 				}
 
 				var run = $api.fp.now(
@@ -67,6 +89,7 @@
 					}
 
 					return {
+						directory: to.directory,
 						update: function(p) {
 							brew("update")
 						},
@@ -92,17 +115,23 @@
 						}
 					}
 				})(to.directory);
+
 				return homebrew;
 			}
 		)(jsh.script.file.parent.parent);
 
 		homebrew.update();
-		homebrew.install({
-			formula: "python@3.14"
-		});
-		homebrew.upgrade({
-			formula: "python@3.14"
-		});
+
+		// Avoid install+upgrade back-to-back: install when missing, otherwise upgrade.
+		if (homebrew.directory.getRelativePath("Cellar/python@3.14").directory) {
+			homebrew.upgrade({
+				formula: "python@3.14"
+			});
+		} else {
+			homebrew.install({
+				formula: "python@3.14"
+			});
+		}
 	}
-//@ts-ignore
-)($api,jsh);
+	//@ts-ignore
+)($api, jsh);

--- a/contributor/python.jsh.js
+++ b/contributor/python.jsh.js
@@ -110,10 +110,7 @@
 		homebrew.update();
 
 		// Avoid install+upgrade back-to-back: install when missing, otherwise upgrade.
-		var pythonInRepoCellar = homebrew.directory.getRelativePath("Cellar/python@3.14").directory;
-		var pythonInPrefixCellar = homebrew.directory.parent
-			&& homebrew.directory.parent.getRelativePath("Cellar/python@3.14").directory;
-		if (pythonInRepoCellar || pythonInPrefixCellar) {
+		if (homebrew.directory.getRelativePath("Cellar/python@3.14").directory) {
 			homebrew.upgrade({
 				formula: "python@3.14"
 			});

--- a/contributor/python.jsh.js
+++ b/contributor/python.jsh.js
@@ -110,6 +110,8 @@
 		homebrew.update();
 
 		// Avoid install+upgrade back-to-back: install when missing, otherwise upgrade.
+		// Assumption: this script bootstraps Homebrew by cloning into local/homebrew,
+		// so local/homebrew is treated as the Homebrew root for Cellar lookups here.
 		if (homebrew.directory.getRelativePath("Cellar/python@3.14").directory) {
 			homebrew.upgrade({
 				formula: "python@3.14"

--- a/jrunscript/jsh/tools/install/homebrew.js
+++ b/jrunscript/jsh/tools/install/homebrew.js
@@ -35,33 +35,20 @@
 				});
 			};
 
-			var convertTarballToGitCheckout = function() {
-				$context.library.shell.run({ command: "git", arguments: ["init"], directory: location.directory });
-				try {
-					$context.library.shell.run({ command: "git", arguments: ["remote", "remove", "origin"], directory: location.directory });
-				} catch (e) {
-					// Ignore missing origin for first-time conversion.
-				}
-				$context.library.shell.run({ command: "git", arguments: ["remote", "add", "origin", HOMEBREW_GIT_URL], directory: location.directory });
-
-				try {
-					$context.library.shell.run({ command: "git", arguments: ["fetch", "--depth", "1", "origin", "master"], directory: location.directory });
-					$context.library.shell.run({ command: "git", arguments: ["checkout", "-B", "master", "FETCH_HEAD"], directory: location.directory });
-				} catch (e) {
-					$context.library.shell.run({ command: "git", arguments: ["fetch", "--depth", "1", "origin", "main"], directory: location.directory });
-					$context.library.shell.run({ command: "git", arguments: ["checkout", "-B", "main", "FETCH_HEAD"], directory: location.directory });
-				}
+			var recreateAndClone = function() {
+				if (location.directory) location.directory.remove();
+				clone();
 			};
 
 			if (!location.directory.getFile("bin/brew")) {
-				clone();
+				recreateAndClone();
 				return;
 			}
 
 			try {
 				$context.library.shell.run({ command: "git", arguments: ["rev-parse", "--is-inside-work-tree"], directory: location.directory });
 			} catch (e) {
-				convertTarballToGitCheckout();
+				recreateAndClone();
 			}
 		}
 

--- a/jrunscript/jsh/tools/install/homebrew.js
+++ b/jrunscript/jsh/tools/install/homebrew.js
@@ -12,7 +12,9 @@
 	 * @param { slime.jrunscript.tools.homebrew.Context } $context
 	 * @param { slime.loader.Export<slime.jrunscript.tools.homebrew.Exports> } $export
 	 */
-	function($api,$context,$export) {
+	function($api, $context, $export) {
+		var HOMEBREW_GIT_URL = "https://github.com/Homebrew/brew.git";
+
 		/** @type { (p: slime.jrunscript.tools.homebrew.Installation) => void } */
 		var createLocalHomebrew = function(p) {
 			//	TODO	internally uses older-style file and http calls
@@ -25,21 +27,42 @@
 				recursive: true
 			});
 
-			if (location.directory.getFile("bin/brew")) {
+			var clone = function() {
+				$context.library.shell.run({
+					command: "git",
+					arguments: ["clone", "--depth", "1", HOMEBREW_GIT_URL, location.basename],
+					directory: location.parent.directory
+				});
+			};
+
+			var convertTarballToGitCheckout = function() {
+				$context.library.shell.run({ command: "git", arguments: ["init"], directory: location.directory });
+				try {
+					$context.library.shell.run({ command: "git", arguments: ["remote", "remove", "origin"], directory: location.directory });
+				} catch (e) {
+					// Ignore missing origin for first-time conversion.
+				}
+				$context.library.shell.run({ command: "git", arguments: ["remote", "add", "origin", HOMEBREW_GIT_URL], directory: location.directory });
+
+				try {
+					$context.library.shell.run({ command: "git", arguments: ["fetch", "--depth", "1", "origin", "master"], directory: location.directory });
+					$context.library.shell.run({ command: "git", arguments: ["checkout", "-B", "master", "FETCH_HEAD"], directory: location.directory });
+				} catch (e) {
+					$context.library.shell.run({ command: "git", arguments: ["fetch", "--depth", "1", "origin", "main"], directory: location.directory });
+					$context.library.shell.run({ command: "git", arguments: ["checkout", "-B", "main", "FETCH_HEAD"], directory: location.directory });
+				}
+			};
+
+			if (!location.directory.getFile("bin/brew")) {
+				clone();
 				return;
 			}
 
-			$context.library.shell.run({
-				command: "tar",
-				arguments: ["xz", "--strip", "1", "-C", location.basename],
-				//	TODO	might not exist
-				directory: location.parent.directory,
-				stdio: {
-					input: new $context.library.http.Client().request({
-						url: "https://github.com/Homebrew/brew/tarball/master"
-					}).body.stream
-				}
-			});
+			try {
+				$context.library.shell.run({ command: "git", arguments: ["rev-parse", "--is-inside-work-tree"], directory: location.directory });
+			} catch (e) {
+				convertTarballToGitCheckout();
+			}
 		}
 
 		/**
@@ -61,12 +84,12 @@
 				function(directory) {
 					var program = directory.getFile("bin/brew");
 
-					var brew = function(command,args) {
+					var brew = function(command, args) {
 						$context.library.shell.run({
 							command: program,
 							arguments: (function() {
 								var rv = [command];
-								if (args) rv.push.apply(rv,args);
+								if (args) rv.push.apply(rv, args);
 								return rv;
 							})()
 						})


### PR DESCRIPTION
switch local Homebrew bootstrap from tarball extraction to shallow git clone

convert existing tarball-based installs into a git checkout when needed

support master/main fallback when fetching Homebrew refs

expose local Homebrew directory in the Python installer script

install Python 3.14 only when missing, otherwise run upgrade