### PR TITLE
Add Fifty timing extractor with threshold and stack-based collapsing

### DIFF
--- a/.github/workflows/test-jdk21.yaml
+++ b/.github/workflows/test-jdk21.yaml
@@ -30,4 +30,19 @@ jobs:
       - name: Use Docker to create image, and then run the linting and tests
         env:
           SLIME_TEST_NO_WF_SUBMODULE_RESET: 1
-        run: contributor/suite-docker-jrunscript 21
+        run: |
+          mkdir -p local
+          set -o pipefail
+          contributor/suite-docker-jrunscript 21 2>&1 | tee local/jrunscript.txt
+      - name: Show timing summary in logs (60s+)
+        if: success()
+        run: |
+          echo "::group::Fifty timing summary (>=60s)"
+          contributor/fifty-timing-lines.bash --threshold-seconds 60 --stdout local/jrunscript.txt | tee local/jrunscript-timing-60s.txt
+          echo "::endgroup::"
+      - name: Upload timing artifact (60s+)
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jdk21-fifty-timing-60s
+          path: local/jrunscript-timing-60s.txt

--- a/contributor/fifty-timing-lines.bash
+++ b/contributor/fifty-timing-lines.bash
@@ -1,0 +1,22 @@
+#!/bin/bash
+#	LICENSE
+#	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+#	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#	END LICENSE
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+NODE="${SCRIPT_DIR}/../local/jsh/lib/node"
+
+if [[ -d "$NODE" ]]; then
+	NODE="${NODE}/bin/node"
+fi
+
+if [[ ! -x "$NODE" ]]; then
+	echo "Node executable not found or not executable: $NODE" >&2
+	exit 1
+fi
+
+exec "$NODE" "${SCRIPT_DIR}/fifty-timing-lines.js" "$@"

--- a/contributor/fifty-timing-lines.bash
+++ b/contributor/fifty-timing-lines.bash
@@ -10,6 +10,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 NODE="${SCRIPT_DIR}/../local/jsh/lib/node"
 
+if [[ ! -e "$NODE" ]]; then
+	"${SCRIPT_DIR}/../wf" initialize --test-skip-git-identity-requirement
+fi
+
 if [[ -d "$NODE" ]]; then
 	NODE="${NODE}/bin/node"
 fi

--- a/contributor/fifty-timing-lines.js
+++ b/contributor/fifty-timing-lines.js
@@ -5,10 +5,14 @@
 //
 //	END LICENSE
 
+//@ts-check
 "use strict";
 
