### PR TITLE
Resolve #2403: Add minimal URL polyfill in loader/polyfill.js

### DIFF
--- a/loader/polyfill.fifty.ts
+++ b/loader/polyfill.fifty.ts
@@ -130,6 +130,43 @@ interface Array<T> {
         const console = (fifty.global.jsh) ? fifty.global.jsh.shell.console : fifty.global.window["console"].log;
 
         fifty.tests.suite = function() {
+            var url = new URL("https://user:pass@example.com:8080/a/b?q=1#frag");
+            fifty.verify(url).protocol.is("https:");
+            fifty.verify(url).username.is("user");
+            fifty.verify(url).password.is("pass");
+            fifty.verify(url).host.is("example.com:8080");
+            fifty.verify(url).hostname.is("example.com");
+            fifty.verify(url).port.is("8080");
+            fifty.verify(url).pathname.is("/a/b");
+            fifty.verify(url).search.is("?q=1");
+            fifty.verify(url).hash.is("#frag");
+            fifty.verify(url).origin.is("https://example.com:8080");
+            fifty.verify(url).href.is("https://user:pass@example.com:8080/a/b?q=1#frag");
+            fifty.verify(url).evaluate(function(p) { return p.toString(); }).is("https://user:pass@example.com:8080/a/b?q=1#frag");
+
+            //  A URL with no explicit path is normalized to "/"
+            fifty.verify(new URL("https://example.com")).pathname.is("/");
+            fifty.verify(new URL("https://example.com")).href.is("https://example.com/");
+
+            //  Relative resolution against a base, per https://tools.ietf.org/html/rfc3986#section-5.3
+            var base = "https://example.com/a/b/c";
+            fifty.verify(new URL("../d", base)).href.is("https://example.com/a/d");
+            fifty.verify(new URL("/d", base)).href.is("https://example.com/d");
+            fifty.verify(new URL("?x=1", base)).href.is("https://example.com/a/b/c?x=1");
+            fifty.verify(new URL("#section", base)).href.is("https://example.com/a/b/c#section");
+            fifty.verify(new URL("//other.example.com/d", base)).href.is("https://other.example.com/d");
+
+            //  Setters re-serialize `href`
+            var mutable = new URL("https://example.com/a");
+            mutable.pathname = "/b";
+            mutable.search = "x=1";
+            mutable.hash = "y";
+            fifty.verify(mutable).href.is("https://example.com/b?x=1#y");
+
+            //  A URL with neither an explicit scheme nor a base is invalid
+            fifty.verify(0).evaluate(function() {
+                return new URL("/a/b");
+            }).threw.type(TypeError);
         }
 
         fifty.tests.manual = {};
@@ -160,7 +197,6 @@ interface Array<T> {
 
             //  Methods not polyfilled yet, so we log the implementations by directly accessing properties of the global object.
             var global = (function() { return this; })();
-            //  Will be polyfilled; see issue #2403.
             console("URL: " + global.URL);
         }
     }

