### PR TITLE
wf: remove credential helpers from git fetch invocation

### DIFF
--- a/tools/wf/plugin.jsh.js
+++ b/tools/wf/plugin.jsh.js
@@ -552,18 +552,12 @@
 				};
 
 				var fetch = $api.fp.impure.Input.memoized(function() {
-					var credentialHelper = jsh.shell.jsh.src.getFile("rhino/tools/git/git-credential-tokens-directory.bash").toString();
-
 					var repository = jsh.tools.git.oo.Repository({ directory: inputs.base() });
 					jsh.shell.console("Fetching all updates ...");
 					repository.fetch({
 						all: true,
 						prune: true,
-						recurseSubmodules: true,
-						credentialHelpers: [
-							"cache",
-							credentialHelper
-						]
+						recurseSubmodules: true
 					}, {
 						remote: function(e) {
 							var remote = e.detail;


### PR DESCRIPTION
## Summary
- Removes the `cache` and tokens-directory credential helpers from the `fetch` call in `tools/wf/plugin.jsh.js` — fetch doesn't need them in this context.

## Test plan
- [x] Local pre-commit checks (lint, license headers, TypeScript) passed