### PR TITLE
Refactor RFC3339 helpers, tighten date codec parsing, and add Date.offset tests

### DIFF
--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -86,46 +86,6 @@ namespace slime.time {
 		function(
 			fifty: slime.fifty.test.Kit
 		) {
-			const { verify } = fifty;
-
-			fifty.tests.Timezone = function() {
-				fifty.run(function zones() {
-					verify(test.subject).Timezone.local.is.type("object");
-					verify(test.subject).Timezone.UTC.is.type("object");
-				});
-
-				verify(Object.keys(test.subject.Timezone).join(" "), "Timezones").is(Object.keys(test.subject.Timezone).join(" "));
-
-				var depart: Datetime = { year: 2025, month: 1, day: 5, hour: 17, minute: 30, second: 40 };
-				var instant = test.subject.Timezone["Pacific/Honolulu"].unix(depart);
-
-				(
-					function(datetime,zone) {
-						var date = new Date(datetime.year, datetime.month-1, datetime.day, datetime.hour, datetime.minute, datetime.second);
-						verify(date,"date").is(date);
-						var stringed = date.toLocaleString("en-US", { timeZone: zone });
-						verify(stringed,"stringed").is(stringed);
-						var rv = new Date(stringed);
-					}
-				)(depart, "Pacific/Honolulu");
-
-				verify(instant, "unix time").is(instant);
-				var converted = test.subject.Timezone["America/New_York"].local(instant);
-				verify(converted).year.is(2025);
-				verify(converted).month.is(1);
-				verify(converted).day.is(5);
-				verify(converted).hour.is(22);
-				verify(converted).minute.is(30);
-				verify(converted).second.is(40);
-			}
-		}
-	//@ts-ignore
-	)(fifty);
-
-	(
-		function(
-			fifty: slime.fifty.test.Kit
-		) {
 			fifty.tests.exports = fifty.test.Parent();
 		}
 	//@ts-ignore
@@ -197,7 +157,7 @@ namespace slime.time {
 		) {
 			fifty.tests.exports.Date = fifty.test.Parent();
 
-			fifty.tests.Date = fifty.test.Parent();
+			fifty.tests.exportsDate = fifty.test.Parent();
 		}
 	//@ts-ignore
 	)(fifty);
