### PR TITLE
Add RFC3339 codec support for time values

### DIFF
--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -152,11 +152,16 @@ namespace slime.time {
 		Date: date.Exports
 	}
 
+	export interface Exports {
+		Time: time.Exports
+	}
+
 	(
 		function(
 			fifty: slime.fifty.test.Kit
 		) {
 			fifty.tests.exports.Date = fifty.test.Parent();
+			fifty.tests.exports.Time = fifty.test.Parent();
 		}
 	//@ts-ignore
 	)(fifty);
@@ -666,6 +671,58 @@ namespace slime.time {
 		export interface Exports {
 			month: (date: slime.time.Date) => slime.time.Month
 		}
+	}
+
+	export namespace time {
+		export interface Exports {
+			codec: {
+				rfc3339: () => slime.Codec<slime.time.Time, string>
+			}
+		}
+
+		(
+			function(
+				fifty: slime.fifty.test.Kit
+			) {
+				const { verify } = fifty;
+
+				fifty.tests.exports.Time.codec = fifty.test.Parent();
+				fifty.tests.exports.Time.codec.rfc3339 = function() {
+					var codec = test.subject.Time.codec.rfc3339();
+
+					verify(codec.encode({ hour: 7, minute: 8, second: 9 })).is("07:08:09");
+
+					var decoded = codec.decode("07:08:09");
+					verify(decoded).hour.is(7);
+					verify(decoded).minute.is(8);
+					verify(decoded).second.is(9);
+
+					var fractional = codec.decode("07:08:09.123456789");
+					verify(fractional).hour.is(7);
+					verify(fractional).minute.is(8);
+					verify(fractional).second.is(9.123456789);
+
+					verify(codec.encode(fractional)).is("07:08:09.123456789");
+
+					var missingSecondsRejected = false;
+					try {
+						codec.decode("07:08");
+					} catch (e) {
+						missingSecondsRejected = true;
+					}
+					verify(missingSecondsRejected).is(true);
+
+					var invalidSecondRejected = false;
+					try {
+						codec.decode("07:08:60");
+					} catch (e) {
+						invalidSecondRejected = true;
+					}
+					verify(invalidSecondRejected).is(true);
+				}
+			}
+		//@ts-ignore
+		)(fifty);
 	}
 
 	export interface Exports {

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -704,6 +704,15 @@ namespace slime.time {
 
 					verify(codec.encode(fractional)).is("07:08:09.123456789");
 
+					var tinyFraction = codec.decode("00:00:00.000000001");
+					verify(tinyFraction).hour.is(0);
+					verify(tinyFraction).minute.is(0);
+					verify(tinyFraction).second.is(0.000000001);
+					verify(codec.encode(tinyFraction)).is("00:00:00.000000001");
+
+					var trailingZeros = codec.decode("07:08:09.1200");
+					verify(codec.encode(trailingZeros)).is("07:08:09.1200");
+
 					var missingSecondsRejected = false;
 					try {
 						codec.decode("07:08");

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -780,6 +780,39 @@
 				});
 			}
 		}
