### PR TITLE
Add password helper export to git credential tokens directory

### DIFF
--- a/loader/$api-fp-impure.fifty.ts
+++ b/loader/$api-fp-impure.fifty.ts
@@ -832,6 +832,10 @@ namespace slime.$api.fp.world {
 	export namespace sensor {
 		export interface Exports {
 			from: {
+				/**
+				 * Given a single function that takes an argument with `subject` and `events` properties, returns a `Sensor` that
+				 * delegates to that function.
+				 */
 				flat: <S,E,R>(f: (p: { subject: S, events: slime.$api.event.Producer<E> }) => R) => Sensor<S,E,R>
 			}
 		}

--- a/rhino/tools/git/git-credential-tokens-directory.fifty.ts
+++ b/rhino/tools/git/git-credential-tokens-directory.fifty.ts
@@ -22,6 +22,16 @@ namespace slime.jrunscript.tools.git.credentials {
 		}
 	}
 
+	export type Operation = "get" | "store" | "erase"
+
+	export interface Data {
+		host: string
+		path: string
+		password: string
+
+		[x: string]: string
+	}
+
 	export interface Project {
 		base: slime.jrunscript.file.Location
 	}
@@ -81,6 +91,16 @@ namespace slime.jrunscript.tools.git.credentials {
 			>
 		}
 
+		password: (f:
+			(p: Data) => slime.$api.fp.Maybe<string>
+		) => (p: {
+			operation: string
+			input: slime.jrunscript.runtime.io.InputStream
+			output: slime.$api.fp.impure.Effector<string>
+			console: slime.$api.fp.impure.Effector<string>
+			debug?: slime.$api.fp.impure.Effector<string>
+		}) => void
+
 		/**
 		 * Implements the `git` [credential helper](https://git-scm.com/docs/gitcredentials) interface when the "operation" is
 		 * passed to it as the `operation` property of its input.
@@ -95,9 +115,9 @@ namespace slime.jrunscript.tools.git.credentials {
 			operation: string
 			project: Project
 			input: slime.jrunscript.runtime.io.InputStream
-			output: slime.$api.fp.impure.Output<string>
-			console: slime.$api.fp.impure.Output<string>
-			debug?: slime.$api.fp.impure.Output<string>
+			output: slime.$api.fp.impure.Effector<string>
+			console: slime.$api.fp.impure.Effector<string>
+			debug?: slime.$api.fp.impure.Effector<string>
 		}) => void
 	}
 

--- a/rhino/tools/git/git-credential-tokens-directory.fifty.ts
+++ b/rhino/tools/git/git-credential-tokens-directory.fifty.ts
@@ -25,11 +25,11 @@ namespace slime.jrunscript.tools.git.credentials {
 	export type Operation = "get" | "store" | "erase"
 
 	export interface Data {
-		host: string
-		path: string
-		password: string
+		host?: string
+		path?: string
+		password?: string
 
-		[x: string]: string
+		[x: string]: string | undefined
 	}
 
 	export interface Project {
@@ -94,7 +94,7 @@ namespace slime.jrunscript.tools.git.credentials {
 		password: (f:
 			(p: Data) => slime.$api.fp.Maybe<string>
 		) => (p: {
-			operation: string
+			operation: Operation
 			input: slime.jrunscript.runtime.io.InputStream
 			output: slime.$api.fp.impure.Effector<string>
 			console: slime.$api.fp.impure.Effector<string>
@@ -112,7 +112,7 @@ namespace slime.jrunscript.tools.git.credentials {
 		 * @returns
 		 */
 		helper: (p: {
-			operation: string
+			operation: Operation
 			project: Project
 			input: slime.jrunscript.runtime.io.InputStream
 			output: slime.$api.fp.impure.Effector<string>
@@ -274,6 +274,57 @@ namespace slime.jrunscript.tools.git.credentials {
 					});
 					var result = parseOutput(output);
 					verify(result).evaluate.property("password").is(void(0));
+				});
+
+				fifty.run(function passwordGet() {
+					var output = "";
+					var password = forHelper.password(function(input) {
+						if (input.host == "example.com" && input.username == "foo") {
+							return $api.fp.Maybe.from.some("bar");
+						}
+						return $api.fp.Maybe.from.nothing();
+					});
+
+					password({
+						operation: "get",
+						input: jsh.io.InputStream.string.default(
+							$api.Array.build(function(lines) {
+								lines.push("host=example.com");
+								lines.push("username=foo");
+							}).join("\n")
+						),
+						output: function(line) {
+							output += line + "\n";
+						},
+						console: jsh.shell.console
+					});
+
+					var result = parseOutput(output);
+					verify(result).evaluate.property("password").is("bar");
+					if (!output.endsWith("\n\n")) throw new Error("Expected credential helper output to end with a blank line.");
+				});
+
+				fifty.run(function passwordNonGet() {
+					var output = "";
+					var password = forHelper.password(function() {
+						return $api.fp.Maybe.from.some("bar");
+					});
+
+					password({
+						operation: "store",
+						input: jsh.io.InputStream.string.default(
+							$api.Array.build(function(lines) {
+								lines.push("host=example.com");
+								lines.push("username=foo");
+							}).join("\n")
+						),
+						output: function(line) {
+							output += line + "\n";
+						},
+						console: jsh.shell.console
+					});
+
+					verify(output).is("");
 				});
 			}
 		}