@@ -217,7 +177,7 @@ namespace slime.time {
 			const { verify } = fifty;
 			const { $api } = fifty.global;
 
-			fifty.tests.Date.today = function() {
+			fifty.tests.exports.Date.today = function() {
 				var subject = test.load({
 					now: $api.fp.returning(1643907600000)
 				});
@@ -245,7 +205,7 @@ namespace slime.time {
 			) {
 				const { verify } = fifty;
 
-				fifty.tests.Date.from = function() {
+				fifty.tests.exports.Date.from = function() {
 					var leap = test.subject.Date.from.ymd(2024,2,29);
 
 					verify(leap).year.is(2024);
@@ -290,7 +250,7 @@ namespace slime.time {
 				var feb28 = ymd(2024,2,28);
 				var mar1 = ymd(2024,3,1);
 
-				fifty.tests.Date.is = function() {
+				fifty.tests.exports.Date.is = function() {
 					var isLeap = test.subject.Date.is(leap);
 
 					var same = ymd(2024,2,29);
@@ -300,14 +260,14 @@ namespace slime.time {
 					verify(mar1).evaluate(isLeap).is(false);
 				};
 
-				fifty.tests.Date.isAfter = function() {
+				fifty.tests.exports.Date.isAfter = function() {
 					var isAfterLeap = test.subject.Date.isAfter(leap);
 
 					verify(feb28).evaluate(isAfterLeap).is(false);
 					verify(mar1).evaluate(isAfterLeap).is(true);
 				};
 
-				fifty.tests.Date.isBefore = function() {
+				fifty.tests.exports.Date.isBefore = function() {
 					var isBefore = test.subject.Date.isBefore(leap);
 
 					verify(feb28).evaluate(isBefore).is(true);
@@ -384,7 +344,7 @@ namespace slime.time {
 			) {
 				const verify = fifty.verify;
 
-				fifty.tests.Date.format = function() {
+				fifty.tests.exports.Date.format = function() {
 					var mar1: slime.time.Date = {
 						year: 2009,
 						month: 3,
@@ -410,7 +370,58 @@ namespace slime.time {
 
 	export namespace date {
 		export interface Exports {
+			/**
+			 * Returns a function that, given a {@link Date}, returns a new {@link Date} that is the given number of days after
+			 * the given {@link Date}.
+			 *
+			 * @param offset A number of days; may be negative.
+			 * @returns A function that, given a {@link Date}, returns a new {@link Date} that is `offset` days after the given
+			 * {@link Date}.
+			 */
 			offset: (offset: number) => (day: slime.time.Date) => slime.time.Date
+		}
+
+		(
+			function(
+				fifty: slime.fifty.test.Kit
+			) {
+				const { verify } = fifty;
+
+				fifty.tests.exports.Date.offset = function() {
+					var start: slime.time.Date = {
+						year: 2020,
+						month: 3,
+						day: 1
+					};
+
+					var previous = test.subject.Date.offset(-1)(start);
+					verify(previous).year.is(2020);
+					verify(previous).month.is(2);
+					verify(previous).day.is(29);
+
+					var nextYear = test.subject.Date.offset(1)({
+						year: 2019,
+						month: 12,
+						day: 31
+					});
+					verify(nextYear).year.is(2020);
+					verify(nextYear).month.is(1);
+					verify(nextYear).day.is(1);
+
+					var unchanged = test.subject.Date.offset(0)(start);
+					verify(unchanged).year.is(2020);
+					verify(unchanged).month.is(3);
+					verify(unchanged).day.is(1);
+
+					verify(start).year.is(2020);
+					verify(start).month.is(3);
+					verify(start).day.is(1);
+				}
+			}
+		//@ts-ignore
+		)(fifty);
+
+		export interface Exports {
 			after: (day: slime.time.Date) => (offset: number) => slime.time.Date
 
 			months: {
@@ -430,7 +441,7 @@ namespace slime.time {
 			) {
 				const { verify } = fifty;
 
-				fifty.tests.Date.add = function() {
+				fifty.tests.exports.Date.add = function() {
 					var day = {
 						year: 2019,
 						month: 11,
@@ -464,7 +475,7 @@ namespace slime.time {
 					verify(plus).day.is(2);
 				};
 
-				fifty.tests.Date.months = function() {
+				fifty.tests.exports.Date.months = function() {
 					var date: slime.time.Date = {
 						year: 2019,
 						month: 1,
@@ -492,7 +503,7 @@ namespace slime.time {
 					verify(before2).day.is(15);
 				};
 
-				fifty.tests.Date.years = function() {
+				fifty.tests.exports.Date.years = function() {
 					var date1: slime.time.Date = {
 						year: 2020,
 						month: 2,
@@ -552,7 +563,7 @@ namespace slime.time {
 			) {
 				const { verify } = fifty;
 
-				fifty.tests.Date.order = function() {
+				fifty.tests.exports.Date.order = function() {
 					var unordered: slime.time.Date[] = [
 						{ year: 2018, month: 2, day: 2 },
 						{ year: 2018, month: 1, day: 1 },
@@ -592,7 +603,7 @@ namespace slime.time {
 			) {
 				const { verify } = fifty;
 
-				fifty.tests.Date.dayOfWeek = function() {
+				fifty.tests.exports.Date.dayOfWeek = function() {
 					var date: slime.time.Date = {
 						year: 2023,
 						month: 3,
@@ -666,6 +677,46 @@ namespace slime.time {
 			[x: string]: Zone
 		}
 	}
+
+	(
+		function(
+			fifty: slime.fifty.test.Kit
+		) {
+			const { verify } = fifty;
+
+			fifty.tests.exports.Timezone = function() {
+				fifty.run(function zones() {
+					verify(test.subject).Timezone.local.is.type("object");
+					verify(test.subject).Timezone.UTC.is.type("object");
+				});
+
+				verify(Object.keys(test.subject.Timezone).join(" "), "Timezones").is(Object.keys(test.subject.Timezone).join(" "));
+
+				var depart: Datetime = { year: 2025, month: 1, day: 5, hour: 17, minute: 30, second: 40 };
+				var instant = test.subject.Timezone["Pacific/Honolulu"].unix(depart);
+
+				(
+					function(datetime,zone) {
+						var date = new Date(datetime.year, datetime.month-1, datetime.day, datetime.hour, datetime.minute, datetime.second);
+						verify(date,"date").is(date);
+						var stringed = date.toLocaleString("en-US", { timeZone: zone });
+						verify(stringed,"stringed").is(stringed);
+						var rv = new Date(stringed);
+					}
+				)(depart, "Pacific/Honolulu");
+
+				verify(instant, "unix time").is(instant);
+				var converted = test.subject.Timezone["America/New_York"].local(instant);
+				verify(converted).year.is(2025);
+				verify(converted).month.is(1);
+				verify(converted).day.is(5);
+				verify(converted).hour.is(22);
+				verify(converted).minute.is(30);
+				verify(converted).second.is(40);
+			}
+		}
+	//@ts-ignore
+	)(fifty);
 
 	export namespace zone {
 		export namespace time {
@@ -774,10 +825,6 @@ namespace slime.time {
 
 			fifty.tests.suite = function() {
 				fifty.run(fifty.tests.exports);
-
-				fifty.run(fifty.tests.Date);
-
-				fifty.run(fifty.tests.Timezone);
 
 				fifty.load("old.fifty.ts");
 			}

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -156,8 +156,6 @@ namespace slime.time {
 			fifty: slime.fifty.test.Kit
 		) {
 			fifty.tests.exports.Date = fifty.test.Parent();
-
-			fifty.tests.exportsDate = fifty.test.Parent();
 		}
 	//@ts-ignore
 	)(fifty);

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -195,6 +195,8 @@ namespace slime.time {
 		function(
 			fifty: slime.fifty.test.Kit
 		) {
+			fifty.tests.exports.Date = fifty.test.Parent();
+
 			fifty.tests.Date = fifty.test.Parent();
 		}
 	//@ts-ignore
@@ -317,6 +319,61 @@ namespace slime.time {
 	}
 
 	export namespace date {
+		export interface Exports {
+			codec: {
+				rfc3339: () => slime.Codec<slime.time.Date, string>
+			}
+		}
+
+		(
+			function(
+				fifty: slime.fifty.test.Kit
+			) {
+				const { verify } = fifty;
+
+				fifty.tests.exports.Date.codec = fifty.test.Parent();
+				fifty.tests.exports.Date.codec.rfc3339 = function() {
+					var codec = test.subject.Date.codec.rfc3339();
+
+					var leapDay: slime.time.Date = {
+						year: 2024,
+						month: 2,
+						day: 29
+					};
+
+					var encoded = codec.encode(leapDay);
+					verify(encoded).is("2024-02-29");
+
+					var decoded = codec.decode(encoded);
+					verify(decoded).year.is(2024);
+					verify(decoded).month.is(2);
+					verify(decoded).day.is(29);
+
+					var decodedPadded = codec.decode("1999-07-03");
+					verify(decodedPadded).year.is(1999);
+					verify(decodedPadded).month.is(7);
+					verify(decodedPadded).day.is(3);
+
+					var unpaddedRejected = false;
+					try {
+						codec.decode("1999-7-3");
+					} catch (e) {
+						unpaddedRejected = true;
+					}
+					verify(unpaddedRejected).is(true);
+
+					var invalidDateRejected = false;
+					try {
+						codec.decode("2023-02-29");
+					} catch (e) {
+						invalidDateRejected = true;
+					}
+					verify(invalidDateRejected).is(true);
+				};
+			}
+		//@ts-ignore
+		)(fifty);
+
 		export interface Exports {
 			format: (mask: string) => (day: slime.time.Date) => string
 		}

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -1016,6 +1016,14 @@
 			}
 		};
 
+		/** @type { slime.time.date.Exports["format"] } */
+		var format = function(mask) {
+			return function(date) {
+				var dayObject = new Day(date.year, date.month, date.day);
+				return dayObject.format(mask);
+			}
+		};
+
 		$export({
 			Value: $api.fp.methods.pin($context)(Value),
 			Date: {
@@ -1093,14 +1101,66 @@
 						}
 					}
 				},
-				/** @type {slime.time.Exports["Date"]["format"] } */
-				format: function(mask) {
-					/** @type { ReturnType<slime.time.Exports["Date"]["format"]> } */
-					return function(day) {
-						var dayObject = new Day(day.year, day.month, day.day);
-						return dayObject.format(mask);
+				codec: {
+					rfc3339: function() {
+							var isInteger = function(value) {
+								return typeof(value) == "number" && isFinite(value) && Math.floor(value) == value;
+							}
+
+						var lzpad = function(value, length) {
+							var rv = String(value);
+							while (rv.length < length) {
+								rv = "0" + rv;
+							}
+							return rv;
+						}
+
+						var isValidDate = function(year, month, day) {
+								if (!isInteger(year) || !isInteger(month) || !isInteger(day)) return false;
+							if (year < 0 || year > 9999) return false;
+							if (month < 1 || month > 12) return false;
+							if (day < 1 || day > 31) return false;
+
+							var js = new Date(Date.UTC(year, month-1, day));
+							return js.getUTCFullYear() == year && js.getUTCMonth() == month-1 && js.getUTCDate() == day;
+						}
+
+						return {
+							encode: function(date) {
+								var year = date && date.year;
+								var month = date && date.month;
+								var day = date && date.day;
+
+								if (!isValidDate(year, month, day)) {
+									throw new TypeError("Does not match RFC3339 format: " + String(year) + "-" + String(month) + "-" + String(day));
+								}
+
+								return lzpad(year, 4) + "-" + lzpad(month, 2) + "-" + lzpad(day, 2);
+							},
+							decode: function(string) {
+								var parsed = /^(\d{4})-(\d{2})-(\d{2})$/.exec(string);
+								if (!parsed) {
+									throw new TypeError("Does not match RFC3339 format: " + string);
+								}
+
+								var year = Number(parsed[1]);
+								var month = Number(parsed[2]);
+								var day = Number(parsed[3]);
+
+								if (!isValidDate(year, month, day)) {
+									throw new TypeError("Does not match RFC3339 format: " + string);
+								}
+
+								return {
+									year: year,
+									month: month,
+									day: day
+								};
+							}
+						}
 					}
 				},
+				format: format,
 				order: {
 					js: ordering.js
 				},

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -1031,8 +1031,10 @@
 			if (month < 1 || month > 12) return false;
 			if (day < 1 || day > 31) return false;
 
-			var js = new Date(Date.UTC(year, month-1, day));
-			return js.getUTCFullYear() == year && js.getUTCMonth() == month-1 && js.getUTCDate() == day;
+			var js = new Date(0);
+			js.setUTCHours(0,0,0,0);
+			js.setUTCFullYear(year, month-1, day);
+			return js.getUTCFullYear() === year && js.getUTCMonth() === month-1 && js.getUTCDate() === day;
 		}
 
 		var Value = {

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -1010,6 +1010,31 @@
 			}
 		}
 
+		var rfc3339Error = function(string) {
+			return new TypeError("Does not match RFC3339 format: " + string);
+		}
+
+		var rfc3339Pad = function(value, length) {
+			var rv = String(value);
+			while (rv.length < length) {
+				rv = "0" + rv;
+			}
+			return rv;
+		}
+
+		var isInteger = function(value) {
+			return typeof(value) == "number" && isFinite(value) && Math.floor(value) == value;
+		}
+
+		var isValidGregorianDate = function(year, month, day) {
+			if (!isInteger(year) || !isInteger(month) || !isInteger(day)) return false;
+			if (month < 1 || month > 12) return false;
+			if (day < 1 || day > 31) return false;
+
+			var js = new Date(Date.UTC(year, month-1, day));
+			return js.getUTCFullYear() == year && js.getUTCMonth() == month-1 && js.getUTCDate() == day;
+		}
+
 		var Value = {
 			now: function(context) {
 				return context.now || Date.now;
@@ -1103,52 +1128,30 @@
 				},
 				codec: {
 					rfc3339: function() {
-							var isInteger = function(value) {
-								return typeof(value) == "number" && isFinite(value) && Math.floor(value) == value;
-							}
-
-						var lzpad = function(value, length) {
-							var rv = String(value);
-							while (rv.length < length) {
-								rv = "0" + rv;
-							}
-							return rv;
-						}
-
-						var isValidDate = function(year, month, day) {
-								if (!isInteger(year) || !isInteger(month) || !isInteger(day)) return false;
-							if (year < 0 || year > 9999) return false;
-							if (month < 1 || month > 12) return false;
-							if (day < 1 || day > 31) return false;
-
-							var js = new Date(Date.UTC(year, month-1, day));
-							return js.getUTCFullYear() == year && js.getUTCMonth() == month-1 && js.getUTCDate() == day;
-						}
-
 						return {
 							encode: function(date) {
 								var year = date && date.year;
 								var month = date && date.month;
 								var day = date && date.day;
 
-								if (!isValidDate(year, month, day)) {
-									throw new TypeError("Does not match RFC3339 format: " + String(year) + "-" + String(month) + "-" + String(day));
+								if (year < 0 || year > 9999 || !isValidGregorianDate(year, month, day)) {
+									throw rfc3339Error(String(year) + "-" + String(month) + "-" + String(day));
 								}
 
-								return lzpad(year, 4) + "-" + lzpad(month, 2) + "-" + lzpad(day, 2);
+								return rfc3339Pad(year, 4) + "-" + rfc3339Pad(month, 2) + "-" + rfc3339Pad(day, 2);
 							},
 							decode: function(string) {
 								var parsed = /^(\d{4})-(\d{2})-(\d{2})$/.exec(string);
 								if (!parsed) {
-									throw new TypeError("Does not match RFC3339 format: " + string);
+									throw rfc3339Error(string);
 								}
 
 								var year = Number(parsed[1]);
 								var month = Number(parsed[2]);
 								var day = Number(parsed[3]);
 
-								if (!isValidDate(year, month, day)) {
-									throw new TypeError("Does not match RFC3339 format: " + string);
+								if (year < 0 || year > 9999 || !isValidGregorianDate(year, month, day)) {
+									throw rfc3339Error(string);
 								}
 
 								return {
@@ -1205,14 +1208,6 @@
 								return Object.prototype.hasOwnProperty.call(object,key);
 							}
 
-							var lzpad = function(n,length) {
-								var rv = String(Math.abs(n));
-								while (rv.length < length) {
-									rv = "0" + rv;
-								}
-								return rv;
-							}
-
 							var parseFixedOffset = function(zoneId) {
 								if (zoneId == "Z") {
 									return 0;
@@ -1232,16 +1227,10 @@
 
 							var validateLocalDateTime = function(local,string) {
 								var message = "Does not match RFC3339 format: " + string;
-								if (local.month < 1 || local.month > 12) throw new TypeError(message);
-								if (local.day < 1 || local.day > 31) throw new TypeError(message);
+								if (!isValidGregorianDate(local.year, local.month, local.day)) throw rfc3339Error(string);
 								if (local.hour < 0 || local.hour > 23) throw new TypeError(message);
 								if (local.minute < 0 || local.minute > 59) throw new TypeError(message);
 								if (local.second < 0 || local.second >= 60) throw new TypeError(message);
-
-								var dayCheck = new Date(local.year, local.month-1, local.day);
-								if (dayCheck.getFullYear() != local.year || dayCheck.getMonth() != local.month-1 || dayCheck.getDate() != local.day) {
-									throw new TypeError(message);
-								}
 							}
 
 							var resolveZone = function(zoneId) {
@@ -1273,7 +1262,7 @@
 								var absolute = Math.abs(offsetMinutes);
 								var hours = Math.floor(absolute / 60);
 								var minutes = absolute % 60;
-								return sign + lzpad(hours,2) + ":" + lzpad(minutes,2);
+								return sign + rfc3339Pad(hours,2) + ":" + rfc3339Pad(minutes,2);
 							}
 
 							var formatSecond = function(second) {
@@ -1283,9 +1272,9 @@
 								whole += carry;
 								milliseconds = (milliseconds == 1000) ? 0 : milliseconds;
 								if (milliseconds == 0) {
-									return lzpad(whole,2);
+									return rfc3339Pad(whole,2);
 								}
-								return lzpad(whole,2) + "." + lzpad(milliseconds,3);
+								return rfc3339Pad(whole,2) + "." + rfc3339Pad(milliseconds,3);
 							}
 
 							return {
@@ -1305,21 +1294,21 @@
 									var utcAsLocal = zones.UTC.unix(dateTimeInZone);
 									var offsetMinutes = Math.round((utcAsLocal - unix) / 1000 / 60);
 									return [
-										lzpad(dateTimeInZone.year,4), "-", lzpad(dateTimeInZone.month,2), "-", lzpad(dateTimeInZone.day,2),
+										rfc3339Pad(dateTimeInZone.year,4), "-", rfc3339Pad(dateTimeInZone.month,2), "-", rfc3339Pad(dateTimeInZone.day,2),
 										"T",
-										lzpad(dateTimeInZone.hour,2), ":", lzpad(dateTimeInZone.minute,2), ":", formatSecond(dateTimeInZone.second),
+										rfc3339Pad(dateTimeInZone.hour,2), ":", rfc3339Pad(dateTimeInZone.minute,2), ":", formatSecond(dateTimeInZone.second),
 										offsetToString(offsetMinutes)
 									].join("");
 								},
 								decode: function(string) {
 									var parsed = /^(\d{4})\-(\d{2})\-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})(?:\.(\d+))?(Z|(?:\+|\-)\d{2}\:\d{2})$/.exec(string);
 									if (!parsed) {
-										throw new TypeError("Does not match RFC3339 format: " + string);
+										throw rfc3339Error(string);
 									}
 									var fractional = (parsed[7]) ? Number("0." + parsed[7]) : 0;
 									var zone = (parsed[8] == "Z") ? "UTC" : parsed[8];
 									if (zone != "UTC" && typeof(parseFixedOffset(zone)) != "number") {
-										throw new TypeError("Does not match RFC3339 format: " + string);
+										throw rfc3339Error(string);
 									}
 									var rv = {
 										year: Number(parsed[1]),


### PR DESCRIPTION
## Summary
- Refactor shared RFC3339 helper logic used by time codecs
- Tighten Date RFC3339 codec parsing behavior and related tests
- Add focused Fifty coverage for `Date.offset`, including boundary cases

## Changes
- Updated [js/time/module.js](js/time/module.js)
- Updated [js/time/module.fifty.ts](js/time/module.fifty.ts)

## Test Coverage
- Ran `./fifty test.jsh js/time/module.fifty.ts`
- Suite passed

## Notes
- Branch contains the RFC3339 refactor/parsing commits plus the Date.offset test coverage commit