### PR TITLE
Issue #2426: Fix test-browsers step label wording

### DIFF
--- a/.github/workflows/test-browsers.yaml
+++ b/.github/workflows/test-browsers.yaml
@@ -27,7 +27,7 @@ jobs:
           docker-images: true
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Use Docker to create image, and then run the linting and tests
+      - name: Use Docker to create image, and then run browser suite
         env:
           SLIME_TEST_NO_WF_SUBMODULE_RESET: 1
         run: contributor/suite-docker-browser


### PR DESCRIPTION
## Summary
- Rename the browser workflow step label to match the command it actually runs.

## Changes
- In `.github/workflows/test-browsers.yaml`, change:
  - `Use Docker to create image, and then run the linting and tests`
  - to `Use Docker to create image, and then run browser suite`

## Validation
- Repository pre-commit checks passed during commit (ESLint, license header check, and TypeScript).

Closes #2426
