### PR TITLE
docs(agents): note benign typedoc dependency hook message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,14 @@ This is safe in a devcontainer when those files are stale lock artifacts from a 
 
 # GitHub integration
 
+## Benign hook message on checkout
+
+When checking out branches, a hook may print:
+
+`Wrote new dependencies TypeDoc includes to .../ui/gae/slim/slime/local/typedoc/dependencies.md`
+
+Treat this as a benign informational message. The target path is under `local/` (gitignored), so it does not imply tracked source changes.
+
 When asked to create a GitHub issue, use the format native to the GitHub Pull Requests extension rather than the format native to
 the GitHub web interface.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,9 +99,9 @@ This is safe in a devcontainer when those files are stale lock artifacts from a 
 
 When checking out branches, a hook may print:
 
-`Wrote new dependencies TypeDoc includes to .../ui/gae/slim/slime/local/typedoc/dependencies.md`
+`Wrote new dependencies TypeDoc includes to <repo>/local/typedoc/dependencies.md`
 
-Treat this as a benign informational message. The target path is under `local/` (gitignored), so it does not imply tracked source changes.
+Treat this as a benign informational message. The target path is under `local/` (ignored by Git), so it does not imply tracked source changes.
 
 When asked to create a GitHub issue, use the format native to the GitHub Pull Requests extension rather than the format native to
 the GitHub web interface.


### PR DESCRIPTION
## Summary
- add an AGENTS note that checkout may print a TypeDoc dependency write message
- clarify that the target path is under `local/` and gitignored
- document that this message is expected and not a tracked source change

## Validation
- pre-commit checks passed (ESLint, TypeScript, license/header checks)