--- a/loader/polyfill.fifty.ts
+++ b/loader/polyfill.fifty.ts
@@ -148,7 +148,7 @@ interface Array<T> {
             fifty.verify(new URL("https://example.com")).pathname.is("/");
             fifty.verify(new URL("https://example.com")).href.is("https://example.com/");
 
-            //  Relative resolution against a base, per https://tools.ietf.org/html/rfc3986#section-5.3
+            //  Relative resolution against a base, per https://tools.ietf.org/html/rfc3986#section-5.2.2
             var base = "https://example.com/a/b/c";
             fifty.verify(new URL("../d", base)).href.is("https://example.com/a/d");
             fifty.verify(new URL("/d", base)).href.is("https://example.com/d");
@@ -162,6 +162,20 @@ interface Array<T> {
             mutable.search = "x=1";
             mutable.hash = "y";
             fifty.verify(mutable).href.is("https://example.com/b?x=1#y");
+
+            //  `host` setter: the hostname portion is always applied; the port portion is applied only when it is
+            //  present and consists entirely of digits, and otherwise the existing port is left unchanged.
+            var hostWithoutPort = new URL("https://example.com:8080/a");
+            hostWithoutPort.host = "other.example.com";
+            fifty.verify(hostWithoutPort).href.is("https://other.example.com:8080/a");
+
+            var hostWithPort = new URL("https://example.com:8080/a");
+            hostWithPort.host = "other.example.com:9090";
+            fifty.verify(hostWithPort).href.is("https://other.example.com:9090/a");
+
+            var hostWithInvalidPort = new URL("https://example.com:8080/a");
+            hostWithInvalidPort.host = "other.example.com:notaport";
+            fifty.verify(hostWithInvalidPort).href.is("https://other.example.com:8080/a");
 
             //  A URL with neither an explicit scheme nor a base is invalid
             fifty.verify(0).evaluate(function() {

--- a/loader/polyfill.js
+++ b/loader/polyfill.js
@@ -183,6 +183,285 @@
 
 			global.Map = Map;
 		}
+
+		if (!global.URL) {
+			//	A minimal polyfill for the `URL` interface defined by the WHATWG URL Standard
+			//	(https://url.spec.whatwg.org/#url). See issue #2403.
+			//
+			//	Intentional limitations, to keep this polyfill small (see issue #2403 for rationale):
+			//	*	Parsing uses a single regular expression based on the generic URI syntax in RFC 3986, rather than the
+			//		specification's state-machine algorithm. It does not implement special-casing for "special schemes" (http,
+			//		https, file, etc.), IDNA/percent-encoding normalization, or validation of most malformed input; it will
+			//		accept many strings the specification would reject, and will not encode/normalize most inputs the way a
+			//		native implementation would.
+			//	*	`searchParams` (the live `URLSearchParams` view of `search`) is not implemented.
+			//	*	Dot-segment (`.` / `..`) removal in paths uses a simple segment-based algorithm, adapted from the one in
+			//		`js/web/module.js`, rather than the specification's buffer-based algorithm, and may disagree with it on
+			//		edge cases (e.g., trailing slashes).
+
+			var URL_PATTERN = /^(?:([a-zA-Z][a-zA-Z0-9+.-]*):)?(\/\/(?:([^:@\/?#]*)(?::([^@\/?#]*))?@)?([^:\/?#]*)(?::(\d*))?)?([^?#]*)(\?[^#]*)?(#.*)?$/;
+
+			var parseUrl = function(string) {
+				var match = URL_PATTERN.exec(string);
+				return {
+					scheme: match[1] || "",
+					hasAuthority: Boolean(match[2]),
+					username: match[3] || "",
+					password: match[4] || "",
+					hostname: match[5] || "",
+					port: match[6] || "",
+					pathname: match[7] || "",
+					search: match[8] || "",
+					hash: match[9] || ""
+				};
+			};
+
+			//	Adapted from the algorithm of the same name in js/web/module.js
+			var removeDotSegments = function(path) {
+				var tokens = path.split("/");
+				var rv = [];
+				for (var i=0; i<tokens.length; i++) {
+					if (tokens[i] == ".") {
+						//	no replacement, just remove
+					} else if (tokens[i] == "..") {
+						rv.splice(rv.length-1,1);
+					} else {
+						rv.push(tokens[i]);
+					}
+				}
+				return rv.join("/");
+			};
+
+			var mergePaths = function(base,relativePath) {
+				if (base.hasAuthority && base.pathname == "") return "/" + relativePath;
+				var dir = base.pathname.substring(0,base.pathname.lastIndexOf("/")+1);
+				return dir + relativePath;
+			};
+
+			//	See https://tools.ietf.org/html/rfc3986#section-5.3, adapted to this file's property names
+			var resolveUrl = function(base,reference) {
+				var rv = {};
+				if (reference.scheme) {
+					rv.scheme = reference.scheme;
+					rv.hasAuthority = reference.hasAuthority;
+					rv.username = reference.username;
+					rv.password = reference.password;
+					rv.hostname = reference.hostname;
+					rv.port = reference.port;
+					rv.pathname = removeDotSegments(reference.pathname);
+					rv.search = reference.search;
+				} else if (reference.hasAuthority) {
+					rv.scheme = base.scheme;
+					rv.hasAuthority = true;
+					rv.username = reference.username;
+					rv.password = reference.password;
+					rv.hostname = reference.hostname;
+					rv.port = reference.port;
+					rv.pathname = removeDotSegments(reference.pathname);
+					rv.search = reference.search;
+				} else {
+					rv.scheme = base.scheme;
+					rv.hasAuthority = base.hasAuthority;
+					rv.username = base.username;
+					rv.password = base.password;
+					rv.hostname = base.hostname;
+					rv.port = base.port;
+					if (reference.pathname == "") {
+						rv.pathname = base.pathname;
+						rv.search = reference.search || base.search;
+					} else if (reference.pathname.charAt(0) == "/") {
+						rv.pathname = removeDotSegments(reference.pathname);
+						rv.search = reference.search;
+					} else {
+						rv.pathname = removeDotSegments(mergePaths(base,reference.pathname));
+						rv.search = reference.search;
+					}
+				}
+				rv.hash = reference.hash;
+				return rv;
+			};
+
+			var normalizeUrl = function(components) {
+				if (components.hasAuthority && components.pathname == "") {
+					components.pathname = "/";
+				}
+				return components;
+			};
+
+			var serializeUrl = function(components) {
+				var rv = components.scheme + ":";
+				if (components.hasAuthority) {
+					rv += "//";
+					if (components.username) {
+						rv += components.username;
+						if (components.password) rv += ":" + components.password;
+						rv += "@";
+					}
+					rv += components.hostname;
+					if (components.port) rv += ":" + components.port;
+				}
+				rv += components.pathname + components.search + components.hash;
+				return rv;
+			};
+
+			function URL(url,base) {
+				var reference = parseUrl(String(url));
+				var resolved;
+				if (typeof(base) != "undefined") {
+					var baseComponents = parseUrl(String(base));
+					if (!baseComponents.scheme) throw new TypeError("Invalid base URL: " + base);
+					resolved = resolveUrl(normalizeUrl(baseComponents),reference);
+				} else {
+					if (!reference.scheme) throw new TypeError("Invalid URL: " + url);
+					resolved = reference;
+				}
+				this._url = normalizeUrl(resolved);
+			}
+
+			Object.defineProperty(URL.prototype, "href", {
+				get: function() {
+					return serializeUrl(this._url);
+				},
+				set: function(value) {
+					var reference = parseUrl(String(value));
+					if (!reference.scheme) throw new TypeError("Invalid URL: " + value);
+					this._url = normalizeUrl(reference);
+				},
+				configurable: true,
+				enumerable: true
+			});
+
+			Object.defineProperty(URL.prototype, "protocol", {
+				get: function() {
+					return this._url.scheme + ":";
+				},
+				set: function(value) {
+					var string = String(value);
+					var scheme = (string.charAt(string.length-1) == ":") ? string.substring(0,string.length-1) : string;
+					if (/^[a-zA-Z][a-zA-Z0-9+.-]*$/.test(scheme)) this._url.scheme = scheme;
+				},
+				configurable: true,
+				enumerable: true
+			});
+
+			Object.defineProperty(URL.prototype, "username", {
+				get: function() {
+					return this._url.username;
+				},
+				set: function(value) {
+					this._url.username = String(value);
+				},
+				configurable: true,
+				enumerable: true
+			});
+
+			Object.defineProperty(URL.prototype, "password", {
+				get: function() {
+					return this._url.password;
+				},
+				set: function(value) {
+					this._url.password = String(value);
+				},
+				configurable: true,
+				enumerable: true
+			});
+
+			Object.defineProperty(URL.prototype, "host", {
+				get: function() {
+					return this._url.hostname + ((this._url.port) ? ":" + this._url.port : "");
+				},
+				set: function(value) {
+					var string = String(value);
+					var index = string.lastIndexOf(":");
+					if (index == -1) {
+						this._url.hostname = string;
+					} else {
+						this._url.hostname = string.substring(0,index);
+						this._url.port = string.substring(index+1);
+					}
+				},
+				configurable: true,
+				enumerable: true
+			});
+
+			Object.defineProperty(URL.prototype, "hostname", {
+				get: function() {
+					return this._url.hostname;
+				},
+				set: function(value) {
+					this._url.hostname = String(value);
+				},
+				configurable: true,
+				enumerable: true
+			});
+
+			Object.defineProperty(URL.prototype, "port", {
+				get: function() {
+					return this._url.port;
+				},
+				set: function(value) {
+					var string = String(value);
+					if (/^\d*$/.test(string)) this._url.port = string;
+				},
+				configurable: true,
+				enumerable: true
+			});
+
+			Object.defineProperty(URL.prototype, "pathname", {
+				get: function() {
+					return this._url.pathname;
+				},
+				set: function(value) {
+					var string = String(value);
+					this._url.pathname = (this._url.hasAuthority && string.charAt(0) != "/") ? "/" + string : string;
+				},
+				configurable: true,
+				enumerable: true
+			});
+
+			Object.defineProperty(URL.prototype, "search", {
+				get: function() {
+					return this._url.search;
+				},
+				set: function(value) {
+					var string = String(value);
+					this._url.search = (string == "" || string.charAt(0) == "?") ? string : "?" + string;
+				},
+				configurable: true,
+				enumerable: true
+			});
+
+			Object.defineProperty(URL.prototype, "hash", {
+				get: function() {
+					return this._url.hash;
+				},
+				set: function(value) {
+					var string = String(value);
+					this._url.hash = (string == "" || string.charAt(0) == "#") ? string : "#" + string;
+				},
+				configurable: true,
+				enumerable: true
+			});
+
+			Object.defineProperty(URL.prototype, "origin", {
+				get: function() {
+					if (!this._url.hasAuthority) return "null";
+					return this._url.scheme + "://" + this._url.hostname + ((this._url.port) ? ":" + this._url.port : "");
+				},
+				configurable: true,
+				enumerable: true
+			});
+
+			URL.prototype.toString = function() {
+				return this.href;
+			};
+
+			URL.prototype.toJSON = function() {
+				return this.href;
+			};
+
+			global.URL = URL;
+		}
 	}
 //@ts-ignore
 )();

--- a/loader/polyfill.js
+++ b/loader/polyfill.js
@@ -464,7 +464,16 @@
 				return this.href;
 			};
 
-			global.URL = URL;
+			if (Object.defineProperty) {
+				Object.defineProperty(global, "URL", {
+					value: URL,
+					writable: true,
+					configurable: true,
+					enumerable: false
+				});
+			} else {
+				global.URL = URL;
+			}
 		}
 	}
 //@ts-ignore

--- a/loader/polyfill.js
+++ b/loader/polyfill.js
@@ -238,7 +238,7 @@
 				return dir + relativePath;
 			};
 
-			//	See https://tools.ietf.org/html/rfc3986#section-5.3, adapted to this file's property names
+			//	See https://tools.ietf.org/html/rfc3986#section-5.2.2, adapted to this file's property names
 			var resolveUrl = function(base,reference) {
 				var rv = {};
 				if (reference.scheme) {
@@ -371,13 +371,17 @@
 					return this._url.hostname + ((this._url.port) ? ":" + this._url.port : "");
 				},
 				set: function(value) {
+					//	Matches observed native behavior: the hostname portion is always applied; the port portion (if any)
+					//	is applied only if it consists entirely of digits, and is otherwise left unchanged (an absent or
+					//	empty port portion, e.g. "host" or "host:", also leaves the existing port unchanged).
 					var string = String(value);
 					var index = string.lastIndexOf(":");
 					if (index == -1) {
 						this._url.hostname = string;
 					} else {
 						this._url.hostname = string.substring(0,index);
-						this._url.port = string.substring(index+1);
+						var port = string.substring(index+1);
+						if (/^\d+$/.test(port)) this._url.port = port;
 					}
 				},
 				configurable: true,


### PR DESCRIPTION
## Summary
- Adds a small, host-agnostic polyfill for the WHATWG URL Standard's `URL` interface to `loader/polyfill.js`, following the pattern of the existing polyfills in that file (feature-detected via `if (!global.URL)`).
- Parsing/resolution use a regex-based RFC 3986 generic-syntax approach (similar to the hand-written parser already in `js/web/module.js`) rather than the specification's state machine, keeping the implementation small. Intentional limitations (no `searchParams`, simplified dot-segment removal, no special-scheme handling) are documented in code comments.
- Adds test coverage in `loader/polyfill.fifty.ts` covering parsing of all URL components, `origin`/`href`/`toString`, relative-URL resolution against a base, property setters, and the `TypeError` thrown for an invalid URL with no base.

Fixes #2403

## Test plan
- [x] `./fifty test.jsh loader/polyfill.fifty.ts` passes (exercises the polyfill under jsh/Rhino, where native `URL` is absent)
- [x] `./fifty test.browser loader/polyfill.fifty.ts` passes (exercises the same tests against a browser's native `URL`, confirming the polyfill's behavior matches spec)
- [x] `./wf tsc` passes