### PR TITLE
fix(io): default read.string.simple charset and add regression test

### DIFF
--- a/loader/jrunscript/io.fifty.ts
+++ b/loader/jrunscript/io.fifty.ts
@@ -172,7 +172,7 @@ namespace slime.jrunscript.runtime.io {
 				/**
 				 * Reads the entire content of this stream as a single string.
 				 *
-				 * @param charset A charset to use to encode bytes as characters; if omitted, the platform default `Charset` will be
+				 * @param charset A charset to use to decode bytes as characters; if omitted, the platform default `Charset` will be
 				 * used.
 				 * @returns A string.
 				 */

--- a/loader/jrunscript/io.fifty.ts
+++ b/loader/jrunscript/io.fifty.ts
@@ -169,7 +169,14 @@ namespace slime.jrunscript.runtime.io {
 	export interface InputStream {
 		read: {
 			string: {
-				simple: (charset: Charset) => string
+				/**
+				 * Reads the entire content of this stream as a single string.
+				 *
+				 * @param charset A charset to use to encode bytes as characters; if omitted, the platform default `Charset` will be
+				 * used.
+				 * @returns A string.
+				 */
+				simple: (charset?: Charset) => string
 			}
 
 			ArrayBuffer: {
@@ -180,6 +187,8 @@ namespace slime.jrunscript.runtime.io {
 
 	(
 		function(
+			//	TODO	should Packages be available through the Fifty (`fifty.jsh`) object?
+			Packages: slime.jrunscript.Packages,
 			fifty: slime.fifty.test.Kit
 		) {
 			const { verify } = fifty;
@@ -188,11 +197,25 @@ namespace slime.jrunscript.runtime.io {
 
 			fifty.tests.exports.InputStream.object = fifty.test.Parent();
 
-			fifty.tests.exports.InputStream.object.content = fifty.test.Parent();
+			fifty.tests.exports.InputStream.object.read = fifty.test.Parent();
 
-			fifty.tests.exports.InputStream.object.content.ArrayBuffer = fifty.test.Parent();
+			fifty.tests.exports.InputStream.object.read.string = fifty.test.Parent();
 
-			fifty.tests.exports.InputStream.object.content.ArrayBuffer.simple = function() {
+			fifty.tests.exports.InputStream.object.read.string.simple = function() {
+				var buffer = new Packages.java.io.ByteArrayOutputStream();
+				var out = new Packages.java.io.OutputStreamWriter(buffer);
+				out.write("hello");
+				out.close();
+				var input = test.subject.InputStream.java(
+					test.javaInputStreamOf( Array.prototype.slice.call(buffer.toByteArray()) )
+				);
+				var string = input.read.string.simple();
+				verify(string).is("hello");
+			}
+
+			fifty.tests.exports.InputStream.object.read.ArrayBuffer = fifty.test.Parent();
+
+			fifty.tests.exports.InputStream.object.read.ArrayBuffer.simple = function() {
 				var len = 19;
 				var array = [];
 				for (var i=0; i<len; i++) {
@@ -221,7 +244,7 @@ namespace slime.jrunscript.runtime.io {
 			}
 		}
 	//@ts-ignore
-	)(fifty);
+	)(Packages,fifty);
 
 	export interface PipeEvents {
 		readProgress: number

--- a/loader/jrunscript/io.js
+++ b/loader/jrunscript/io.js
@@ -134,6 +134,7 @@
 				read: {
 					string: {
 						simple: function(charset) {
+							if (!charset) charset = Charset.default;
 							var _reader = new Packages.java.io.InputStreamReader(peer, charset.java.adapt());
 							return String(_java.readString(_reader));
 						}


### PR DESCRIPTION
## Summary
- make `InputStream.read.string.simple` accept an optional charset
- default to the platform charset when no charset argument is provided
- document the no-argument behavior in the type definition
- add regression coverage for no-argument string reads
- align related test namespace from `content` to `read`

## Validation
- pre-commit checks passed (ESLint, TypeScript, license/header checks)
- targeted test part used during development:
  - `fifty test.jsh ui/gae/slim/slime/loader/jrunscript/io.fifty.ts --part exports.InputStream.object.read.string.simple`