### PR TITLE
Issue #2397: Collapse browser Compose topology to a single local service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #	support any deployment use cases.
 
 FROM lscr.io/linuxserver/webtop:ubuntu-xfce
-RUN apt update && apt install -y git gh chromium chromium-sandbox curl socat ripgrep
+RUN apt update && apt install -y git gh chromium chromium-sandbox firefox curl socat ripgrep
 # Chromium in this container runtime needs sandbox-disabled flags to launch reliably.
 RUN mkdir -p /etc/chromium.d && printf '%s\n' \
 	'export CHROMIUM_FLAGS="$CHROMIUM_FLAGS --no-sandbox --disable-setuid-sandbox"' \

--- a/contributor/README.md
+++ b/contributor/README.md
@@ -74,12 +74,11 @@ command (plus any additional arguments) inside the container.
 
 The containerized browser tests can be run from within the devcontainer:
 
-* Restart browser-specific container in Docker
-* Ensure Selenium is installed by running `contributor/selenium-install.jsh.js`
+* Ensure you are in the `local` devcontainer service.
 * Run browser-specific Fifty tests:
-  * `./fifty test.browser --browser dockercompose:selenium:chrome contributor/browser.fifty.ts --interactive`
-  * `./fifty test.browser --browser dockercompose:selenium:firefox contributor/browser.fifty.ts --interactive`
-* Go to appropriate VNC port (see `../docker-compose.yaml`) using HTTP to get a VNC client and use `secret` as the password
+  * `./fifty test.browser --browser chrome contributor/browser.fifty.ts --interactive`
+  * `./fifty test.browser --browser firefox contributor/browser.fifty.ts --interactive`
+* Use the Webtop desktop on port 3000 to observe interactive browser runs.
 
 ### Test suite performance
 

