### PR TITLE
Rename git credential helper's password export to credentials, adding username

### DIFF
--- a/rhino/tools/git/git-credential-tokens-directory.fifty.ts
+++ b/rhino/tools/git/git-credential-tokens-directory.fifty.ts
@@ -294,9 +294,11 @@ namespace slime.jrunscript.tools.git.credentials {
 					password({
 						operation: "get",
 						input: jsh.io.InputStream.string.default(
+							//	The input's username deliberately differs from the callback's returned username, so this test
+							//	proves the output username comes from the callback rather than merely echoing the input.
 							$api.Array.build(function(lines) {
 								lines.push("host=example.com");
-								lines.push("username=foo");
+								lines.push("username=input-username");
 							}).join("\n")
 						),
 						output: function(line) {
@@ -306,6 +308,7 @@ namespace slime.jrunscript.tools.git.credentials {
 					});
 
 					var result = parseOutput(output);
+					verify(result).evaluate.property("username").is("foo");
 					verify(result).evaluate.property("password").is("bar");
 					if (!output.endsWith("\n\n")) throw new Error("Expected credential helper output to end with a blank line.");
 				});

--- a/rhino/tools/git/git-credential-tokens-directory.fifty.ts
+++ b/rhino/tools/git/git-credential-tokens-directory.fifty.ts
@@ -91,8 +91,11 @@ namespace slime.jrunscript.tools.git.credentials {
 			>
 		}
 
-		password: (f:
-			(p: Data) => slime.$api.fp.Maybe<string>
+		credentials: (f:
+			(p: Data) => slime.$api.fp.Maybe<{
+				username: string
+				password: string
+			}>
 		) => (p: {
 			operation: Operation
 			input: slime.jrunscript.runtime.io.InputStream
@@ -278,9 +281,12 @@ namespace slime.jrunscript.tools.git.credentials {
 
 				fifty.run(function passwordGet() {
 					var output = "";
-					var password = forHelper.password(function(input) {
-						if (input.host == "example.com" && input.username == "foo") {
-							return $api.fp.Maybe.from.some("bar");
+					var password = forHelper.credentials(function(input) {
+						if (input.host == "example.com") {
+							return $api.fp.Maybe.from.some({
+								username: "foo",
+								password: "bar"
+							});
 						}
 						return $api.fp.Maybe.from.nothing();
 					});
@@ -306,8 +312,11 @@ namespace slime.jrunscript.tools.git.credentials {
 
 				fifty.run(function passwordNonGet() {
 					var output = "";
-					var password = forHelper.password(function() {
-						return $api.fp.Maybe.from.some("bar");
+					var password = forHelper.credentials(function() {
+						return $api.fp.Maybe.from.some({
+							username: "foo",
+							password: "bar"
+						});
 					});
 
 					password({

--- a/rhino/tools/git/git-credential-tokens-directory.js
+++ b/rhino/tools/git/git-credential-tokens-directory.js
@@ -211,15 +211,18 @@
 				location: getUserTokenLocation,
 				get: userGet
 			},
-			password: function(f) {
+			credentials: function(f) {
 				return function(p) {
 					var input = read({
 						debug: p.debug
 					})(p.input);
 					if (p.operation == "get") {
 						var output = $api.Object.compose(input);
-						var password = f(input)
-						if (password.present) output.password = password.value;
+						var credentials = f(input)
+						if (credentials.present) {
+							output.username = credentials.value.username;
+							output.password = credentials.value.password;
+						}
 						for (var x in output) {
 							if (typeof(output[x]) != "undefined") {
 								p.output(x + "=" + output[x]);


### PR DESCRIPTION
## Summary
- `credentials(f)` (formerly `password(f)`) now returns `Maybe<{ username, password }>` instead of just a password string, so a caller'''s callback can supply a per-path/per-org username alongside the token.

## Test plan
- [x] `./fifty test.jsh rhino/tools/git/git-credential-tokens-directory.fifty.ts` — all 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)