### PR TITLE
Add percentage-based threshold support to Fifty timing summary

### DIFF
--- a/.github/workflows/test-jdk21.yaml
+++ b/.github/workflows/test-jdk21.yaml
@@ -34,15 +34,15 @@ jobs:
           mkdir -p local
           set -o pipefail
           contributor/suite-docker-jrunscript 21 2>&1 | tee local/jrunscript.txt
-      - name: Show timing summary in logs (60s+)
+      - name: Show timing summary in logs (60s or 2%+)
         if: success()
         run: |
-          echo "::group::Fifty timing summary (>=60s)"
-          contributor/fifty-timing-lines.bash --threshold-seconds 60 --stdout local/jrunscript.txt | tee local/jrunscript-timing-60s.txt
+          echo "::group::Fifty timing summary (>=60s or >=2% of total)"
+          contributor/fifty-timing-lines.bash --threshold-seconds 60 --threshold-percentage 2 --stdout local/jrunscript.txt | tee local/jrunscript-timing-60s-or-2pct.txt
           echo "::endgroup::"
-      - name: Upload timing artifact (60s+)
+      - name: Upload timing artifact (60s or 2%+)
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: jdk21-fifty-timing-60s
-          path: local/jrunscript-timing-60s.txt
+          name: jdk21-fifty-timing-60s-or-2pct
+          path: local/jrunscript-timing-60s-or-2pct.txt

--- a/contributor/fifty-timing-lines.js
+++ b/contributor/fifty-timing-lines.js
@@ -31,11 +31,14 @@ const path = nodeRequire("path");
  */
 
 function usage() {
-	console.error("Usage: fifty-timing-lines [--threshold-seconds <number>] [--stdout] <fifty-output-file> [timing-output-file]");
+	console.error("Usage: fifty-timing-lines [--threshold-seconds <number>] [--threshold-percentage <number>] [--stdout] <fifty-output-file> [timing-output-file]");
 }
 
 function parseArgs(argv) {
-	let thresholdSeconds = 0;
+	/** @type {number | null} */
+	let thresholdSeconds = null;
+	/** @type {number | null} */
+	let thresholdPercentage = null;
 	let writeStdout = false;
 	const positional = [];
 
@@ -48,6 +51,13 @@ function parseArgs(argv) {
 				throw new Error("--threshold-seconds must be a non-negative number");
 			}
 			thresholdSeconds = value;
+		} else if (arg === "--threshold-percentage") {
+			if (i + 1 >= argv.length) throw new Error("Missing value for --threshold-percentage");
+			const value = Number(argv[++i]);
+			if (!isFinite(value) || value < 0) {
+				throw new Error("--threshold-percentage must be a non-negative number");
+			}
+			thresholdPercentage = value;
 		} else if (arg === "--stdout") {
 			writeStdout = true;
 		} else {
@@ -64,11 +74,39 @@ function parseArgs(argv) {
 	}
 
 	return {
-		thresholdMs: thresholdSeconds * 1000,
+		thresholdSeconds,
+		thresholdPercentage,
 		inputFile: positional[0],
 		outputFile: positional[1] || null,
 		writeStdout
 	};
+}
+
+function parseLastLineDurationMs(lines) {
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i].trim();
+		if (!line) continue;
+		const match = line.match(/\(([0-9]+) ms\)$/);
+		if (match) return Number(match[1]);
+		break;
+	}
+	return null;
+}
+
+function computeThresholdMs(parsed, totalMs) {
+	/** @type {number[]} */
+	const thresholds = [];
+
+	if (parsed.thresholdSeconds !== null) {
+		thresholds.push(parsed.thresholdSeconds * 1000);
+	}
+
+	if (parsed.thresholdPercentage !== null && totalMs !== null) {
+		thresholds.push((parsed.thresholdPercentage / 100) * totalMs);
+	}
+
+	if (thresholds.length === 0) return 0;
+	return Math.min(...thresholds);
 }
 
 /** @returns {TreeNode} */
@@ -189,8 +227,10 @@ function main() {
 
 	const text = fs.readFileSync(parsed.inputFile, "utf8");
 	const lines = text.split(/\r?\n/).filter((line) => line.length > 0);
+	const totalMs = parseLastLineDurationMs(lines);
+	const thresholdMs = computeThresholdMs(parsed, totalMs);
 	const root = buildTree(lines);
-	markIncluded(root, parsed.thresholdMs);
+	markIncluded(root, thresholdMs);
 
 	const outputLines = [];
 	emit(root, outputLines);

--- a/contributor/fifty-timing-lines.js
+++ b/contributor/fifty-timing-lines.js
@@ -12,7 +12,7 @@ const globalObj = /** @type {any} */ (Function("return this")());
 // @ts-ignore Node.js provides require in this runtime, but ambient types are not loaded in this tsconfig.
 const nodeRequire = /** @type {(id: string) => any} */ (require);
 // @ts-ignore Node.js provides process in this runtime, but ambient types are not loaded in this tsconfig.
-const process = /** @type {{ argv: string[]; stdout: { write: (text: string) => void }; exit: (code: number) => never }} */ (globalObj.process);
+const process = /** @type {{ argv: string[]; stdout: { write: (text: string) => void }; stderr: { write: (text: string) => void }; exit: (code: number) => never }} */ (globalObj.process);
 const fs = nodeRequire("fs");
 const path = nodeRequire("path");
 
@@ -88,7 +88,6 @@ function parseLastLineDurationMs(lines) {
 		if (!line) continue;
 		const match = line.match(/\(([0-9]+) ms\)$/);
 		if (match) return Number(match[1]);
-		break;
 	}
 	return null;
 }
@@ -228,6 +227,9 @@ function main() {
 	const text = fs.readFileSync(parsed.inputFile, "utf8");
 	const lines = text.split(/\r?\n/).filter((line) => line.length > 0);
 	const totalMs = parseLastLineDurationMs(lines);
+	if (parsed.thresholdPercentage !== null && totalMs === null) {
+		process.stderr.write("Warning: --threshold-percentage was provided but total duration could not be parsed from input; ignoring percentage threshold.\n");
+	}
 	const thresholdMs = computeThresholdMs(parsed, totalMs);
 	const root = buildTree(lines);
 	markIncluded(root, thresholdMs);


### PR DESCRIPTION
## Summary
- Add `--threshold-percentage` to `contributor/fifty-timing-lines.js`
- Compute percentage threshold from the total duration parsed from the last non-empty line (`(... ms)`)
- When both thresholds are provided, use the lower effective threshold
- Update JDK 21 workflow to pass `--threshold-percentage 2` and rename related timing artifact labels/files

## Validation
- Ran script with both options:
  - `contributor/fifty-timing-lines.bash --threshold-seconds 60 --threshold-percentage 2 --stdout local/jsh-script-plugin_exports-oo-main-remote.txt`
- Type-check passed:
  - `./wf tsc --vscode`
- Commit hook checks passed (ESLint, MPL headers, TypeScript)
