### PR TITLE
Add URL polyfill support path (#2403)

### DIFF
--- a/loader/polyfill.fifty.ts
+++ b/loader/polyfill.fifty.ts
@@ -145,6 +145,8 @@ interface Array<T> {
             if (fifty.global.jsh.internal.bootstrap.engine.rhino.running()) {
                 fifty.global.jsh.shell.console("Rhino version " + fifty.global.jsh.internal.bootstrap.engine.rhino.running().getImplementationVersion());
             }
+
+            //  Polyfilled methods; output shows whether they are polyfills or native based on toString()
             console("Object.defineProperty: " + Object.defineProperty);
             console("Object.assign: " + Object.assign);
             console("Object.fromEntries: " + Object.fromEntries);
@@ -154,6 +156,11 @@ interface Array<T> {
             console("Array.prototype.find: " + Array.prototype.find);
             console("Array.prototype.findIndex: " + Array.prototype.findIndex);
             console("Map: " + Map);
+
+            //  Methods not polyfilled yet, so need to conditionally check for their existence on the global object
+            var global = (function() { return this; })();
+            //  See issue #2403, requesting implementation of this polyfill
+            console("URL: " + global.URL);
         }
     }
 //@ts-ignore

--- a/loader/polyfill.fifty.ts
+++ b/loader/polyfill.fifty.ts
@@ -141,9 +141,9 @@ interface Array<T> {
         fifty.tests.manual.engine = function() {
             if (fifty.global.jsh) {
                 fifty.global.jsh.shell.console("java version = " + fifty.global.jsh.shell.java.version);
-            }
-            if (fifty.global.jsh.internal.bootstrap.engine.rhino.running()) {
-                fifty.global.jsh.shell.console("Rhino version " + fifty.global.jsh.internal.bootstrap.engine.rhino.running().getImplementationVersion());
+                if (fifty.global.jsh.internal.bootstrap.engine.rhino.running()) {
+                    fifty.global.jsh.shell.console("Rhino version " + fifty.global.jsh.internal.bootstrap.engine.rhino.running().getImplementationVersion());
+                }
             }
 
             //  Polyfilled methods; output shows whether they are polyfills or native based on toString()


### PR DESCRIPTION
## Summary
- add URL placeholder visibility in `loader/polyfill.fifty.ts` for manual diagnostics
- this PR intentionally does not implement URL polyfilling yet

## Issue
- related to #2403

## Follow-up
- URL polyfill implementation and non-manual test coverage will be added in a subsequent PR

## Notes
- branch name intentionally includes `#2403` per request