### PR TITLE
Add Date.delta API for signed day differences

### DIFF
--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -323,6 +323,61 @@ namespace slime.time {
 		)(fifty);
 
 		export interface Exports {
+			/**
+			 * Returns a function that, given a {@link Date}, returns the number of days by which it differs from `reference`.
+			 *
+			 * Positive values indicate `day` is later than `reference`; negative values indicate it is earlier.
+			 */
+			delta: (reference: slime.time.Date) => (day: slime.time.Date) => number
+		}
+
+		(
+			function(
+				fifty: slime.fifty.test.Kit
+			) {
+				const { verify } = fifty;
+
+				fifty.tests.exports.Date.delta = function() {
+					var reference: slime.time.Date = {
+						year: 2020,
+						month: 3,
+						day: 1
+					};
+
+					var delta = test.subject.Date.delta(reference);
+
+					verify(delta(reference)).is(0);
+
+					var later = delta({
+						year: 2020,
+						month: 3,
+						day: 2
+					});
+					verify(later).is(1);
+
+					var earlier = delta({
+						year: 2020,
+						month: 2,
+						day: 29
+					});
+					verify(earlier).is(-1);
+
+					var acrossYear = delta({
+						year: 2021,
+						month: 3,
+						day: 1
+					});
+					verify(acrossYear).is(365);
+
+					verify(reference).year.is(2020);
+					verify(reference).month.is(3);
+					verify(reference).day.is(1);
+				}
+			}
+		//@ts-ignore
+		)(fifty);
+
+		export interface Exports {
 			after: (day: slime.time.Date) => (offset: number) => slime.time.Date
 
 			months: {

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -442,6 +442,17 @@
 		}
 
 		/**
+		 * @param { slime.time.Date } reference
+		 * @param { slime.time.Date } day
+		 * @returns { number }
+		 */
+		var Date_delta = function(reference, day) {
+			var referenceUtc = Date.UTC(reference.year, reference.month - 1, reference.day);
+			var dayUtc = Date.UTC(day.year, day.month - 1, day.day);
+			return Math.round((dayUtc - referenceUtc) / (24 * 60 * 60 * 1000));
+		};
+
+		/**
 		 * @constructor
 		 * @param { any } p
 		 */
@@ -592,6 +603,7 @@
 				var args = arguments[0];
 				if (typeof(args.hours) != "undefined") {
 					hours = between("hours",0,23);
+
 					minutes = between("minutes",0,59);
 					seconds = (args.seconds) ? Number(args.seconds) : 0;
 					if (seconds < 0 || seconds >= 60) {
@@ -1215,6 +1227,11 @@
 				offset: function(offset) {
 					return function(day) {
 						return Date_add(day, offset);
+					}
+				},
+				delta: function(reference) {
+					return function(day) {
+						return Date_delta(reference, day);
 					}
 				},
 				after: function(day) {


### PR DESCRIPTION
## Summary
- add a new `Date.delta(reference)` API that returns a function mapping a date to its signed day difference from `reference`
- declare the API in a separate mergeable `date.Exports` interface block immediately after `Date.offset` tests
- add Fifty tests for same-day, positive, negative, and cross-year behavior
- keep `reference` input unchanged in tests to verify immutability behavior
- implement runtime support in `js/time/module.js` using UTC-day arithmetic

## Validation
- ran `./fifty test.jsh js/time/module.fifty.ts`
- pre-commit checks also passed (`ESLint`, `TypeScript`, MPL header verification)

## Notes
- branch: `davidpcaldwell/date-delta-api`
- commit: `017022f2c`