### PR TITLE
Improve readability of contributor/test-docker-clean-command

### DIFF
--- a/contributor/test-docker-clean-command
+++ b/contributor/test-docker-clean-command
@@ -18,11 +18,6 @@ SLIME="$(dirname $0)/.."
 
 cd ${SLIME}
 
-# Emit the Docker command for visiblity
-set -x
-
-cd ${SLIME}
-
 # Emit the Docker command for visibility
 set -x
 
@@ -48,4 +43,16 @@ docker compose -f docker-compose.yaml -f docker-compose.test.yaml \
 	-e JDK_VERSION \
 	-e SLIME_WF_JDK_VERSION=$JDK_VERSION \
 	local \
-	/bin/bash -c 'if [ -n "${SLIME_TEST_REQUIRE_DISPLAY:-}" ]; then export DISPLAY="${DISPLAY:-:1}"; export SLIME_TEST_BROWSER_HEADLESS=1; fi; echo "CI DEBUG container env: SLIME_TEST_REQUIRE_DISPLAY=${SLIME_TEST_REQUIRE_DISPLAY:-<unset>} SLIME_TEST_BROWSER_HEADLESS=${SLIME_TEST_BROWSER_HEADLESS:-<unset>} DISPLAY=${DISPLAY:-<unset>} JDK_VERSION=${JDK_VERSION:-<unset>} SLIME_WF_JDK_VERSION=${SLIME_WF_JDK_VERSION:-<unset>} SLIME_WF_SKIP_GIT_IDENTITY_REQUIREMENT=${SLIME_WF_SKIP_GIT_IDENTITY_REQUIREMENT:-<unset>}"; env | grep -E "^(SLIME_TEST_REQUIRE_DISPLAY|SLIME_TEST_BROWSER_HEADLESS|DISPLAY|JDK_VERSION|SLIME_WF_JDK_VERSION|SLIME_WF_SKIP_GIT_IDENTITY_REQUIREMENT)=" | sort || true; ./jsh --install-jdk-$JDK_VERSION; "$@"' -- "$@"
+	/bin/bash -c '
+		if [ -n "${SLIME_TEST_REQUIRE_DISPLAY:-}" ]; then
+			export DISPLAY="${DISPLAY:-:1}"
+			export SLIME_TEST_BROWSER_HEADLESS=1
+		fi
+
+		echo "CI DEBUG container env: SLIME_TEST_REQUIRE_DISPLAY=${SLIME_TEST_REQUIRE_DISPLAY:-<unset>} SLIME_TEST_BROWSER_HEADLESS=${SLIME_TEST_BROWSER_HEADLESS:-<unset>} DISPLAY=${DISPLAY:-<unset>} JDK_VERSION=${JDK_VERSION:-<unset>} SLIME_WF_JDK_VERSION=${SLIME_WF_JDK_VERSION:-<unset>} SLIME_WF_SKIP_GIT_IDENTITY_REQUIREMENT=${SLIME_WF_SKIP_GIT_IDENTITY_REQUIREMENT:-<unset>}"
+
+		env | grep -E "^(SLIME_TEST_REQUIRE_DISPLAY|SLIME_TEST_BROWSER_HEADLESS|DISPLAY|JDK_VERSION|SLIME_WF_JDK_VERSION|SLIME_WF_SKIP_GIT_IDENTITY_REQUIREMENT)=" | sort || true
+
+		./jsh --install-jdk-"$JDK_VERSION"
+		"$@"
+	' -- "$@"

--- a/contributor/test-docker-clean-command
+++ b/contributor/test-docker-clean-command
@@ -14,9 +14,9 @@ fi
 export JDK_VERSION="$1"
 shift 1
 
-SLIME="$(dirname $0)/.."
+SLIME="$(dirname "$0")/.."
 
-cd ${SLIME}
+cd "${SLIME}" || exit 1
 
 # Emit the Docker command for visibility
 set -x


### PR DESCRIPTION
## Summary
Improve formatting and readability of the Docker test runner script without changing behavior.

## Changes
- Remove duplicated `cd` and duplicate `set -x` setup lines.
- Expand the inline `/bin/bash -c` one-liner into a multiline script block.
- Keep environment variable handling and command execution semantics unchanged.

## Validation
- `bash -n /slime/contributor/test-docker-clean-command` passes.
