### PR TITLE
Update loader API Function and fp impure definitions

### DIFF
--- a/loader/$api-Function.fifty.ts
+++ b/loader/$api-Function.fifty.ts
@@ -1517,6 +1517,8 @@ namespace slime.$api.fp {
 			prettify: (p: {
 				space: Parameters<slime.external.lib.es5.JSON["stringify"]>[2]
 			}) => (json: string) => string
+
+			parse: <T>(f: (data: slime.$api.fp.Data) => T) => (json: string) => T
 		}
 	}
 

--- a/loader/$api-Function.js
+++ b/loader/$api-Function.js
@@ -715,6 +715,11 @@
 					return function(v) {
 						return JSON.stringify(JSON.parse(v), void(0), space);
 					}
+				},
+				parse: function(cast) {
+					return function(string) {
+						return cast(JSON.parse(string));
+					}
 				}
 			},
 			RegExp: {

--- a/loader/$api-fp-impure.fifty.ts
+++ b/loader/$api-fp-impure.fifty.ts
@@ -33,8 +33,37 @@ namespace slime.$api.fp {
 namespace slime.$api.fp.impure {
 	/**
 	 * A function capable of observing some kind of external state and obtaining and returning it to the caller.
+	 *
+	 * @deprecated Replaced by {@link Reading}.
 	 */
 	export type External<T> = () => T
+
+	/**
+	 * Represents a value external to the running program's environment that can be retrieved by an invocation. This value may be
+	 * mutated over time by external processes; examples might include the current time, the CPU load on the system, or some
+	 * remotely readable value from a shared filesystem or database.
+	 */
+	export interface Reading<T> {
+		read: () => T
+	}
+
+	/**
+	 * Represents a mutable, non-thread-safe value internal to the running program. After calling `set`, `get` should return the
+	 * value just set under all circumstances.
+	 */
+	export interface Variable<T> {
+		get: () => T
+		set: (t: T) => void
+	}
+
+	/**
+	 * Represents a mutable value external to the running program.
+	 */
+	export interface Persistent<T> {
+		read: () => T
+		write: (t: T) => void
+	}
+
 
 	/** @deprecated Replaced by `External` and `Thunk` (for non-external operations). */
 	export type Input<T> = () => T

--- a/loader/$api-fp-impure.fifty.ts
+++ b/loader/$api-fp-impure.fifty.ts
@@ -65,7 +65,7 @@ namespace slime.$api.fp.impure {
 	}
 
 
-	/** @deprecated Replaced by `External` and `Thunk` (for non-external operations). */
+	/** @deprecated Replaced by `Reading` (for external operations) and `Thunk` (for non-external operations). */
 	export type Input<T> = () => T
 
 	/**


### PR DESCRIPTION
## Summary
- extend loader Function API typings/behavior support
- update generated loader Function runtime file accordingly
- add/expand fp impure loader type definitions

## Validation
- repository commit hooks passed (eslint, license header checks, and TypeScript compile)

## Changes
- 3 files changed
- 36 insertions