### PR TITLE
Disable explicit credential.helper config in git push/remote-show

### DIFF
--- a/tools/wf/plugin-standard.jsh.js
+++ b/tools/wf/plugin-standard.jsh.js
@@ -134,7 +134,7 @@
 					//	master
 					repository.push({
 						repository: "origin",
-						refspec: status.branch//,
+						refspec: status.branch
 						// config: {
 						// 	"credential.helper": credentialHelper
 						// }
@@ -589,7 +589,7 @@
 					//	master
 					repository.push({
 						repository: "origin",
-						refspec: "HEAD"//,
+						refspec: "HEAD"
 						// config: {
 						// 	"credential.helper": credentialHelper
 						// }

--- a/tools/wf/plugin-standard.jsh.js
+++ b/tools/wf/plugin-standard.jsh.js
@@ -134,10 +134,10 @@
 					//	master
 					repository.push({
 						repository: "origin",
-						refspec: status.branch,
-						config: {
-							"credential.helper": credentialHelper
-						}
+						refspec: status.branch//,
+						// config: {
+						// 	"credential.helper": credentialHelper
+						// }
 					});
 				}
 
@@ -589,10 +589,10 @@
 					//	master
 					repository.push({
 						repository: "origin",
-						refspec: "HEAD",
-						config: {
-							"credential.helper": credentialHelper
-						}
+						refspec: "HEAD"//,
+						// config: {
+						// 	"credential.helper": credentialHelper
+						// }
 					});
 				}
 

--- a/tools/wf/plugin-standard.jsh.js
+++ b/tools/wf/plugin-standard.jsh.js
@@ -60,10 +60,7 @@
 					throw new TypeError("Old signature of standard plugin export function used. Please update to the new signature, which takes three arguments: context, project, and exports.");
 				}
 
-				//	TODO	the below credentialHelper code also appears to be in tools/wf/plugin.jsh.js
-
 				//	TODO	is this stuff documented anywhere?
-				var credentialHelper = jsh.shell.jsh.src.getFile("rhino/tools/git/git-credential-tokens-directory.bash").toString();
 
 				/** @type { slime.jrunscript.tools.git.Command<void,{ current: boolean, name: string }[]> } */
 				var getBranches = {
@@ -135,9 +132,6 @@
 					repository.push({
 						repository: "origin",
 						refspec: status.branch
-						// config: {
-						// 	"credential.helper": credentialHelper
-						// }
 					});
 				}
 
@@ -590,9 +584,6 @@
 					repository.push({
 						repository: "origin",
 						refspec: "HEAD"
-						// config: {
-						// 	"credential.helper": credentialHelper
-						// }
 					});
 				}
 

--- a/tools/wf/plugin.jsh.js
+++ b/tools/wf/plugin.jsh.js
@@ -1045,7 +1045,6 @@
 						events.fire("console", "Verifying up to date with origin ...");
 						var remote = "origin";
 						var origin = jsh.tools.git.program({ command: "git" })
-							//.config({ "credential.helper": jsh.shell.jsh.src.getRelativePath("rhino/tools/git/git-credential-tokens-directory.bash").toString() })
 							.repository(inputs.project())
 							.command(jsh.tools.git.commands.remote.show)
 							.argument(remote)

--- a/tools/wf/plugin.jsh.js
+++ b/tools/wf/plugin.jsh.js
@@ -1045,7 +1045,7 @@
 						events.fire("console", "Verifying up to date with origin ...");
 						var remote = "origin";
 						var origin = jsh.tools.git.program({ command: "git" })
-							.config({ "credential.helper": jsh.shell.jsh.src.getRelativePath("rhino/tools/git/git-credential-tokens-directory.bash").toString() })
+							//.config({ "credential.helper": jsh.shell.jsh.src.getRelativePath("rhino/tools/git/git-credential-tokens-directory.bash").toString() })
 							.repository(inputs.project())
 							.command(jsh.tools.git.commands.remote.show)
 							.argument(remote)


### PR DESCRIPTION
## Summary
- Comment out the `credential.helper` config used for `push` operations (both branch push and HEAD push) in `tools/wf/plugin-standard.jsh.js`
- Comment out the `credential.helper` config used for the `remote show` verification check in `tools/wf/plugin.jsh.js`

## Test plan
- [ ] Confirm wf push/verify-up-to-date flows still authenticate correctly without the explicit credential.helper config