### PR TITLE
Devcontainer: bridge GitHub credentials to gh

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,6 +46,10 @@
 	},
 	"service": "local",
 	"remoteUser": "abc",
+	"remoteEnv": {
+		"GH_TOKEN": "${localEnv:GH_TOKEN}",
+		"GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
+	},
 	"workspaceFolder": "/slime",
 	"forwardPorts": [
 		3000

--- a/.devcontainer/docker-compose.extend.yaml
+++ b/.devcontainer/docker-compose.extend.yaml
@@ -8,7 +8,7 @@ version: '3.9'
 services:
   local:
     environment:
-      GIT_EDITOR=code --wait
+      GIT_EDITOR: code --wait
     volumes:
       - type: bind
         source: ./local/git/credentials/github.com

--- a/.devcontainer/docker-compose.extend.yaml
+++ b/.devcontainer/docker-compose.extend.yaml
@@ -9,3 +9,8 @@ services:
   local:
     environment:
       GIT_EDITOR=code --wait
+    volumes:
+      - type: bind
+        source: ./local/git/credentials/github.com
+        target: /run/secrets/github.com
+        read_only: true

--- a/.devcontainer/postStartCommand
+++ b/.devcontainer/postStartCommand
@@ -36,13 +36,17 @@ if command -v gh >/dev/null 2>&1; then
 	GH_USER="${GITHUB_USERNAME:-}"
 
 	if [ -z "${GH_USER}" ] && [ -d "${GH_SECRETS_DIR}" ]; then
-		count="$(find "${GH_SECRETS_DIR}" -maxdepth 1 -type f | wc -l | tr -d ' ')"
-		if [ "${count}" = "1" ]; then
-			GH_USER="$(basename "$(find "${GH_SECRETS_DIR}" -maxdepth 1 -type f | head -n 1)")"
+		# Best-effort discovery: if the mount is unreadable, skip silently.
+		shopt -s nullglob
+		secret_files=("${GH_SECRETS_DIR}"/*)
+		shopt -u nullglob
+
+		if [ "${#secret_files[@]}" = "1" ] && [ -f "${secret_files[0]}" ]; then
+			GH_USER="$(basename "${secret_files[0]}")"
 		fi
 	fi
 
-	if [ -n "${GH_USER}" ] && [ -f "${GH_SECRETS_DIR}/${GH_USER}" ]; then
+	if [ -n "${GH_USER}" ] && [ -r "${GH_SECRETS_DIR}/${GH_USER}" ]; then
 		token="$(tr -d '\r\n' < "${GH_SECRETS_DIR}/${GH_USER}")"
 		if [ -n "${token}" ]; then
 			current="$(gh auth token 2>/dev/null || true)"

--- a/.devcontainer/postStartCommand
+++ b/.devcontainer/postStartCommand
@@ -30,3 +30,27 @@ run_as_root chown "${TARGET_UID}:${TARGET_GID}" /slime/local
 
 # Keep startup cost low by only repairing root-owned entries.
 run_as_root find /slime/local -xdev \( -uid 0 -o -gid 0 \) -exec chown "${TARGET_UID}:${TARGET_GID}" {} +
+
+if command -v gh >/dev/null 2>&1; then
+	GH_SECRETS_DIR=/run/secrets/github.com
+	GH_USER="${GITHUB_USERNAME:-}"
+
+	if [ -z "${GH_USER}" ] && [ -d "${GH_SECRETS_DIR}" ]; then
+		count="$(find "${GH_SECRETS_DIR}" -maxdepth 1 -type f | wc -l | tr -d ' ')"
+		if [ "${count}" = "1" ]; then
+			GH_USER="$(basename "$(find "${GH_SECRETS_DIR}" -maxdepth 1 -type f | head -n 1)")"
+		fi
+	fi
+
+	if [ -n "${GH_USER}" ] && [ -f "${GH_SECRETS_DIR}/${GH_USER}" ]; then
+		token="$(tr -d '\r\n' < "${GH_SECRETS_DIR}/${GH_USER}")"
+		if [ -n "${token}" ]; then
+			current="$(gh auth token 2>/dev/null || true)"
+			if [ "${current}" != "${token}" ]; then
+				if ! printf '%s\n' "${token}" | gh auth login --hostname github.com --with-token; then
+					echo "Warning: GitHub token validation failed (likely missing required scopes for gh login, e.g. read:org)." >&2
+				fi
+			fi
+		fi
+	fi
+fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #	support any deployment use cases.
 
 FROM lscr.io/linuxserver/webtop:ubuntu-xfce
-RUN apt update && apt install -y git chromium chromium-sandbox curl socat
+RUN apt update && apt install -y git gh chromium chromium-sandbox curl socat
 # Chromium in this container runtime needs sandbox-disabled flags to launch reliably.
 RUN mkdir -p /etc/chromium.d && printf '%s\n' \
 	'export CHROMIUM_FLAGS="$CHROMIUM_FLAGS --no-sandbox --disable-setuid-sandbox"' \


### PR DESCRIPTION
## Summary
- install `gh` in the devcontainer image
- mount GitHub credentials into `/run/secrets/github.com`
- pass through `GH_TOKEN` and `GITHUB_TOKEN` via devcontainer remote env
- bootstrap `gh` auth in post-start script when token material is available
- avoid hard-failing startup when token validation fails due to missing optional scopes

## Why
This makes `gh` usable automatically inside the devcontainer and prevents startup failures when a provided token is valid for API use but does not satisfy `gh auth login --with-token` scope validation.

## Validation
- ran `bash -n .devcontainer/postStartCommand`
- executed `.devcontainer/postStartCommand` and confirmed non-zero auth validation no longer aborts startup
