### PR TITLE
Add Thunk.force and use it in wf jrunscript tests

### DIFF
--- a/loader/$api-Function.fifty.ts
+++ b/loader/$api-Function.fifty.ts
@@ -176,6 +176,7 @@ namespace slime.$api.fp {
 	export interface Exports {
 		Thunk: {
 			memoize: <T>(f: Thunk<T>) => Thunk<T>
+			force: <T>(f: Thunk<T>) => T
 			map: Thunk_map
 			value: Thunk_value
 			now: Thunk_now
@@ -198,6 +199,17 @@ namespace slime.$api.fp {
 
 				verify(one).invocations.length.is(1);
 				verify(memoized).invocations.length.is(2);
+			}
+
+			fifty.tests.exports.Thunk.force = function() {
+				const one = fifty.spy.create($api.fp.Thunk.value(1));
+
+				var x = $api.fp.Thunk.force(one.function);
+				var y = $api.fp.Thunk.force(one.function);
+
+				verify(x).is(1);
+				verify(y).is(1);
+				verify(one).invocations.length.is(2);
 			}
 
 			fifty.tests.exports.Thunk.now = function() {

--- a/loader/$api-Function.js
+++ b/loader/$api-Function.js
@@ -339,6 +339,9 @@
 						return now_map.apply(this, args);
 					}
 				},
+				force: function(thunk) {
+					return thunk();
+				},
 				now: function(thunk) {
 					var maps = Array.prototype.slice.call(arguments, 1);
 					var rv = thunk();

--- a/wf.js
+++ b/wf.js
@@ -516,15 +516,19 @@
 					return result.status == 0;
 				};
 
-				var runTests = $api.fp.now(test_jrunscript, $api.fp.world.Question.thunk({
-					console: function(e) {
-						jsh.shell.console(e.detail);
-					},
-					output: function(e) {
-						jsh.shell.echo(e.detail);
-					}
-				}));
-				var success = runTests();
+				var success = $api.fp.now(
+					test_jrunscript,
+					$api.fp.world.Question.thunk({
+						console: function(e) {
+							jsh.shell.console(e.detail);
+						},
+						output: function(e) {
+							jsh.shell.echo(e.detail);
+						}
+					}),
+					$api.fp.Thunk.force
+				);
+
 				if (!success) jsh.shell.console("jrunscript tests failed.");
 				return (success) ? 0 : 1;
 			}


### PR DESCRIPTION
## Summary
- add `$api.fp.Thunk.force` as a minimal thunk evaluator (`Thunk<T> -> T`)
- add Fifty definition and test coverage for `Thunk.force`
- update `wf test.jrunscript` flow in `wf.js` to use `Thunk.force` in the pipeline

## Validation
- pre-commit checks passed (ESLint, MPL header verification, TypeScript check)
- branch pushed successfully