### PR TITLE
Add JDK-based jrunscript path API and use it in contributor tests

### DIFF
--- a/contributor/jrunscript.jsh.js
+++ b/contributor/jrunscript.jsh.js
@@ -74,7 +74,39 @@
 
 					var suite = new jsh.unit.html.Suite();
 
-					//	TODO	Potentially valuable building block, but not here and not now, where we are testing a single engine
+					//	TODO	Potentially valuable building blocks, but not here and not now, where we are testing a single engine
+					// var launch = (
+					// 	function() {
+					// 		var launch = (jsh.shell.jsh.home) ? [jsh.shell.jsh.home.getRelativePath("jsh.js").toString()] : [jsh.shell.jsh.src.getRelativePath("rhino/jrunscript/api.js").toString(), "jsh"];
+					// 		(
+					// 			function addNashornBootstrapLibraries() {
+					// 				var names = jsh.internal.bootstrap.nashorn.dependencies.names.concat(["nashorn"]);
+					// 				//	TODO	Should only be used for versions of Java that need it
+					// 				if (jsh.shell.jsh.home && jsh.shell.jsh.home.getFile("lib/nashorn.jar")) {
+					// 					launch = [
+					// 						"-classpath",
+					// 						names.map(function(name) {
+					// 							return jsh.shell.jsh.home.getRelativePath("lib/" + name + ".jar").toString();
+					// 						//	TODO	below is platform-specific
+					// 						}).join(":")
+					// 					].concat(launch)
+					// 				} else if (jsh.shell.jsh.src && jsh.shell.jsh.src.getFile("local/jsh/lib/nashorn.jar")) {
+					// 					//	TODO	Should only be used for versions of Java that need it
+					// 					launch = [
+					// 						"-classpath",
+					// 						names.map(function(name) {
+					// 							return jsh.shell.jsh.src.getRelativePath("local/jsh/lib/" + name + ".jar").toString();
+					// 						//	TODO	below is platform-specific
+					// 						}).join(":")
+					// 					].concat(launch)
+					// 				}
+					// 			}
+					// 		)();
+					//
+					// 		return launch;
+					// 	}
+					// )();
+					//
 					// var engines = jsh.shell.run({
 					// 	command: launcher,
 					// 	arguments: launch.concat(["-engines"]),
@@ -87,46 +119,30 @@
 					// 	}
 					// });
 
