### PR TITLE
Build infrastructure for migrating time module to ES6-like world-oriented structure

### DIFF
--- a/jrunscript/jsh/_.fifty.ts
+++ b/jrunscript/jsh/_.fifty.ts
@@ -256,7 +256,7 @@ namespace slime.jsh {
 		}
 
 		file: slime.jrunscript.file.Plugin
-		time: slime.time.Exports
+		time: slime.time.Interface
 		ip: slime.jrunscript.ip.Exports
 		db: {
 			jdbc: slime.jsh.db.jdbc.Exports

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -29,15 +29,13 @@ namespace slime.time {
 	export interface Datetime extends Date, Time {
 	}
 
-	export namespace zone {
-		export interface Time extends Datetime {
-			/**
-			 * The timezone offset, in minutes, from UTC.
-			 */
-			offset: number
-		}
-	}
+	//	TODO	the below type should probably be deprecated and replaced with two exported functions, while converting the
+	//			world.Zone type to a set of codecs
 
+	/**
+	 * A time zone definition that can be used by the implementation to convert between ECMAScript time values and local times in
+	 * the given time zone.
+	 */
 	export interface Zone {
 		/**
 		 * Given a UNIX time, in milliseconds, returns the corresponding time in this time zone.
@@ -50,17 +48,23 @@ namespace slime.time {
 		unix: (time: Datetime) => slime.external.lib.es5.TimeValue
 	}
 
-	export interface Context {
+	export namespace world {
+		export type Zone = slime.time.Zone
+	}
+
+	export interface World {
 		/**
 		 * A function that returns the number of milliseconds since the UNIX epoch. If not supplied, the standard JavaScript
 		 * implementation will be used.
 		 */
-		now?: slime.$api.fp.impure.External<number>
+		now: slime.$api.fp.impure.Reading<number>
 
-		zones?: {
-			[id: string]: Zone
+		zones: {
+			[id: string]: world.Zone
 		}
 	}
+
+	export type Context = Partial<World>;
 
 	export namespace test {
 		export const { subject, load } = (function(fifty: slime.fifty.test.Kit) {
@@ -99,7 +103,7 @@ namespace slime.time {
 	//@ts-ignore
 	)(fifty);
 
-	export interface Exports {
+	export interface Interface {
 		/**
 		 * Functions that pertain to "time values", as defined by the ECMAScript
 		 * [specification](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-time-values-and-time-range), representing
@@ -125,8 +129,10 @@ namespace slime.time {
 
 				fifty.tests.exports.Value.now = function() {
 					var context: Context = {
-						now: function() {
-							return 1000;
+						now: {
+							read: function() {
+								return 1000;
+							}
 						}
 					};
 
@@ -148,11 +154,11 @@ namespace slime.time {
 
 	export type DayOfWeek = "Mo" | "Tu" | "We" | "Th" | "Fr" | "Sa" | "Su"
 
-	export interface Exports {
+	export interface Interface {
 		Date: date.Exports
 	}
 
-	export interface Exports {
+	export interface Interface {
 		Time: time.Exports
 	}
 
@@ -188,7 +194,9 @@ namespace slime.time {
 
 			fifty.tests.exports.Date.today = function() {
 				var subject = test.load({
-					now: $api.fp.returning(1643907600000)
+					now: {
+						read: $api.fp.Thunk.value(1643907600000)
+					}
 				});
 				var today = subject.Date.input.today();
 				var todayReading = subject.Date.today.read();
@@ -789,7 +797,7 @@ namespace slime.time {
 		)(fifty);
 	}
 
-	export interface Exports {
+	export interface Interface {
 		Datetime: datetime.Exports
 	}
 
@@ -898,12 +906,15 @@ namespace slime.time {
 		)(fifty);
 	}
 
-	export interface Exports {
+	export interface Interface {
 		Month: month.Exports
 	}
 
-	export interface Exports {
+	export interface Interface {
 		Timezone: {
+			/**
+			 * A timezone that uses the global Date function to handle timezone offsets.
+			 */
 			local: Zone
 			UTC: Zone
 			[x: string]: Zone
@@ -951,6 +962,13 @@ namespace slime.time {
 	)(fifty);
 
 	export namespace zone {
+		export interface Time extends Datetime {
+			/**
+			 * The timezone offset, in minutes, from UTC.
+			 */
+			offset: number
+		}
+
 		export namespace time {
 			export interface Exports {
 				create: {
@@ -969,7 +987,7 @@ namespace slime.time {
 		}
 	}
 
-	export interface Exports {
+	export interface Interface {
 		zone: {
 			Time: zone.time.Exports
 		}
@@ -1124,6 +1142,8 @@ namespace slime.time {
 		}
 	//@ts-ignore
 	)(fifty);
+
+	export type Exports = Interface
 
 	export type Script = slime.runtime.loader.Scoped<Context|void,Exports>
 }

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -9,47 +9,45 @@
 	/**
 	 * @param { slime.$api.Global } $api
 	 * @param { slime.time.Context } $context
-	 * @param { slime.loader.Export<slime.time.Exports> } $export
+	 * @param { slime.loader.Export<slime.time.Interface> } $export
 	 */
 	function($api,$context,$export) {
-		var now = $context.now || function() { return new Date().getTime(); };
-
-		/** @type { { local: slime.time.Zone, UTC: slime.time.Zone, [id: string]: slime.time.Zone } } */
-		var zones = {
-			local: new function() {
-				this.local = function(unix) {
-					var date = new Date(unix);
-					return {
-						year: date.getFullYear(), month: date.getMonth()+1, day: date.getDate(),
-						hour: date.getHours(), minute: date.getMinutes(), second: date.getSeconds() + date.getMilliseconds() / 1000
+		var world = {
+			now: { read: function() { return new Date().getTime(); } },
+			zones: {
+				local: new function() {
+					this.local = function(unix) {
+						var date = new Date(unix);
+						return {
+							year: date.getFullYear(), month: date.getMonth()+1, day: date.getDate(),
+							hour: date.getHours(), minute: date.getMinutes(), second: date.getSeconds() + date.getMilliseconds() / 1000
+						}
 					}
-				}
-				this.unix = function(local) {
-					return new Date(local.year,local.month-1,local.day,local.hour,local.minute,local.second).getTime();
-				}
-			},
-			//	TODO	Should we make this conditional on $context.zones.UTC?
-			UTC: new function() {
-				this.local = function(unix) {
-					var date = new Date(unix);
-					return {
-						year: date.getUTCFullYear(), month: date.getUTCMonth()+1, day: date.getUTCDate(),
-						hour: date.getUTCHours(), minute: date.getUTCMinutes(), second: date.getUTCSeconds() + date.getUTCMilliseconds() / 1000
-					};
-				}
-				this.unix = function(local) {
-					var wholeSeconds = Math.floor(local.second);
-					var milliseconds = Math.round((local.second - Math.floor(local.second)) * 1000);
-					return Date.UTC(local.year,local.month-1,local.day,local.hour,local.minute,wholeSeconds,milliseconds);
+					this.unix = function(local) {
+						return new Date(local.year,local.month-1,local.day,local.hour,local.minute,local.second).getTime();
+					}
+				},
+				//	TODO	Should we make this conditional on $context.zones.UTC?
+				UTC: new function() {
+					this.local = function(unix) {
+						var date = new Date(unix);
+						return {
+							year: date.getUTCFullYear(), month: date.getUTCMonth()+1, day: date.getUTCDate(),
+							hour: date.getUTCHours(), minute: date.getUTCMinutes(), second: date.getUTCSeconds() + date.getUTCMilliseconds() / 1000
+						};
+					}
+					this.unix = function(local) {
+						var wholeSeconds = Math.floor(local.second);
+						var milliseconds = Math.round((local.second - Math.floor(local.second)) * 1000);
+						return Date.UTC(local.year,local.month-1,local.day,local.hour,local.minute,wholeSeconds,milliseconds);
+					}
 				}
 			}
 		};
 
-		if (typeof($context.zones) != "undefined") {
-			for (var x in $context.zones) {
-				zones[x] = $context.zones[x];
-			}
-		}
+		var now = $context.now || world.now;
+
+		var zones = $api.Object.compose(world.zones, $context.zones);
 
 		var harmonize = function(y,m,d) {
 			if (typeof(y) != "number") throw "y not number: " + y;
@@ -1140,9 +1138,10 @@
 			return js.getUTCFullYear() === year && js.getUTCMonth() === month-1 && js.getUTCDate() === day;
 		}
 
+		/** @type { { now: (world: slime.time.World) => () => number }} */
 		var Value = {
-			now: function(context) {
-				return context.now || Date.now;
+			now: function(world) {
+				return world.now.read || Date.now;
 			}
 		};
 
@@ -1155,7 +1154,7 @@
 		};
 
 		var today = function() {
-			var datetime = zones.local.local(now());
+			var datetime = zones.local.local(now.read());
 			return {
 				year: datetime.year,
 				month: datetime.month,
@@ -1164,7 +1163,7 @@
 		};
 
 		$export({
-			Value: $api.fp.methods.pin($context)(Value),
+			Value: $api.fp.methods.pin({ now: now, zones: zones })(Value),
 			Datetime: {
 				date: function(datetime) {
 					return {

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -45,9 +45,13 @@
 			}
 		};
 
-		var now = $context.now || world.now;
+		var now = (function(now) {
+			if (typeof(now) == "function") return { read: now };
+			if (now && typeof(now.read) == "function") return now;
+			return world.now;
+		})($context.now);
 
-		var zones = $api.Object.compose(world.zones, $context.zones);
+		var zones = $api.Object.compose(world.zones, $context.zones || {});
 
 		var harmonize = function(y,m,d) {
 			if (typeof(y) != "number") throw "y not number: " + y;

--- a/js/time/old.fifty.ts
+++ b/js/time/old.fifty.ts
@@ -5,7 +5,7 @@
 //	END LICENSE
 
 namespace slime.time {
-	export interface Context {
+	export interface World {
 		/** @deprecated */
 		old?: {
 			/** @deprecated */
@@ -366,12 +366,12 @@ namespace slime.time {
 		)(fifty);
 	}
 
-	export interface Exports {
+	export interface Interface {
 		/** @deprecated */
 		Day: day.Exports
 	}
 
-	export interface Exports {
+	export interface Interface {
 		/** @deprecated */
 		Year: {
 			/** @deprecated */
@@ -444,7 +444,7 @@ namespace slime.time {
 		)(fifty);
 	}
 
-	export interface Exports {
+	export interface Interface {
 		/** @deprecated */
 		Time: time.Exports
 	}
@@ -490,12 +490,12 @@ namespace slime.time {
 		)(fifty);
 	}
 
-	export interface Exports {
+	export interface Interface {
 		/** @deprecated */
 		When: when.Exports
 	}
 
-	export interface Exports {
+	export interface Interface {
 		/** @deprecated */
 		install: Function
 	}
@@ -515,7 +515,7 @@ namespace slime.time {
 
 				fifty.run(function harvested() {
 					var global = (function() { return this; })();
-					var subject: slime.time.Exports = (global.jsh) ? $loader.module("module.js", $loader.file("context.java.js")) : $loader.module("module.js");
+					var subject: slime.time.Interface = (global.jsh) ? $loader.module("module.js", $loader.file("context.java.js")) : $loader.module("module.js");
 					//var subject: slime.time.Exports = $loader.module("module.js");
 
 					var when = new subject.When({ unix: 1599143670821 });

--- a/rhino/tools/git/log.fifty.ts
+++ b/rhino/tools/git/log.fifty.ts
@@ -38,7 +38,7 @@ namespace slime.jrunscript.tools.git {
 namespace slime.jrunscript.tools.git.internal.log {
 	export interface Context {
 		library: {
-			time: slime.time.Exports
+			time: slime.time.Interface
 		}
 	}
 

--- a/rhino/tools/git/module.fifty.ts
+++ b/rhino/tools/git/module.fifty.ts
@@ -700,7 +700,7 @@ namespace slime.jrunscript.tools.git {
 			shell: slime.jrunscript.shell.Exports
 			//	TODO	fix this
 			Error: slime.$api.old.Exports["Error"]
-			time: slime.time.Exports
+			time: slime.time.Interface
 			web: slime.web.Exports
 		}
 		environment: any


### PR DESCRIPTION
## Summary
This PR introduces the infrastructure needed to migrate the time module to an ES6-like, world-oriented structure.

## Commit Message Anchor
"Build infrastructure for migrating time module to ES6-like world-oriented structure"

## What This PR Focuses On
- Lays foundational scaffolding for the migration path
- Establishes structure to support the new world-oriented module organization
- Keeps the change set focused on infrastructure rather than behavioral feature expansion

## Notes
- This PR is intentionally foundational and designed to enable subsequent migration work in smaller follow-up changes.