### PR TITLE
Remove stale TODO comment in InputStream interface

### DIFF
--- a/loader/jrunscript/io.fifty.ts
+++ b/loader/jrunscript/io.fifty.ts
@@ -167,8 +167,6 @@ namespace slime.jrunscript.runtime.io {
 	 * A stream from which bytes may be read.
 	 */
 	export interface InputStream {
-		//	TODO	rename to read, we have overloaded content to represent a tree
-
 		read: {
 			string: {
 				simple: (charset: Charset) => string


### PR DESCRIPTION
## Summary
- remove an outdated TODO comment in `loader/jrunscript/io.fifty.ts`
- keep `InputStream` interface documentation concise and current

## Validation
- pre-commit checks passed (ESLint, TypeScript compile, header/license checks)