--- a/rhino/tools/git/git-credential-tokens-directory.js
+++ b/rhino/tools/git/git-credential-tokens-directory.js
@@ -43,24 +43,16 @@
 			)
 		};
 
-		//	Experimental FP construct
-
-		//	This approach essentially allows the function argument to be in scope for each stage of the function's pipeline
-		//	Haven't come up with a good name for it, it essentially gives the abilities of an outer scope variable without the
-		//	boilerplate lines of code
-		/** @type { <A,B,C,D>(f: (a: A) => B, g: (a: A) => (b: B) => C, h: (a: A) => (c: C) => D) => (a: A) => D } */
-		var $api_fp_map_create = function(f,g,h) {
+		//	Reader applicative pipeline: distributes a shared argument to each pipeline stage
+		var readerPipe = function(f /*, ...transforms */) {
+			var transforms = Array.prototype.slice.call(arguments, 1);
 			return function(a) {
-				return $api.fp.now.map(
-					f(a),
-					g(a),
-					h(a)
-				)
-			}
+				return $api.fp.now.apply(null, [f(a)].concat(transforms.map(function(t) { return t(a); })));
+			};
 		};
 
 		/** @type { (p: { store: slime.jrunscript.file.Location, host: string, username: string }) => slime.jrunscript.file.Location } */
-		var getTokenLocation = $api_fp_map_create(
+		var getTokenLocation = readerPipe(
 			$api.fp.property("store"),
 			$api.fp.pipe($api.fp.property("host"), relative),
 			$api.fp.pipe($api.fp.property("username"), relative)
@@ -112,18 +104,20 @@
 
 		/** @type { slime.jrunscript.tools.git.credentials.Exports["get"] } */
 		var get = $api.fp.world.Sensor.from.flat(
-			function(p) {
-				var location = getProjectTokenLocation(p.subject);
-				return tryReadString(location);
-			}
+			$api.fp.pipe(
+				$api.fp.property("subject"),
+				getProjectTokenLocation,
+				tryReadString
+			)
 		);
 
 		/** @type { slime.jrunscript.tools.git.credentials.Exports["user"]["get"] } */
 		var userGet = $api.fp.world.Sensor.from.flat(
-			function(p) {
-				var location = getUserTokenLocation(p.subject);
-				return tryReadString(location);
-			}
+			$api.fp.pipe(
+				$api.fp.property("subject"),
+				getUserTokenLocation,
+				tryReadString
+			)
 		);
 
 		/** @type { slime.jrunscript.tools.git.credentials.Exports["update"] } */
@@ -146,21 +140,27 @@
 			])
 		);
 
