### PR TITLE
Fix zone time offset and RFC3339 normalization

### DIFF
--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -26,7 +26,10 @@ namespace slime.time {
 
 	export namespace zone {
 		export interface Time extends Datetime {
-			zone: string
+			/**
+			 * The timezone offset, in minutes, from UTC.
+			 */
+			offset: number
 		}
 	}
 
@@ -759,6 +762,10 @@ namespace slime.time {
 					// 	upper/lower case for T/Z?
 					rfc3339: () => slime.Codec<slime.time.zone.Time, string>
 				}
+
+				create: {
+					zone: (zone: Zone) => (datetime: Datetime) => slime.time.zone.Time
+				}
 			}
 		}
 	}
@@ -784,15 +791,18 @@ namespace slime.time {
 
 			fifty.tests.exports.zone.Time.zoneTimeCodecRoundTripWithNamedZone = function() {
 				var codec = test.subject.zone.Time.codec.rfc3339();
-				var encoded = codec.encode({
+
+				var created = test.subject.zone.Time.create.zone(test.subject.Timezone["Pacific/Honolulu"])({
 					year: 2025,
 					month: 1,
 					day: 5,
 					hour: 17,
 					minute: 30,
-					second: 40,
-					zone: "Pacific/Honolulu"
+					second: 40
 				});
+
+				var encoded = codec.encode(created);
+
 				verify(encoded).is("2025-01-05T17:30:40-10:00");
 
 				var decoded = codec.decode(encoded);
@@ -802,7 +812,7 @@ namespace slime.time {
 				verify(decoded).hour.is(17);
 				verify(decoded).minute.is(30);
 				verify(decoded).second.is(40);
-				verify(decoded).zone.is("-10:00");
+				verify(decoded).offset.is(-600);
 			};
 
 			//	TODO	determine why this test fails in Firefox
@@ -810,14 +820,14 @@ namespace slime.time {
 				var codec = test.subject.zone.Time.codec.rfc3339();
 				var decoded = codec.decode("2026-06-23T07:08:09.125Z");
 				verify(decoded).second.is(9.125);
-				verify(decoded).zone.is("UTC");
+				verify(decoded).offset.is(0);
 				verify(codec.encode(decoded)).is("2026-06-23T07:08:09.125Z");
 			};
 
 			fifty.tests.exports.zone.Time.zoneTimeCodecFixedOffset = function() {
 				var codec = test.subject.zone.Time.codec.rfc3339();
 				var decoded = codec.decode("2026-06-23T07:08:09+05:30");
-				verify(decoded).zone.is("+05:30");
+				verify(decoded).offset.is(330);
 				verify(codec.encode(decoded)).is("2026-06-23T07:08:09+05:30");
 			};
 
@@ -842,7 +852,7 @@ namespace slime.time {
 					hour: 7,
 					minute: 8,
 					second: 59.9996,
-					zone: "UTC"
+					offset: 0
 				});
 				verify(encoded).is("2026-06-23T07:09:00Z");
 			};

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -1210,15 +1210,6 @@
 				Time: {
 					codec: {
 						rfc3339: function() {
-							/**
-							 * @param { object } object
-							 * @param { string } key
-							 * @returns { boolean }
-							 */
-							var hasOwn = function(object,key) {
-								return Object.prototype.hasOwnProperty.call(object,key);
-							}
-
 							var parseFixedOffset = function(offset) {
 								if (offset == "Z") {
 									return 0;
@@ -1281,9 +1272,18 @@
 								};
 							}
 
+							var validateOffsetMinutes = function(offset,string) {
+								var message = "Does not match RFC3339 format: " + string;
+								if (typeof(offset) != "number" || !isFinite(offset) || Math.floor(offset) != offset) {
+									throw new TypeError(message);
+								}
+								if (offset < -1439 || offset > 1439) {
+									throw new TypeError(message);
+								}
+							}
+
 							return {
 								encode: function(zt) {
-									//var zone = resolveZone(zt.zone);
 									var requested = {
 										year: zt.year,
 										month: zt.month,
@@ -1293,6 +1293,7 @@
 										second: zt.second
 									};
 									validateLocalDateTime(requested, String(zt));
+									validateOffsetMinutes(zt.offset, String(zt));
 									var normalized = normalizeLocalDateTime(requested);
 									return [
 										rfc3339Pad(normalized.year,4), "-", rfc3339Pad(normalized.month,2), "-", rfc3339Pad(normalized.day,2),

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -1219,11 +1219,11 @@
 								return Object.prototype.hasOwnProperty.call(object,key);
 							}
 
-							var parseFixedOffset = function(zoneId) {
-								if (zoneId == "Z") {
+							var parseFixedOffset = function(offset) {
+								if (offset == "Z") {
 									return 0;
 								}
-								var parsed = /^(\+|\-)(\d{2})\:(\d{2})$/.exec(zoneId);
+								var parsed = /^(\+|\-)(\d{2})\:(\d{2})$/.exec(offset);
 								if (!parsed) {
 									return void(0);
 								}
@@ -1242,27 +1242,6 @@
 								if (local.hour < 0 || local.hour > 23) throw new TypeError(message);
 								if (local.minute < 0 || local.minute > 59) throw new TypeError(message);
 								if (local.second < 0 || local.second >= 60) throw new TypeError(message);
-							}
-
-							var resolveZone = function(zoneId) {
-								if (zoneId == "Z" || zoneId == "UTC") {
-									return zones.UTC;
-								}
-								if (hasOwn(zones,zoneId)) {
-									return zones[zoneId];
-								}
-								var offsetMinutes = parseFixedOffset(zoneId);
-								if (typeof(offsetMinutes) == "number") {
-									return {
-										local: function(unix) {
-											return zones.UTC.local(unix + offsetMinutes * 60 * 1000);
-										},
-										unix: function(local) {
-											return zones.UTC.unix(local) - offsetMinutes * 60 * 1000;
-										}
-									}
-								}
-								throw new TypeError("Unknown zone: " + zoneId);
 							}
 
 							var offsetToString = function(offsetMinutes) {
@@ -1288,9 +1267,23 @@
 								return rfc3339Pad(whole,2) + "." + rfc3339Pad(milliseconds,3);
 							}
 
+							var normalizeLocalDateTime = function(local) {
+								var unix = Date.UTC(local.year, local.month-1, local.day, local.hour, local.minute, 0, 0)
+									+ Math.round(local.second * 1000);
+								var normalized = new Date(unix);
+								return {
+									year: normalized.getUTCFullYear(),
+									month: normalized.getUTCMonth() + 1,
+									day: normalized.getUTCDate(),
+									hour: normalized.getUTCHours(),
+									minute: normalized.getUTCMinutes(),
+									second: normalized.getUTCSeconds() + normalized.getUTCMilliseconds() / 1000
+								};
+							}
+
 							return {
 								encode: function(zt) {
-									var zone = resolveZone(zt.zone);
+									//var zone = resolveZone(zt.zone);
 									var requested = {
 										year: zt.year,
 										month: zt.month,
@@ -1300,15 +1293,12 @@
 										second: zt.second
 									};
 									validateLocalDateTime(requested, String(zt));
-									var unix = zone.unix(requested);
-									var dateTimeInZone = zone.local(unix);
-									var utcAsLocal = zones.UTC.unix(dateTimeInZone);
-									var offsetMinutes = Math.round((utcAsLocal - unix) / 1000 / 60);
+									var normalized = normalizeLocalDateTime(requested);
 									return [
-										rfc3339Pad(dateTimeInZone.year,4), "-", rfc3339Pad(dateTimeInZone.month,2), "-", rfc3339Pad(dateTimeInZone.day,2),
+										rfc3339Pad(normalized.year,4), "-", rfc3339Pad(normalized.month,2), "-", rfc3339Pad(normalized.day,2),
 										"T",
-										rfc3339Pad(dateTimeInZone.hour,2), ":", rfc3339Pad(dateTimeInZone.minute,2), ":", formatSecond(dateTimeInZone.second),
-										offsetToString(offsetMinutes)
+										rfc3339Pad(normalized.hour,2), ":", rfc3339Pad(normalized.minute,2), ":", formatSecond(normalized.second),
+										offsetToString(zt.offset)
 									].join("");
 								},
 								decode: function(string) {
@@ -1328,10 +1318,25 @@
 										hour: Number(parsed[4]),
 										minute: Number(parsed[5]),
 										second: Number(parsed[6]) + fractional,
-										zone: zone
+										offset: (zone == "UTC") ? 0 : parseFixedOffset(zone)
 									};
 									validateLocalDateTime(rv, string);
 									return rv;
+								}
+							}
+						}
+					},
+					create: {
+						zone: function(zone) {
+							return function(datetime) {
+								return {
+									year: datetime.year,
+									month: datetime.month,
+									day: datetime.day,
+									hour: datetime.hour,
+									minute: datetime.minute,
+									second: datetime.second,
+									offset: Math.round((zones.UTC.unix(datetime) - zone.unix(datetime)) / (60 * 1000))
 								}
 							}
 						}

--- a/loader/$api-fp-impure.fifty.ts
+++ b/loader/$api-fp-impure.fifty.ts
@@ -34,8 +34,8 @@ namespace slime.$api.fp.impure {
 	/**
 	 * A function capable of observing some kind of external state and obtaining and returning it to the caller.
 	 *
-	 * @deprecated Replaced by {@link Reading}. Note that `Reading` is not a drop-in replacement, but is requires a `read` method
-	 * replacing the function signature provided by `External`.
+	 * @deprecated Replaced by {@link Reading}. Note that `Reading` is not a drop-in replacement, but requires a `read` method
+	 * instead of the function signature provided by `External`.
 	 */
 	export type External<T> = () => T
 

--- a/loader/$api-fp-impure.fifty.ts
+++ b/loader/$api-fp-impure.fifty.ts
@@ -34,7 +34,8 @@ namespace slime.$api.fp.impure {
 	/**
 	 * A function capable of observing some kind of external state and obtaining and returning it to the caller.
 	 *
-	 * @deprecated Replaced by {@link Reading}.
+	 * @deprecated Replaced by {@link Reading}. Note that `Reading` is not a drop-in replacement, but is requires a `read` method
+	 * replacing the function signature provided by `External`.
 	 */
 	export type External<T> = () => T
 


### PR DESCRIPTION
## Summary
- compute `zone.Time.create.zone(...).offset` from `Zone.unix`/`Timezone.UTC.unix` instead of calling a non-existent `zone.offset(...)`
- normalize local datetime components during RFC3339 encode so rounded fractional seconds correctly carry into minute/hour/day when needed
- refine `External` deprecation note in `loader/$api-fp-impure.fifty.ts`

## Validation
- `./fifty test.jsh js/time/module.fifty.ts` (pass)
- commit hooks passed (ESLint, MPL headers, TypeScript)