--- a/contributor/suite-docker-browser.jsh.js
+++ b/contributor/suite-docker-browser.jsh.js
@@ -14,7 +14,7 @@
 		jsh.loader.plugins(jsh.script.file.parent);
 
 		jsh.project.suite.initialize({
-			selenium: true
+			selenium: false
 		});
 
 		if (!jsh.unit.browser) {
@@ -55,10 +55,8 @@
 
 		suite.add("browsers", new function() {
 			var browsers = $api.Array.build(function(rv) {
-				rv.push({ id: "dockercompose:selenium:chrome", name: "Chrome (Selenium)" });
-				//	TODO	need to debug why this didn't work:
-				//	TypeError: Cannot call method "start" of undefined
-				rv.push({ id: "dockercompose:selenium:firefox", name: "Firefox (Selenium)" });
+				rv.push({ id: "chrome", name: "Chrome" });
+				rv.push({ id: "firefox", name: "Firefox" });
 			});
 
 			this.name = "Browser tests";

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,8 +13,7 @@ services:
   # Also used by the devcontainer implementation.
   #
   # The primary user interface for the container is Webtop (HTTP on 3000 and HTTPS on 3001 in-container).
-  # The chrome and firefox services are still started so that the container can emulate the CI tests for debugging CI-only failures
-  # via the contributor/devcontainer/check script.
+  # Browser tests run from this service using local browser processes.
   local:
     build: .
     environment:
@@ -40,21 +39,6 @@ services:
       - 8000:8000
       - 3000:3000
       - 3001:3001
-    depends_on:
-      - chrome
-      - firefox
-
-  chrome:
-    image: selenium/standalone-chromium:149.0-20260606
-    shm_size: 2gb
-    ports:
-      - 7900:7900
-
-  firefox:
-    image: selenium/standalone-firefox:152.0-20260606
-    shm_size: 2gb
-    ports:
-      - 7901:7900
 
 volumes:
   local:

--- a/loader/api/old/jsh/plugin.jsh.browser.js
+++ b/loader/api/old/jsh/plugin.jsh.browser.js
@@ -439,8 +439,10 @@
 				var Firefox = function(configuration) {
 					var PROFILE = jsh.shell.TMPDIR.createTemporary({ directory: true });
 					return Browser({
-						program: configuration.program,
+						program: "/usr/bin/env",
 						arguments: $api.Array.build(function(rv) {
+							rv.push("HOME=" + PROFILE.toString());
+							rv.push(configuration.program);
 							rv.push("-no-remote");
 							rv.push("-profile", PROFILE.toString())
 						})

--- a/loader/api/old/jsh/plugin.jsh.browser.js
+++ b/loader/api/old/jsh/plugin.jsh.browser.js
@@ -438,11 +438,18 @@
 
 				var Firefox = function(configuration) {
 					var PROFILE = jsh.shell.TMPDIR.createTemporary({ directory: true });
+					var runHeadless = (function() {
+						if (jsh.shell.os.name != "Linux") return false;
+						if (jsh.shell.USER == "root") return true;
+						if (jsh.shell.environment.CI) return true;
+						return false;
+					})();
 					return Browser({
 						program: "/usr/bin/env",
 						arguments: $api.Array.build(function(rv) {
 							rv.push("HOME=" + PROFILE.toString());
 							rv.push(configuration.program);
+							if (runHeadless) rv.push("-headless");
 							rv.push("-no-remote");
 							rv.push("-profile", PROFILE.toString())
 						})

--- a/loader/browser/test/suite.jsh.js
+++ b/loader/browser/test/suite.jsh.js
@@ -256,6 +256,9 @@
 					if (parameters.options["chrome:debug:vscode"]) return 9222;
 				})();
 				var instance = (parameters.options["chrome:instance"]) || jsh.shell.TMPDIR.createTemporary({ directory: true }).pathname;
+				if (!jsh.shell.browser.installed.chrome) {
+					throw new Error("Chrome not installed; cannot run Chrome browser tests.");
+				}
 				return jshUnitBrowserToBrowser(
 					"Chrome",
 					$api.fp.identity,
@@ -269,10 +272,12 @@
 			}
 			if (argument == "firefox") {
 				var firefoxProgram = (function() {
+					var command = jsh.shell.PATH.getCommand("firefox") || jsh.shell.PATH.getCommand("firefox-esr");
+					if (command) return command.toString();
 					var linux = jsh.file.Pathname("/usr/bin/firefox").file;
-					if (linux) return linux;
+					if (linux) return linux.toString();
 					var macos = jsh.file.Pathname("/Applications/Firefox.app/Contents/MacOS/firefox").file;
-					if (macos) return macos;
+					if (macos) return macos.toString();
 				})();
 				if (!firefoxProgram) {
 					throw new Error("Firefox not installed; cannot run Firefox browser tests.");
@@ -281,7 +286,7 @@
 					"Firefox",
 					$api.fp.identity,
 					jsh.unit.browser.local.Firefox({
-						program: firefoxProgram.toString()
+						program: firefoxProgram
 					})
 				)
 			}

--- a/loader/browser/test/suite.jsh.js
+++ b/loader/browser/test/suite.jsh.js
@@ -268,13 +268,20 @@
 				)
 			}
 			if (argument == "firefox") {
+				var firefoxProgram = (function() {
+					var linux = jsh.file.Pathname("/usr/bin/firefox").file;
+					if (linux) return linux;
+					var macos = jsh.file.Pathname("/Applications/Firefox.app/Contents/MacOS/firefox").file;
+					if (macos) return macos;
+				})();
+				if (!firefoxProgram) {
+					throw new Error("Firefox not installed; cannot run Firefox browser tests.");
+				}
 				return jshUnitBrowserToBrowser(
 					"Firefox",
 					$api.fp.identity,
 					jsh.unit.browser.local.Firefox({
-						//	TODO	push knowledge of these locations back into rhino/shell
-						program: "/Applications/Firefox.app/Contents/MacOS/firefox"
-						//	Linux: /usr/bin/firefox
+						program: firefoxProgram.toString()
 					})
 				)
 			}

--- a/tools/fifty/test-browser.jsh.js
+++ b/tools/fifty/test-browser.jsh.js
@@ -164,11 +164,19 @@
 								throw new Error("Chrome not installed; cannot run Chrome browser tests.");
 							}
 						} else if (p.options.browser == "firefox") {
-							return jsh.unit.browser.local.Firefox({
-								//	TODO	push knowledge of these locations back into rhino/shell
-								program: "/Applications/Firefox.app/Contents/MacOS/firefox"
-								//	Linux: /usr/bin/firefox
-							});
+								var firefoxProgram = (function() {
+									var linux = jsh.file.Pathname("/usr/bin/firefox").file;
+									if (linux) return linux;
+									var macos = jsh.file.Pathname("/Applications/Firefox.app/Contents/MacOS/firefox").file;
+									if (macos) return macos;
+								})();
+								if (firefoxProgram) {
+									return jsh.unit.browser.local.Firefox({
+										program: firefoxProgram.toString()
+									});
+								} else {
+									throw new Error("Firefox not installed; cannot run Firefox browser tests.");
+								}
 						} else if (p.options.browser == "safari") {
 							return jsh.unit.browser.local.Safari();
 						} else if (p.options.browser == "selenium:chrome") {

--- a/tools/fifty/test-browser.jsh.js
+++ b/tools/fifty/test-browser.jsh.js
@@ -164,19 +164,21 @@
 								throw new Error("Chrome not installed; cannot run Chrome browser tests.");
 							}
 						} else if (p.options.browser == "firefox") {
-								var firefoxProgram = (function() {
-									var linux = jsh.file.Pathname("/usr/bin/firefox").file;
-									if (linux) return linux;
-									var macos = jsh.file.Pathname("/Applications/Firefox.app/Contents/MacOS/firefox").file;
-									if (macos) return macos;
-								})();
-								if (firefoxProgram) {
-									return jsh.unit.browser.local.Firefox({
-										program: firefoxProgram.toString()
-									});
-								} else {
-									throw new Error("Firefox not installed; cannot run Firefox browser tests.");
-								}
+							var firefoxProgram = (function() {
+								var command = jsh.shell.PATH.getCommand("firefox") || jsh.shell.PATH.getCommand("firefox-esr");
+								if (command) return command.toString();
+								var linux = jsh.file.Pathname("/usr/bin/firefox").file;
+								if (linux) return linux.toString();
+								var macos = jsh.file.Pathname("/Applications/Firefox.app/Contents/MacOS/firefox").file;
+								if (macos) return macos.toString();
+							})();
+							if (firefoxProgram) {
+								return jsh.unit.browser.local.Firefox({
+									program: firefoxProgram
+								});
+							} else {
+								throw new Error("Firefox not installed; cannot run Firefox browser tests.");
+							}
 						} else if (p.options.browser == "safari") {
 							return jsh.unit.browser.local.Safari();
 						} else if (p.options.browser == "selenium:chrome") {


### PR DESCRIPTION
Summary
- Implements issue #2397 by removing external Selenium browser services from the Compose topology and running browser tests from the main local service.
- Switches browser suite execution from dockercompose Selenium browser IDs to local Chrome and Firefox IDs.
- Updates Firefox launch logic to detect installed executables in Linux and macOS paths instead of relying on a hardcoded macOS location.
- Updates contributor docs to reflect the new local-browser workflow.

What changed
- Removed chrome and firefox services from Compose and removed local depends_on links to those services.
- Installed Firefox in the development image.
- Changed contributor browser suite initialization to run without Selenium setup.
- Updated browser selection in suite execution to use local chrome and firefox.
- Updated browser runner scripts to resolve Firefox executable path dynamically and fail with a clear message when not installed.
- Updated contributor browser test instructions for local execution.

Validation
- TypeScript check passed.
- Local Firefox browser test passed:
  - ./fifty test.browser --browser firefox contributor/browser.fifty.ts
  - Exit status 0
- Full browser suite passed:
  - ./jsh contributor/suite-docker-browser.jsh.js
  - Browser tests: PASSED
  - Tools/browser API checks: PASSED

Notes
- Browser runtime warnings related to DBus/EGL/sandbox appeared in container logs, but did not cause test failures.