### PR TITLE
Exclude .env from license checker scan

### DIFF
--- a/contributor/code/license.jsh.js
+++ b/contributor/code/license.jsh.js
@@ -75,6 +75,7 @@
 				return !n.directory
 					&& n.pathname.basename != "package.json"
 					&& n.pathname.basename != "package-lock.json"
+					&& n.pathname.basename != ".env"
 					&& n.pathname.basename != ".gitignore"
 					&& n.pathname.basename != ".project"
 					&& n.pathname.basename != ".classpath"
@@ -152,7 +153,6 @@
 			var file = files[i];
 			var extension = getExtension(file);
 			if (files[i].path == "jsh") extension = "bash";
-			if (files[i].path == ".env") extension = "bash";
 			if (files[i].path == ".eslintrc.json") extension = "js";
 			if (files[i].path == "jsconfig.json") extension = "js";
 			if (files[i].path == "jsconfig-fifty-browser-test.json") extension = "js";


### PR DESCRIPTION
## Summary
- Exclude `.env` from files collected by `contributor/code/license.jsh.js`
- Remove the `.env` path-to-`bash` extension mapping since `.env` is no longer scanned

## Why
`.env` files are local environment/config artifacts and should not be forced to carry repository license headers.

## Notes
This keeps existing license enforcement behavior for all other tracked text files unchanged.
