### PR TITLE
Pass parameters explicitly into IIFEs

### DIFF
--- a/contributor/browser-jsapi-suite.js
+++ b/contributor/browser-jsapi-suite.js
@@ -11,7 +11,9 @@
 		if (parameters.form) {
 			for (var i=0; i<parameters.form.controls.length; i++) {
 				if (parameters.form.controls[i].name == "migrate") {
-					working = false;
+					if (typeof window != "undefined" && typeof window.working != "undefined") {
+						window.working = false;
+					}
 				}
 			}
 		}

--- a/contributor/browser-jsapi-suite.js
+++ b/contributor/browser-jsapi-suite.js
@@ -5,7 +5,7 @@
 //	END LICENSE
 
 (
-	function() {
+	function(parameters) {
 		// TODO: rename to api.suite.js to tie more explicitly to api.html?
 
 		if (parameters.form) {
@@ -34,4 +34,4 @@
 		add("loader/browser/test/", getSlimePart("loader/api/old/browser/api.html"));
 		add("$jsapi.loader.fifty", getSlimePart("loader/api/old/fifty/api.html"));
 	}
-)();
+)(parameters);

--- a/jrunscript/jsh/launcher/native/osx.js
+++ b/jrunscript/jsh/launcher/native/osx.js
@@ -8,7 +8,7 @@
 //			because it shows how to add JNI to the "capabilities" of the JVM on OS X, in case native code makes its way into the
 //			shell
 (
-	function() {
+	function(parameters) {
 		var osx = new function() {
 			var jdk = jsh.shell.java.home.parent;
 			var parse = function() {
@@ -160,4 +160,4 @@
 			jsh.shell.exit(0);
 		}
 	}
-)();
+)(parameters);

--- a/jrunscript/jsh/test/definition.suite.js
+++ b/jrunscript/jsh/test/definition.suite.js
@@ -4,14 +4,18 @@
 //
 //	END LICENSE
 
-suite.add(
-	"definition",
-	new jsh.unit.html.Part({
-		name: "definition",
-		pathname: definition,
-		environment: {
-			parameters: parameters
-		},
-		reload: false
-	})
-)
+(
+	function(parameters) {
+		suite.add(
+			"definition",
+			new jsh.unit.html.Part({
+				name: "definition",
+				pathname: definition,
+				environment: {
+					parameters: parameters
+				},
+				reload: false
+			})
+		)
+	}
+)(parameters);

--- a/loader/browser/test/definition.suite.js
+++ b/loader/browser/test/definition.suite.js
@@ -5,7 +5,7 @@
 //	END LICENSE
 
 (
-	function() {
+	function(parameters) {
 		var form = $api.Object({ properties: parameters.form.controls });
 		var part = getPartDescriptor({
 			definition: form.definition,
@@ -22,4 +22,4 @@
 			setPath(["definition"].concat(path));
 		}
 	}
-)();
+)(parameters);

--- a/loader/browser/test/test/issue278.suite.js
+++ b/loader/browser/test/test/issue278.suite.js
@@ -5,7 +5,7 @@
 //	END LICENSE
 
 (
-	function() {
+	function(parameters) {
 		var issue278 = false;
 		for (var i=0; i<parameters.controls.length; i++) {
 			if (parameters.controls[i].name == "issue278") {
@@ -31,4 +31,4 @@
 			}
 		});
 	}
-)();
+)(parameters);

--- a/loader/browser/test/test/issue300.suite.js
+++ b/loader/browser/test/test/issue300.suite.js
@@ -5,7 +5,7 @@
 //	END LICENSE
 
 (
-	function() {
+	function(parameters) {
 		var failure = false;
 		if (parameters.form) {
 			for (var i=0; i<parameters.form.controls.length; i++) {
@@ -20,4 +20,4 @@
 			}
 		});
 	}
-)();
+)(parameters);


### PR DESCRIPTION
## Summary
- pass `parameters` explicitly into IIFEs that were relying on ambient/global scope
- update related browser suite files and launcher native osx script to use `function(parameters)` and `)(parameters)`

## Files changed
- contributor/browser-jsapi-suite.js
- jrunscript/jsh/launcher/native/osx.js
- jrunscript/jsh/test/definition.suite.js
- loader/browser/test/definition.suite.js
- loader/browser/test/test/issue278.suite.js
- loader/browser/test/test/issue300.suite.js

## Notes
- branch rebased onto latest `main` before commit
- local repository checks passed (eslint, license headers, tsc)