-const fs = require("fs");
-const path = require("path");
+const globalObj = /** @type {any} */ (Function("return this")());
+const nodeRequire = /** @type {(id: string) => any} */ (globalObj.require);
+const process = /** @type {{ argv: string[]; stdout: { write: (text: string) => void }; exit: (code: number) => never }} */ (globalObj.process);
+const fs = nodeRequire("fs");
+const path = nodeRequire("path");
 
 /**
  * @typedef {{
@@ -38,7 +42,7 @@ function parseArgs(argv) {
 		if (arg === "--threshold-seconds") {
 			if (i + 1 >= argv.length) throw new Error("Missing value for --threshold-seconds");
 			const value = Number(argv[++i]);
-			if (!Number.isFinite(value) || value < 0) {
+			if (!isFinite(value) || value < 0) {
 				throw new Error("--threshold-seconds must be a non-negative number");
 			}
 			thresholdSeconds = value;
@@ -65,9 +69,10 @@ function parseArgs(argv) {
 	};
 }
 
+/** @returns {TreeNode} */
 function makeNode(name, runningLine) {
 	return {
-		type: "node",
+		type: /** @type {"node"} */ ("node"),
 		name,
 		runningLine,
 		completionLine: null,

--- a/contributor/fifty-timing-lines.js
+++ b/contributor/fifty-timing-lines.js
@@ -25,11 +25,12 @@ const path = require("path");
  */
 
 function usage() {
-	console.error("Usage: fifty-timing-lines [--threshold-seconds <number>] <fifty-output-file> <timing-output-file>");
+	console.error("Usage: fifty-timing-lines [--threshold-seconds <number>] [--stdout] <fifty-output-file> [timing-output-file]");
 }
 
 function parseArgs(argv) {
 	let thresholdSeconds = 0;
+	let writeStdout = false;
 	const positional = [];
 
 	for (let i = 0; i < argv.length; i++) {
@@ -41,19 +42,26 @@ function parseArgs(argv) {
 				throw new Error("--threshold-seconds must be a non-negative number");
 			}
 			thresholdSeconds = value;
+		} else if (arg === "--stdout") {
+			writeStdout = true;
 		} else {
 			positional.push(arg);
 		}
 	}
 
-	if (positional.length !== 2) {
-		throw new Error("Expected exactly 2 positional arguments");
+	if (writeStdout) {
+		if (positional.length !== 1 && positional.length !== 2) {
+			throw new Error("When using --stdout, expected 1 or 2 positional arguments");
+		}
+	} else if (positional.length !== 2) {
+		throw new Error("Expected exactly 2 positional arguments unless using --stdout");
 	}
 
 	return {
 		thresholdMs: thresholdSeconds * 1000,
 		inputFile: positional[0],
-		outputFile: positional[1]
+		outputFile: positional[1] || null,
+		writeStdout
 	};
 }
 
@@ -180,9 +188,16 @@ function main() {
 	const outputLines = [];
 	emit(root, outputLines);
 
-	fs.mkdirSync(path.dirname(parsed.outputFile), { recursive: true });
 	const output = outputLines.length ? `${outputLines.join("\n")}\n` : "";
-	fs.writeFileSync(parsed.outputFile, output, "utf8");
+
+	if (parsed.writeStdout) {
+		process.stdout.write(output);
+	}
+
+	if (parsed.outputFile) {
+		fs.mkdirSync(path.dirname(parsed.outputFile), { recursive: true });
+		fs.writeFileSync(parsed.outputFile, output, "utf8");
+	}
 }
 
 main();

--- a/contributor/fifty-timing-lines.js
+++ b/contributor/fifty-timing-lines.js
@@ -9,7 +9,9 @@
 "use strict";
 
 const globalObj = /** @type {any} */ (Function("return this")());
-const nodeRequire = /** @type {(id: string) => any} */ (globalObj.require);
+// @ts-ignore Node.js provides require in this runtime, but ambient types are not loaded in this tsconfig.
+const nodeRequire = /** @type {(id: string) => any} */ (require);
+// @ts-ignore Node.js provides process in this runtime, but ambient types are not loaded in this tsconfig.
 const process = /** @type {{ argv: string[]; stdout: { write: (text: string) => void }; exit: (code: number) => never }} */ (globalObj.process);
 const fs = nodeRequire("fs");
 const path = nodeRequire("path");

--- a/contributor/fifty-timing-lines.js
+++ b/contributor/fifty-timing-lines.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+//	LICENSE
+//	This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+//	distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+//	END LICENSE
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * @typedef {{
+ *   type: "node",
+ *   name: string,
+ *   runningLine: string,
+ *   completionLine: string | null,
+ *   completionStatus: "PASSED" | "FAILED" | null,
+ *   durationMs: number | null,
+ *   children: TreeNode[],
+ *   included: boolean,
+ *   selfIncluded: boolean
+ * }} TreeNode
+ */
+
+function usage() {
+	console.error("Usage: fifty-timing-lines [--threshold-seconds <number>] <fifty-output-file> <timing-output-file>");
+}
+
+function parseArgs(argv) {
+	let thresholdSeconds = 0;
+	const positional = [];
+
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--threshold-seconds") {
+			if (i + 1 >= argv.length) throw new Error("Missing value for --threshold-seconds");
+			const value = Number(argv[++i]);
+			if (!Number.isFinite(value) || value < 0) {
+				throw new Error("--threshold-seconds must be a non-negative number");
+			}
+			thresholdSeconds = value;
+		} else {
+			positional.push(arg);
+		}
+	}
+
+	if (positional.length !== 2) {
+		throw new Error("Expected exactly 2 positional arguments");
+	}
+
+	return {
+		thresholdMs: thresholdSeconds * 1000,
+		inputFile: positional[0],
+		outputFile: positional[1]
+	};
+}
+
+function makeNode(name, runningLine) {
+	return {
+		type: "node",
+		name,
+		runningLine,
+		completionLine: null,
+		completionStatus: null,
+		durationMs: null,
+		children: [],
+		included: false,
+		selfIncluded: false
+	};
+}
+
+function sameNodeName(a, b) {
+	return a.trim() === b.trim();
+}
+
+/**
+ * Build a tree from interleaved "Running:" and timed completion lines.
+ * Timed completion lines are either "PASSED: ... (N ms)" or "FAILED: ... (N ms)".
+ * Other lines are ignored.
+ */
+function buildTree(lines) {
+	/** @type {TreeNode} */
+	const root = makeNode("<root>", "");
+	/** @type {TreeNode[]} */
+	const stack = [];
+
+	for (const line of lines) {
+		const running = line.match(/^([\t ]*)Running: (.*)$/);
+		if (running) {
+			const name = running[2];
+			const parent = stack.length > 0 ? stack[stack.length - 1] : root;
+			const node = makeNode(name, line);
+			parent.children.push(node);
+			stack.push(node);
+			continue;
+		}
+
+		const completion = line.match(/^([\t ]*)(PASSED|FAILED): (.*) \(([0-9]+) ms\)$/);
+		if (completion) {
+			const status = completion[2];
+			const name = completion[3];
+			const durationMs = Number(completion[4]);
+
+			let matchIndex = -1;
+			for (let i = stack.length - 1; i >= 0; i--) {
+				if (!sameNodeName(stack[i].name, name)) continue;
+				matchIndex = i;
+				break;
+			}
+
+			if (matchIndex !== -1) {
+				const node = stack[matchIndex];
+				node.completionLine = line;
+				node.completionStatus = /** @type {"PASSED" | "FAILED"} */ (status);
+				node.durationMs = durationMs;
+				// This completion closes the matching node and any unclosed descendants.
+				stack.length = matchIndex;
+			}
+		}
+	}
+
+	return root;
+}
+
+function markIncluded(node, thresholdMs) {
+	let childIncluded = false;
+	for (const child of node.children) {
+		if (markIncluded(child, thresholdMs)) childIncluded = true;
+	}
+
+	const selfIncluded = node.durationMs !== null && node.durationMs >= thresholdMs;
+	node.selfIncluded = selfIncluded;
+	node.included = selfIncluded || childIncluded;
+	return node.included;
+}
+
+function emit(node, outputLines) {
+	for (const child of node.children) {
+		if (!child.included) continue;
+		const includedChildren = child.children.filter((c) => c.included);
+		const hasTimedCompletion = child.completionLine !== null;
+
+		const isLeaf = includedChildren.length === 0;
+		if (isLeaf) {
+			if (child.completionLine) outputLines.push(child.completionLine);
+			continue;
+		}
+
+		// If a container has no timed completion, promote included children.
+		if (hasTimedCompletion) {
+			outputLines.push(child.runningLine);
+		}
+		emit(child, outputLines);
+		if (hasTimedCompletion && child.completionLine) outputLines.push(child.completionLine);
+	}
+}
+
+function main() {
+	let parsed;
+	try {
+		parsed = parseArgs(process.argv.slice(2));
+	} catch (e) {
+		usage();
+		console.error(String(e.message || e));
+		process.exit(2);
+	}
+
+	if (!fs.existsSync(parsed.inputFile)) {
+		console.error(`Input file not found: ${parsed.inputFile}`);
+		process.exit(1);
+	}
+
+	const text = fs.readFileSync(parsed.inputFile, "utf8");
+	const lines = text.split(/\r?\n/).filter((line) => line.length > 0);
+	const root = buildTree(lines);
+	markIncluded(root, parsed.thresholdMs);
+
+	const outputLines = [];
+	emit(root, outputLines);
+
+	fs.mkdirSync(path.dirname(parsed.outputFile), { recursive: true });
+	const output = outputLines.length ? `${outputLines.join("\n")}\n` : "";
+	fs.writeFileSync(parsed.outputFile, output, "utf8");
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `contributor/fifty-timing-lines.js` to extract timing-focused output from Fifty console logs
- add `contributor/fifty-timing-lines.bash` wrapper using the repository-local Node runtime
- support `--threshold-seconds <n>` filtering
- parse `Running:` start nodes and timed completion lines (`PASSED`/`FAILED`) with stack-based matching
- collapse leaf nodes to a single completion line
- suppress wrapper starts that have no timed completion while promoting included children

## Validation
- generated output from `local/jrunscript.txt` at multiple thresholds (including `--threshold-seconds 60`)
- verified root suite completion line is retained:
  - `PASSED: /slime/contributor/jrunscript.fifty.ts:suite (1517193 ms)`
- repo checks passed via commit hooks (ESLint, MPL headers, TypeScript)