-					var jre = jsh.shell.java.home.pathname;
-
-					var searchpath = jsh.file.Searchpath([jre.directory.getRelativePath("bin"),jre.directory.getRelativePath("../bin")]);
-
-					var launcher = searchpath.getCommand("jrunscript");
-					var launch = (jsh.shell.jsh.home) ? [jsh.shell.jsh.home.getRelativePath("jsh.js").toString()] : [jsh.shell.jsh.src.getRelativePath("rhino/jrunscript/api.js").toString(), "jsh"];
-					(
-						function addNashornBootstrapLibraries() {
-							var names = jsh.internal.bootstrap.nashorn.dependencies.names.concat(["nashorn"]);
-							//	TODO	Should only be used for versions of Java that need it
-							if (jsh.shell.jsh.home && jsh.shell.jsh.home.getFile("lib/nashorn.jar")) {
-								launch = [
-									"-classpath",
-									names.map(function(name) {
-										return jsh.shell.jsh.home.getRelativePath("lib/" + name + ".jar").toString();
-									//	TODO	below is platform-specific
-									}).join(":")
-								].concat(launch)
-							} else if (jsh.shell.jsh.src && jsh.shell.jsh.src.getFile("local/jsh/lib/nashorn.jar")) {
-								//	TODO	Should only be used for versions of Java that need it
-								launch = [
-									"-classpath",
-									names.map(function(name) {
-										return jsh.shell.jsh.src.getRelativePath("local/jsh/lib/" + name + ".jar").toString();
-									//	TODO	below is platform-specific
-									}).join(":")
-								].concat(launch)
-							}
+					var jrunscript = (
+						function() {
+							var jdk = jsh.shell.java.Jdk.from.javaHome();
+							var pathname = jsh.shell.java.Jdk.jrunscript(jdk);
+							if (!pathname.present) throw new Error();
+							return pathname.value;
 						}
 					)();
 
-					//	TODO	this is kind of clunky and seems to indicate a less clunky API should be available to get this
-					//			string
-					var ENGINE = jsh.internal.bootstrap.engine.resolve({
-						rhino: function() { return "rhino"; },
-						nashorn: function() { return "nashorn"; },
-						graal: function() { return "graal"; }
-					});
-					var engine = ENGINE();
-					jsh.shell.console("Running " + jsh.shell.jsh.home + " with Java " + launcher + " and engine " + engine + " ...");
+					var engine = (
+						function() {
+							//	TODO	this is kind of clunky and seems to indicate a less clunky API should be available to get this
+							//			string
+							var ENGINE = jsh.internal.bootstrap.engine.resolve({
+								rhino: function() { return "rhino"; },
+								nashorn: function() { return "nashorn"; },
+								graal: function() { return "graal"; }
+							});
+							var engine = ENGINE();
+							return engine;
+						}
+					)();
+
+					jsh.shell.console("Running " + jsh.shell.jsh.src + " with jrunscript " + jrunscript + " and engine " + engine + " ...");
 
 					suite.add("jrunscript/fifty", jsh.unit.fifty.Part({
 						shell: environment.jsh.unbuilt.src,
@@ -135,7 +151,7 @@
 					}));
 
 					suite.add("jrunscript/jsapi", jsh.unit.Suite.Fork({
-						name: "JSAPI Java tests for JRE " + jre.toString() + " and engine " + engine,
+						name: "JSAPI Java tests for JRE " + jsh.shell.java.home.pathname.toString() + " and engine " + engine,
 						run: jsh.shell.jsh,
 						vmarguments: ["-Xms1024m"],
 						shell: environment.jsh.src,

--- a/contributor/jrunscript.jsh.js
+++ b/contributor/jrunscript.jsh.js
@@ -123,7 +123,7 @@
 						function() {
 							var jdk = jsh.shell.java.Jdk.from.javaHome();
 							var pathname = jsh.shell.java.Jdk.jrunscript(jdk);
-							if (!pathname.present) throw new Error();
+							if (!pathname.present) throw new Error("Could not resolve jrunscript for JDK home: " + jdk.base);
 							return pathname.value;
 						}
 					)();

--- a/rhino/shell/java.fifty.ts
+++ b/rhino/shell/java.fifty.ts
@@ -6,6 +6,8 @@
 
 namespace slime.jrunscript.shell.java {
 	export interface Context {
+		getJrunscriptPathFromJdk: (home: string) => slime.$api.fp.Maybe<string>
+
 		home: slime.$api.fp.impure.Input<slime.jrunscript.file.Directory>
 	}
 
@@ -13,6 +15,7 @@ namespace slime.jrunscript.shell.java {
 		export const subject = (function(fifty: slime.fifty.test.Kit) {
 			var script: Script = fifty.$loader.script("java.js");
 			return script({
+				getJrunscriptPathFromJdk: fifty.global.$api.TODO(),
 				home: function() { return fifty.global.jsh.shell.java.home; }
 			})
 		//@ts-ignore
@@ -35,8 +38,13 @@ namespace slime.jrunscript.shell.java {
 	export interface Exports extends Invoke {
 		Jdk: {
 			from: {
+				/**
+				 * Returns a Jdk object based on the value of the `java.home` property.
+				 */
 				javaHome: () => Jdk
 			}
+
+			jrunscript: (jdk: Jdk) => slime.$api.fp.Maybe<string>
 		}
 	}
 

--- a/rhino/shell/java.js
+++ b/rhino/shell/java.js
@@ -26,6 +26,9 @@
 							base: javaHome.toString()
 						};
 					}
+				},
+				jrunscript: function(jdk) {
+					return $context.getJrunscriptPathFromJdk(jdk.base);
 				}
 			}
 		})

--- a/rhino/shell/module.js
+++ b/rhino/shell/module.js
@@ -289,14 +289,14 @@
 
 		var getJrunscriptFileFromJdk = function(/** @type { slime.jrunscript.file.Directory } */ home) {
 			return $context.api.file.Searchpath([home.getRelativePath("bin"),home.getRelativePath("../bin")]).getCommand("jrunscript");
-		}
+		};
 
 		/** @type { (home: string) => slime.$api.fp.Maybe<string> } */
 		var getJrunscriptPathFromJdk = function(home) {
 			var homedir = $context.api.file.Pathname(home).directory;
 			var rv = getJrunscriptFileFromJdk(homedir);
 			return (rv) ? $api.fp.Maybe.from.value(rv.pathname.toString()) : $api.fp.Maybe.from.nothing();
-		}
+		};
 
 		$exports.java = Object.assign(
 			function(p) {

--- a/rhino/shell/module.js
+++ b/rhino/shell/module.js
@@ -287,6 +287,17 @@
 			}
 		};
 
+		var getJrunscriptFileFromJdk = function(/** @type { slime.jrunscript.file.Directory } */ home) {
+			return $context.api.file.Searchpath([home.getRelativePath("bin"),home.getRelativePath("../bin")]).getCommand("jrunscript");
+		}
+
+		/** @type { (home: string) => slime.$api.fp.Maybe<string> } */
+		var getJrunscriptPathFromJdk = function(home) {
+			var homedir = $context.api.file.Pathname(home).directory;
+			var rv = getJrunscriptFileFromJdk(homedir);
+			return (rv) ? $api.fp.Maybe.from.value(rv.pathname.toString()) : $api.fp.Maybe.from.nothing();
+		}
+
 		$exports.java = Object.assign(
 			function(p) {
 				//	TODO	check for both p.classpath and p.jar being defined and decide what to do
@@ -326,6 +337,7 @@
 				jrunscript: void(0),
 				home: void(0),
 				Jdk: code.java({
+					getJrunscriptPathFromJdk: getJrunscriptPathFromJdk,
 					home: function() { return properties.directory("java.home"); }
 				}).Jdk
 			}


### PR DESCRIPTION
## Summary
- Add a new Java shell API: `Jdk.jrunscript(jdk)` to resolve the `jrunscript` executable path from a JDK.
- Wire this API through the Rhino shell module context (`getJrunscriptPathFromJdk`) and implementation.
- Update `contributor/jrunscript.jsh.js` to use the new API instead of manually reconstructing a search path.
- Keep engine resolution logic intact while making launcher selection clearer and less duplicated.

## Why
The previous test runner logic duplicated the JDK/bin search-path behavior in `contributor/jrunscript.jsh.js`. Centralizing this in `rhino/shell/java` reduces duplication and makes jrunscript path lookup reusable through a typed API surface.

## Files changed
- `rhino/shell/module.js`
  - Adds `getJrunscriptFileFromJdk` and `getJrunscriptPathFromJdk` helpers.
  - Exposes the new context function to the Java shell code.
- `rhino/shell/java.js`
  - Adds `Jdk.jrunscript(jdk)` implementation backed by the injected context function.
- `rhino/shell/java.fifty.ts`
  - Extends context and exported API typings with `getJrunscriptPathFromJdk` and `Jdk.jrunscript`.
- `contributor/jrunscript.jsh.js`
  - Replaces inline JDK/bin search logic with `jsh.shell.java.Jdk.jrunscript(...)`.
  - Minor refactor/cleanup around engine resolution and console output text.

## Testing
- Not run in this PR creation step.
- Expected follow-up validation: run relevant Fifty tests for jrunscript and shell/java coverage.