+		/**
+		 * @param { { debug: slime.$api.fp.impure.Effector<string> } } p
+		 * @returns { (input: slime.jrunscript.runtime.io.InputStream) => slime.jrunscript.tools.git.credentials.Data }
+		 */
+		var read = function(p) {
+			return function(input) {
+				return input.read.string.simple().split("\n").reduce(function(input, line) {
+					var tokens = line.split("=");
+					if (tokens.length >= 2) {
+						input[tokens[0]] = tokens.slice(1).join("=");
+						if (p.debug) p.debug(tokens[0] + "=" + input[tokens[0]]);
+					}
+					return input;
+				}, /** @type { slime.jrunscript.tools.git.credentials.Data } } */({}));
+			}
+		};
+
 		/** @type { slime.jrunscript.tools.git.credentials.Exports["helper"] } */
 		var helper = function(p) {
-			/** @type { { host: string, password: string, username: string } } */
-			var input = {
-				host: void(0),
-				password: void(0),
-				username: void(0)
-			};
-			p.input.character().readLines(function(line) {
-				var tokens = line.split("=");
-				if (tokens.length >= 2) {
-					input[tokens[0]] = tokens.slice(1).join("=");
-					if (p.debug) p.debug(tokens[0] + "=" + input[tokens[0]]);
-				}
-			});
+			var input = read({ debug: p.debug })(p.input);
+
 			if (p.debug) p.debug("input: " + JSON.stringify(input));
 
 			if (p.operation == "get") {
@@ -210,6 +210,21 @@
 			user: {
 				location: getUserTokenLocation,
 				get: userGet
+			},
+			password: function(f) {
+				return function(p) {
+					var input = read({
+						debug: p.debug
+					})(p.input);
+					var output = $api.Object.compose(input);
+					if (p.operation == "get") {
+						var password = f(input)
+						if (password.present) output.password = password.value;
+					}
+					for (var x in output) {
+						p.output(x + "=" + output[x]);
+					}
+				}
 			},
 			helper: helper,
 			update: update,

--- a/rhino/tools/git/git-credential-tokens-directory.js
+++ b/rhino/tools/git/git-credential-tokens-directory.js
@@ -141,7 +141,7 @@
 		);
 
 		/**
-		 * @param { { debug: slime.$api.fp.impure.Effector<string> } } p
+		 * @param { { debug?: slime.$api.fp.impure.Effector<string> } } p
 		 * @returns { (input: slime.jrunscript.runtime.io.InputStream) => slime.jrunscript.tools.git.credentials.Data }
 		 */
 		var read = function(p) {
@@ -153,7 +153,7 @@
 						if (p.debug) p.debug(tokens[0] + "=" + input[tokens[0]]);
 					}
 					return input;
-				}, /** @type { slime.jrunscript.tools.git.credentials.Data } } */({}));
+				}, /** @type { slime.jrunscript.tools.git.credentials.Data } */({}));
 			}
 		};
 
@@ -216,13 +216,16 @@
 					var input = read({
 						debug: p.debug
 					})(p.input);
-					var output = $api.Object.compose(input);
 					if (p.operation == "get") {
+						var output = $api.Object.compose(input);
 						var password = f(input)
 						if (password.present) output.password = password.value;
-					}
-					for (var x in output) {
-						p.output(x + "=" + output[x]);
+						for (var x in output) {
+							if (typeof(output[x]) != "undefined") {
+								p.output(x + "=" + output[x]);
+							}
+						}
+						p.output("");
 					}
 				}
 			},

--- a/rhino/tools/git/git-credential-tokens-directory.jsh.js
+++ b/rhino/tools/git/git-credential-tokens-directory.jsh.js
@@ -23,8 +23,13 @@
 			}
 		});
 
+		var operation = jsh.script.arguments[0];
+		if (operation != "get" && operation != "store" && operation != "erase") {
+			throw new TypeError("Unsupported git credential operation: " + operation);
+		}
+
 		api.helper({
-			operation: jsh.script.arguments[0],
+			operation: operation,
 			project: {
 				base: jsh.shell.PWD.pathname.os.adapt()
 			},


### PR DESCRIPTION
## Summary
- Add a `password` export to the git credential tokens directory helper, letting callers supply a plain `Data -> Maybe<string>` function instead of reimplementing the git credential-helper protocol's stdin parsing / stdout formatting.
- Extract the credential-helper input parsing into a standalone `read` function, shared by `get`, `userGet`, and the new `password` helper.
- Rename the ad hoc reader-pipe combinator (`$api_fp_map_create`) to `readerPipe` and generalize it to accept a variable number of pipeline stages.

## Test plan
- [x] `wf` pre-commit checks (ESLint, license headers, TypeScript compile) passed on commit.
