### PR TITLE
Use plugin-provided jrunscript suite environment

### DIFF
--- a/contributor/jrunscript-engines.jsh.js
+++ b/contributor/jrunscript-engines.jsh.js
@@ -23,17 +23,9 @@
 
 		var environment = (
 			function() {
-				var Environment = (
-					function() {
-						/** @type { slime.project.internal.jrunscript_environment.Script } */
-						var script = jsh.script.loader.script("jrunscript-environment.js");
-						return script({
-							jsh: jsh
-						})
-					}
-				)();
+				jsh.loader.plugins(jsh.script.file.parent);
 
-				var environment = new Environment({
+				var environment = new jsh.project.suite.Environment({
 					src: jsh.script.file.parent.parent,
 					noselfping: false,
 					tomcat: true,

--- a/contributor/jrunscript-jsapi.jsh.js
+++ b/contributor/jrunscript-jsapi.jsh.js
@@ -65,17 +65,9 @@
 
 		(
 			function() {
-				var Environment = (
-					function() {
-						/** @type { slime.project.internal.jrunscript_environment.Script } */
-						var script = jsh.script.loader.script("jrunscript-environment.js");
-						return script({
-							jsh: jsh
-						})
-					}
-				)();
+				jsh.loader.plugins(jsh.script.file.parent);
 
-				var environment = new Environment({
+				var environment = new jsh.project.suite.Environment({
 					src: jsh.script.file.parent.parent,
 					home: parameters.options["shell:built"],
 					noselfping: parameters.options.noselfping,


### PR DESCRIPTION
## Summary
- replace manual loading of `jrunscript-environment.js` with plugin initialization via `jsh.loader.plugins(jsh.script.file.parent)` in contributor jrunscript scripts
- construct the environment directly from `jsh.project.suite.Environment`
- remove duplicated inline environment-loader boilerplate from both scripts

## Files changed
- contributor/jrunscript-engines.jsh.js
- contributor/jrunscript-jsapi.jsh.js

## Validation
- `./wf tsc --vscode`
- `./fifty test.jsh contributor/jrunscript-engines.jsh.fifty.ts`
- `./fifty test.jsh contributor/jrunscript.fifty.ts`