### PR TITLE
devcontainer: add personal agent instructions workflow

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -174,9 +174,9 @@
 			"problemMatcher": []
 		},
 		{
-			"label": "(Local only) Project: Run all project tests locally",
+			"label": "Project: Open my personal agent instructions",
 			"type": "shell",
-			"command": "./wf test",
+			"command": "./jsh contributor/open-personal-agent-instructions.jsh.js --execPath \"${execPath}\"",
 			"problemMatcher": []
 		}
 	],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -176,7 +176,12 @@
 		{
 			"label": "Project: Open my personal agent instructions",
 			"type": "shell",
-			"command": "./jsh contributor/open-personal-agent-instructions.jsh.js --execPath \"${execPath}\"",
+			"command": "./jsh",
+			"args": [
+				"contributor/open-personal-agent-instructions.jsh.js",
+				"--execPath",
+				"${execPath}"
+			],
 			"problemMatcher": []
 		}
 	],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,12 @@ this host directory is mounted through `docker-compose.yaml` as `/config/.agents
 
 Recommended setup:
 
-* Create `README.md` in the personal agent location as the primary entry point for your personal instructions
-* Add one or more instruction files in the same directory and reference them from `README.md`
+* Create `local/agents/README.md` as the primary entry point for your personal instructions on the host.
+* In the devcontainer, this same file is available at `/config/.agents/README.md`.
+* Add one or more instruction files in `local/agents` and reference them from `local/agents/README.md`.
 * The VSCode task "Open my personal agent instructions" will bring these instructions up in the editor, if they exist.
 
-Agent behavior in this repository is configured to read `README.md` from the instructions location first, then follow references from that file.
+Agent behavior in this repository is configured to read `/config/.agents/README.md` first, then follow references from that file.
 
 ## Continuous integration testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,24 +13,16 @@ also available in the TypeDoc documentation in the `slime.internal` namespace.
 
 ## Personal agent instructions in devcontainers
 
-Contributors can configure personal instructions for coding agents via files in the host path:
-
-* `local/docker/home/.agents`
-
-In the devcontainer, this host directory is mounted through `docker-compose.yaml` as:
-
-* Host `./local/docker/home` -> container `/config`
-
-So personal instructions are available in-container at:
-
-* `/config/.agents`
+Contributors can configure personal instructions for coding agents via files in the host path `local/agents`. In the devcontainer,
+this host directory is mounted through `docker-compose.yaml` as `/config/.agents`.
 
 Recommended setup:
 
-* Create `local/docker/home/.agents/README.md` as the primary entry point for your personal instructions
+* Create `README.md` in the personal agent location as the primary entry point for your personal instructions
 * Add one or more instruction files in the same directory and reference them from `README.md`
+* The VSCode task "Open my personal agent instructions" will bring these instructions up in the editor, if they exist.
 
-Agent behavior in this repository is configured to read `/config/.agents/README.md` first, then follow references from that file.
+Agent behavior in this repository is configured to read `README.md` from the instructions location first, then follow references from that file.
 
 ## Continuous integration testing
 

--- a/contributor/open-personal-agent-instructions.jsh.js
+++ b/contributor/open-personal-agent-instructions.jsh.js
@@ -15,10 +15,7 @@
 			$api.fp.pipe(
 				jsh.script.cli.option.string({ longname: "execPath" }),
 				function(p) {
-					var devcontainerHome = $api.fp.now(
-						jsh.shell.HOME.pathname.os.adapt(),
-						jsh.file.Location.directory.relativePath(".agents")
-					);
+					var devcontainerLocation = jsh.file.Location.from.os("/config/.agents");
 					var hostLocation = $api.fp.now(
 						jsh.script.world.file,
 						jsh.file.Location.parent(),
@@ -30,7 +27,7 @@
 						$api.fp.world.Means.effector()
 					);
 					var readmeLocations = {
-						devcontainer: $api.fp.now(devcontainerHome, jsh.file.Location.directory.relativePath("README.md")),
+						devcontainer: $api.fp.now(devcontainerLocation, jsh.file.Location.directory.relativePath("README.md")),
 						host: $api.fp.now(hostLocation, jsh.file.Location.directory.relativePath("README.md"))
 					};
 					var fileExists = jsh.file.Location.file.exists.simple;
@@ -38,7 +35,7 @@
 						function() {
 							if (fileExists(readmeLocations.host)) {
 								return {
-									program: p.options.execPath,
+									program: p.options.execPath || "code",
 									file: readmeLocations.host.pathname
 								};
 							} else if (fileExists(readmeLocations.devcontainer)) {

--- a/contributor/open-personal-agent-instructions.jsh.js
+++ b/contributor/open-personal-agent-instructions.jsh.js
@@ -1,0 +1,70 @@
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+//@ts-check
+(
+	/**
+	 * @param { slime.$api.Global } $api
+	 * @param { slime.jsh.Global } jsh
+	 */
+	function($api,jsh) {
+		jsh.script.cli.main(
+			$api.fp.pipe(
+				jsh.script.cli.option.string({ longname: "execPath" }),
+				function(p) {
+					var devcontainerHome = $api.fp.now(
+						jsh.shell.HOME.pathname.os.adapt(),
+						jsh.file.Location.directory.relativePath(".agents")
+					);
+					var hostLocation = $api.fp.now(
+						jsh.script.world.file,
+						jsh.file.Location.parent(),
+						jsh.file.Location.parent(),
+						jsh.file.Location.directory.relativePath("local/agents")
+					);
+					var run = $api.fp.now(
+						jsh.shell.subprocess.action,
+						$api.fp.world.Means.effector()
+					);
+					var readmeLocations = {
+						devcontainer: $api.fp.now(devcontainerHome, jsh.file.Location.directory.relativePath("README.md")),
+						host: $api.fp.now(hostLocation, jsh.file.Location.directory.relativePath("README.md"))
+					};
+					var fileExists = jsh.file.Location.file.exists.simple;
+					var locations = (
+						function() {
+							if (fileExists(readmeLocations.host)) {
+								return {
+									program: p.options.execPath,
+									file: readmeLocations.host.pathname
+								};
+							} else if (fileExists(readmeLocations.devcontainer)) {
+								return {
+									program: "code",
+									file: readmeLocations.devcontainer.pathname
+								};
+							} else {
+								return void(0);
+							}
+						}
+					)();
+					if (locations) {
+						run({
+							command: locations.program,
+							arguments: [locations.file]
+						});
+					} else {
+						jsh.shell.console("Did not find README.md for agents.");
+						jsh.shell.console("locations.host: " + readmeLocations.host.pathname);
+						jsh.shell.console("locations.devcontainer: " + readmeLocations.devcontainer.pathname);
+						jsh.shell.exit(1);
+					}
+				}
+			)
+		)
+	}
+//@ts-ignore
+)($api,jsh);

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,6 +33,9 @@ services:
       - type: bind
         source: ./local/docker/home
         target: /config
+      - type: bind
+        source: ./local/agents
+        target: /config/.agents
     ports:
       - 8000:8000
       - 3000:3000


### PR DESCRIPTION
## Summary
- mount `local/agents` into `/config/.agents` in the devcontainer
- add a VS Code task to open personal agent instructions
- add `contributor/open-personal-agent-instructions.jsh.js` to open the appropriate README
- update contributing docs for the new personal-instructions location and workflow

## Validation
- commit checks passed (ESLint, MPL headers, and TypeScript checks)

Refs #2413