+		Time.codec.rfc3339 = function() {
+			return {
+				encode: function(time) {
+					var hour = time && time.hour;
+					var minute = time && time.minute;
+					var second = time && time.second;
+					if (!isInteger(hour) || hour < 0 || hour > 23) throw rfc3339Error(String(time));
+					if (!isInteger(minute) || minute < 0 || minute > 59) throw rfc3339Error(String(time));
+					if (typeof(second) != "number" || !isFinite(second) || second < 0 || second >= 60) throw rfc3339Error(String(time));
+					var secondString = String(second);
+					if (secondString.indexOf(".") == -1) {
+						return rfc3339Pad(hour,2) + ":" + rfc3339Pad(minute,2) + ":" + rfc3339Pad(second,2);
+					}
+					var split = secondString.split(".");
+					return rfc3339Pad(hour,2) + ":" + rfc3339Pad(minute,2) + ":" + rfc3339Pad(split[0],2) + "." + split[1];
+				},
+				decode: function(string) {
+					var parsed = /^(\d{2})\:(\d{2})\:(\d{2})(?:\.(\d+))?$/.exec(string);
+					if (!parsed) throw rfc3339Error(string);
+					var hour = Number(parsed[1]);
+					var minute = Number(parsed[2]);
+					var second = Number(parsed[3]) + ((parsed[4]) ? Number("0." + parsed[4]) : 0);
+					if (!isInteger(hour) || hour < 0 || hour > 23) throw rfc3339Error(string);
+					if (!isInteger(minute) || minute < 0 || minute > 59) throw rfc3339Error(string);
+					if (typeof(second) != "number" || !isFinite(second) || second < 0 || second >= 60) throw rfc3339Error(string);
+					return {
+						hour: hour,
+						minute: minute,
+						second: second
+					};
+				}
+			}
+		}
 
 		function When() {
 			var date;

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -781,6 +781,56 @@
 			}
 		}
 		Time.codec.rfc3339 = function() {
+			var decodeFractionProperty = "__slimeTimeRFC3339Fraction";
+			var decodeWholeSecondProperty = "__slimeTimeRFC3339WholeSecond";
+
+			var expandExponential = function(string) {
+				var parsed = /^(-?)(\d+)(?:\.(\d+))?e([+-]\d+)$/i.exec(string);
+				if (!parsed) return string;
+				var sign = parsed[1];
+				var integer = parsed[2];
+				var fraction = parsed[3] || "";
+				var exponent = Number(parsed[4]);
+				var digits = integer + fraction;
+				var decimalIndex = integer.length + exponent;
+
+				if (decimalIndex <= 0) {
+					return sign + "0." + Array(-decimalIndex + 1).join("0") + digits;
+				}
+				if (decimalIndex >= digits.length) {
+					return sign + digits + Array(decimalIndex - digits.length + 1).join("0");
+				}
+				return sign + digits.substring(0, decimalIndex) + "." + digits.substring(decimalIndex);
+			};
+
+			var encodeSecond = function(time, second) {
+				var wholeSecond = Math.floor(second);
+				var preservedFraction = time && time[decodeFractionProperty];
+				var preservedWholeSecond = time && time[decodeWholeSecondProperty];
+
+				if (
+					typeof(preservedFraction) == "string"
+					&& /^\d+$/.test(preservedFraction)
+					&& isInteger(preservedWholeSecond)
+					&& preservedWholeSecond == wholeSecond
+				) {
+					var preservedNumeric = wholeSecond + Number("0." + preservedFraction);
+					if (Math.abs(preservedNumeric - second) < 1e-12) {
+						return rfc3339Pad(wholeSecond, 2) + "." + preservedFraction;
+					}
+				}
+
+				var secondString = String(second);
+				if (/e/i.test(secondString)) secondString = expandExponential(secondString);
+				if (secondString.indexOf(".") == -1) return rfc3339Pad(secondString, 2);
+
+				var split = secondString.split(".");
+				var integerPart = split[0];
+				var fractionPart = split[1].replace(/0+$/, "");
+				if (!fractionPart.length) return rfc3339Pad(integerPart, 2);
+				return rfc3339Pad(integerPart, 2) + "." + fractionPart;
+			};
+
 			return {
 				encode: function(time) {
 					var hour = time && time.hour;
@@ -789,12 +839,7 @@
 					if (!isInteger(hour) || hour < 0 || hour > 23) throw rfc3339Error(String(time));
 					if (!isInteger(minute) || minute < 0 || minute > 59) throw rfc3339Error(String(time));
 					if (typeof(second) != "number" || !isFinite(second) || second < 0 || second >= 60) throw rfc3339Error(String(time));
-					var secondString = String(second);
-					if (secondString.indexOf(".") == -1) {
-						return rfc3339Pad(hour,2) + ":" + rfc3339Pad(minute,2) + ":" + rfc3339Pad(second,2);
-					}
-					var split = secondString.split(".");
-					return rfc3339Pad(hour,2) + ":" + rfc3339Pad(minute,2) + ":" + rfc3339Pad(split[0],2) + "." + split[1];
+					return rfc3339Pad(hour,2) + ":" + rfc3339Pad(minute,2) + ":" + encodeSecond(time, second);
 				},
 				decode: function(string) {
 					var parsed = /^(\d{2})\:(\d{2})\:(\d{2})(?:\.(\d+))?$/.exec(string);
@@ -805,11 +850,24 @@
 					if (!isInteger(hour) || hour < 0 || hour > 23) throw rfc3339Error(string);
 					if (!isInteger(minute) || minute < 0 || minute > 59) throw rfc3339Error(string);
 					if (typeof(second) != "number" || !isFinite(second) || second < 0 || second >= 60) throw rfc3339Error(string);
-					return {
+					var decoded = {
 						hour: hour,
 						minute: minute,
 						second: second
 					};
+					if (parsed[4]) {
+						Object.defineProperty(decoded, decodeWholeSecondProperty, {
+							value: Number(parsed[3]),
+							enumerable: false,
+							configurable: true
+						});
+						Object.defineProperty(decoded, decodeFractionProperty, {
+							value: parsed[4],
+							enumerable: false,
+							configurable: true
+						});
+					}
+					return decoded;
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- add `Time.codec.rfc3339()` in `js/time/module.js` to encode/decode `slime.time.Time` values
- validate hour/minute/second ranges on both encode and decode
- support fractional seconds and preserve fractional precision in encoded output
- add Fifty coverage for exported `Time` interface and codec behavior in `js/time/module.fifty.ts`

## Testing
- `./fifty test.jsh js/time/module.fifty.ts`