### PR TITLE
Add fp Result type and Jdk base validation contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,20 @@
 General information for contributors is in [CONTRIBUTING.md](CONTRIBUTING.md); please read that first and incorporate its
 information into your approach.
 
-# Personal instructions
+## Quick start checklist (required for agents)
+
+Before making code edits, running tests, replying to PR comments, or resolving review threads:
+
+* Read [AGENTS.md](AGENTS.md).
+* Read [CONTRIBUTING.md](CONTRIBUTING.md).
+* If `~/.agents/README.md` exists, read it and any personal instruction files it references.
+* Confirm in the next user-facing message what personal instruction sources were loaded, or that none were found.
+* If personal instructions conflict with repository instructions, stop and ask the user how to proceed.
+* Follow the "FP error handling conventions" section in [CONTRIBUTING.md](CONTRIBUTING.md#fp-error-handling-conventions) for when to throw exceptions versus returning `Result` failures.
+
+## Reference guidance
+
+## Personal instructions
 
 When running inside a devcontainer, load personal instructions for operating this repository from
 `~/.agents` before taking substantive action.
@@ -17,7 +30,7 @@ When running inside a devcontainer, load personal instructions for operating thi
 The initial source of personal instructions is
 `~/.agents/README.md`.
 
-## Preflight protocol for agents
+### Preflight protocol for agents
 
 Before making code edits, running tests, replying to PR comments, or resolving review threads, do all of the following:
 
@@ -28,19 +41,19 @@ Before making code edits, running tests, replying to PR comments, or resolving r
 
 If personal instructions conflict with repository instructions, stop and ask the user how to proceed.
 
-# Modules
+## Modules
 
 SLIME modules are defined by a top-level script, usually called `module.js`. This main module file often loads sibling files to
 help implement the module, and sometimes loads files from subfolders if the module is sufficiently complex.
 
-## `jsh` plugins
+### `jsh` plugins
 
 `jsh` plugins use a `plugin.jsh.js` to define their `jsh`-facing interface. Sometimes a `jsh` plugin will have no module interface
 at all (if the module is designed only to be used in `jsh`).
 
-# Testing and Documentation
+## Testing and Documentation
 
-## Fifty definitions
+### Fifty definitions
 
 SLIME uses co-located documentation and tests (which it refers to as "definitions").
 
@@ -59,7 +72,7 @@ Typically, the Fifty `.fifty.ts` file provides an `Exports` type which is export
 Fifty files heavily use TypeScript declaration merging, so looking at a single file's definition of a type may not capture the
 entire definition.
 
-## Older JSAPI definitions
+### Older JSAPI definitions
 
 Some other older modules use documentation using a literate HTML format called "JSAPI." JSAPI files have names like `api.html`
 (for a top-level module definition), and `foo.api.html` (documentation for the `foo.js` script). JSAPI files are being migrated to
@@ -68,7 +81,7 @@ Fifty and should be targeted for refactoring and elimination.
 Often Fifty files will contain tests with `jsapi` in the name. These were migrated from the JSAPI format. Often they could use some
 refactoring, but they are much better than tests still executed via JSAPI.
 
-## Testing
+### Testing
 
 To run tests for a JavaScript (`.js`) file, look for a sibling file named `.fifty.ts` (for example, `run.fifty.ts` for `run.js`). Run the tests by executing the Fifty test tool on the `.fifty.ts` file, not the `.js` file itself.
 
@@ -77,7 +90,7 @@ For example, to run the tests for `rhino/shell/run.js`, use:
 
 This ensures you are running the actual test definitions, not just executing the script file.
 
-### Testing = Modules
+#### Testing = Modules
 
 Typically the main module definition file (`module.fifty.ts`) will invoke the other script files needed to test the module as a whole, and then the test suite will just invoke the module file rather than invoking each script file in the module.
 
@@ -91,12 +104,12 @@ To run all tests for a file:
 * Browser-compatible tests: `./fifty test.browser <test-file>`
 * In both cases, a 0 exit status indicates the tests passed.
 
-## Documentation
+### Documentation
 
 A module's documentation typically is contained in a primary TypeScript namespace. Namespaces with `internal` in the name are
 designed for internal module or project use.
 
-### Troubleshooting: `./wf documentation` in devcontainers
+#### Troubleshooting: `./wf documentation` in devcontainers
 
 If serving documentation fails because Chrome reports that the profile is already in use, clear stale Chrome Singleton lock files
 from the project-local documentation profile and retry.
@@ -112,9 +125,9 @@ rm -f local/chrome/documentation/SingletonCookie \
 
 This is safe in a devcontainer when those files are stale lock artifacts from a previous run.
 
-# GitHub integration
+## GitHub integration
 
-## Benign hook message on checkout
+### Benign hook message on checkout
 
 When checking out branches, a hook may print:
 
@@ -130,15 +143,15 @@ Create the issue template in the `local/.github/ISSUE_TEMPLATE` folder, creating
 Issues with a strong focus on improving documentation should receive the `documentation` label, while issues focused on test
 coverage should receive the `project` label.
 
-# Developer workflow
+## Developer workflow
 
 When refactoring, always run `./wf tsc` after the refactor to make sure type-checking passed. If it does not, something is wrong.
 
-## Branch naming
+### Branch naming
 
 When naming branches, if working on an issue, respect the convention specified in the [`VSCode githubIssues.issueBranchTitle setting`](.vscode/settings.json). Otherwise, name the branch with the format `<github-username>/<description>`.
 
-# Code Quality
+## Code Quality
 
 If you are asked for suggestions on how to improve the project, please use the information in this section.
 
@@ -148,7 +161,7 @@ checking, ESLint errors, and files that need to be split.
 * If modules are deprecated (have the `@deprecated` annotation in the namespace definition, or have `old` in the namespace name,
 they can be deprioritized).
 
-## Metrics you can access for assessing code quality
+### Metrics you can access for assessing code quality
 
 The project contains several `jsh` scripts you can run in order to generate metrics that will help you find targets for improvement.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,15 @@ Recommended setup:
 
 Agent behavior in this repository is configured to read `~/.agents/README.md` first, then follow references from that file.
 
+## FP error handling conventions
+
+When adding or refactoring functional APIs, use this rule of thumb for failures:
+
+* Throw JavaScript exceptions only for compile-type contract violations at runtime (for example, a non-string passed where a string is required). In this project, throws are a defensive backstop for runtime type erasure and untyped JavaScript callers.
+* Return `Result` failures for domain-invalid values that are still in the expected representation domain (for example, missing or empty string input).
+
+This split keeps normal validation failures composable through `Result.map` / `Result.flatMap`, while reserving exceptions for clear programmer misuse.
+
 ## Devcontainer Compose ports and project naming
 
 The devcontainer uses Docker Compose with container ports published without fixed host ports. Docker assigns an available host

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Agent behavior in this repository is configured to read `~/.agents/README.md` fi
 
 When adding or refactoring functional APIs, use this rule of thumb for failures:
 
-* Throw JavaScript exceptions only for compile-type contract violations at runtime (for example, a non-string passed where a string is required). In this project, throws are a defensive backstop for runtime type erasure and untyped JavaScript callers.
+* Throw JavaScript exceptions only for compile-time contract violations at runtime (for example, a non-string passed where a string is required). In this project, throws are a defensive backstop for runtime type erasure and untyped JavaScript callers.
 * Return `Result` failures for domain-invalid values that are still in the expected representation domain (for example, missing or empty string input).
 
 This split keeps normal validation failures composable through `Result.map` / `Result.flatMap`, while reserving exceptions for clear programmer misuse.

--- a/loader/$api-Function.fifty.ts
+++ b/loader/$api-Function.fifty.ts
@@ -868,6 +868,10 @@ namespace slime.$api.fp {
 	export type Some<T> = Readonly<{ present: true, value: T }>
 	export type Maybe<T> = Some<T> | Nothing
 
+	export type Success<T> = Readonly<{ ok: true, value: T }>
+	export type Failure<E> = Readonly<{ ok: false, error: E }>
+	export type Result<E,T> = Success<T> | Failure<E>
+
 	export interface Exports {
 		Maybe: {
 			from: {
@@ -898,6 +902,17 @@ namespace slime.$api.fp {
 				): (a: A) => Maybe<C>
 			}
 		}
+
+		Result: {
+			from: {
+				success: <T>(t: T) => Success<T>
+				failure: <E>(e: E) => Failure<E>
+			}
+
+			map: <E,T,R>(f: (t: T) => R) => (r: Result<E,T>) => Result<E,R>
+			flatMap: <E,T,E2,R>(f: (t: T) => Result<E2,R>) => (r: Result<E,T>) => Result<E|E2,R>
+			mapError: <E,E2,T>(f: (e: E) => E2) => (r: Result<E,T>) => Result<E2,T>
+		}
 	}
 
 	(
@@ -927,6 +942,44 @@ namespace slime.$api.fp {
 				if (quarter4.present) verify(quarter4).value.is(1);
 				verify(quarterEvenly(2)).present.is(false);
 				verify(quarterEvenly(1)).present.is(false);
+			}
+
+			fifty.tests.exports.Result = fifty.test.Parent();
+
+			fifty.tests.exports.Result.map = function() {
+				var doubled = $api.fp.now(
+					$api.fp.Result.from.success(2),
+					$api.fp.Result.map(function(n: number) { return n*2; })
+				);
+				verify(doubled).evaluate.property("ok").is(true);
+				if (doubled.ok) verify(doubled).value.is(4);
+
+				var failed = $api.fp.now(
+					$api.fp.Result.from.failure("boom"),
+					$api.fp.Result.map(function(n: number) { return n*2; })
+				);
+				verify(failed).evaluate.property("ok").is(false);
+				if ("error" in failed) verify(failed.error).is("boom");
+			}
+
+			fifty.tests.exports.Result.flatMap = function() {
+				var half = function(n: number): Result<string,number> {
+					if (n%2 == 0) return $api.fp.Result.from.success(n/2);
+					return $api.fp.Result.from.failure("odd");
+				}
+
+				var quarter = $api.fp.pipe(
+					half,
+					$api.fp.Result.flatMap(half)
+				);
+
+				var fromFour = quarter(4);
+				verify(fromFour).evaluate.property("ok").is(true);
+				if (fromFour.ok) verify(fromFour).value.is(1);
+
+				var fromTwo = quarter(2);
+				verify(fromTwo).evaluate.property("ok").is(false);
+				if ("error" in fromTwo) verify(fromTwo.error).is("odd");
 			}
 		}
 	//@ts-ignore

--- a/loader/$api-Function.js
+++ b/loader/$api-Function.js
@@ -98,19 +98,24 @@
 					},
 					map: function(f) {
 						return function(r) {
-							if ("value" in r) return success(f(r.value));
-							return failure(r.error);
+							if (r.ok) return success(f(r.value));
+							var notOk = /** @type {{ error: any }} */(r);
+							return failure(notOk.error);
 						}
 					},
 					flatMap: function(f) {
 						return function(r) {
-							if ("value" in r) return f(r.value);
-							return failure(r.error);
+							if (r.ok) return f(r.value);
+							var notOk = /** @type {{ error: any }} */(r);
+							return failure(notOk.error);
 						}
 					},
 					mapError: function(f) {
 						return function(r) {
-							if ("error" in r) return failure(f(r.error));
+							if (!r.ok) {
+								var notOk = /** @type {{ error: any }} */(r);
+								return failure(f(notOk.error));
+							}
 							return success(r.value);
 						}
 					}

--- a/loader/$api-Function.js
+++ b/loader/$api-Function.js
@@ -78,6 +78,46 @@
 			}
 		)();
 
+		var Result = (
+			/** @type { () => slime.$api.fp.Exports["Result"] } */
+			function() {
+				/** @type { slime.$api.fp.Exports["Result"]["from"]["success"] } */
+				var success = function(v) {
+					return { ok: true, value: v };
+				};
+
+				/** @type { slime.$api.fp.Exports["Result"]["from"]["failure"] } */
+				var failure = function(e) {
+					return { ok: false, error: e };
+				};
+
+				return {
+					from: {
+						success: success,
+						failure: failure
+					},
+					map: function(f) {
+						return function(r) {
+							if ("value" in r) return success(f(r.value));
+							return failure(r.error);
+						}
+					},
+					flatMap: function(f) {
+						return function(r) {
+							if ("value" in r) return f(r.value);
+							return failure(r.error);
+						}
+					},
+					mapError: function(f) {
+						return function(r) {
+							if ("error" in r) return failure(f(r.error));
+							return success(r.value);
+						}
+					}
+				}
+			}
+		)();
+
 		/** @type { slime.$api.fp.Exports["Partial"] } */
 		var Partial = {
 			from: {
@@ -549,6 +589,7 @@
 				fromEntries: Object.fromEntries
 			},
 			Maybe: Maybe,
+			Result: Result,
 			Partial: Partial,
 			switch: function(cases) {
 				return function(p) {

--- a/rhino/shell/java.fifty.ts
+++ b/rhino/shell/java.fifty.ts
@@ -35,9 +35,18 @@ namespace slime.jrunscript.shell.java {
 		base: string
 	}
 
+	export type JdkFromBaseError = (
+		| {
+			type: "empty-base"
+			missing: "null" | "undefined" | "empty-string"
+		}
+	)
+
 	export interface Exports extends Invoke {
 		Jdk: {
 			from: {
+				base: (base: string) => slime.$api.fp.Result<JdkFromBaseError,Jdk>
+
 				/**
 				 * Returns a Jdk object based on the value of the `java.home` property.
 				 */
@@ -67,7 +76,41 @@ namespace slime.jrunscript.shell.java {
 		function(
 			fifty: slime.fifty.test.Kit
 		) {
+			const { verify } = fifty;
+			const { $api } = fifty.global;
+			const { subject } = test;
+
+			var asAny: slime.js.Cast<any> = $api.fp.cast.unsafe;
+
 			fifty.tests.suite = function() {
+				var fromEmpty = subject.Jdk.from.base("");
+				verify(fromEmpty).evaluate.property("ok").is(false);
+				if ("error" in fromEmpty) {
+					verify(fromEmpty.error.type).is("empty-base");
+					verify(fromEmpty.error.missing).is("empty-string");
+				}
+
+				var fromNull = subject.Jdk.from.base(asAny(null));
+				verify(fromNull).evaluate.property("ok").is(false);
+				if ("error" in fromNull) {
+					verify(fromNull.error.type).is("empty-base");
+					verify(fromNull.error.missing).is("null");
+				}
+
+				var fromUndefined = subject.Jdk.from.base(asAny(void(0)));
+				verify(fromUndefined).evaluate.property("ok").is(false);
+				if ("error" in fromUndefined) {
+					verify(fromUndefined.error.type).is("empty-base");
+					verify(fromUndefined.error.missing).is("undefined");
+				}
+
+				verify(3).evaluate(function(value) {
+					subject.Jdk.from.base(asAny(value));
+				}).threw.type(TypeError);
+
+				var normalized = subject.Jdk.from.base("  /jdk/home  ");
+				verify(normalized).evaluate.property("ok").is(true);
+				if ("value" in normalized) verify(normalized.value.base).is("/jdk/home");
 			}
 		}
 	//@ts-ignore

--- a/rhino/shell/java.js
+++ b/rhino/shell/java.js
@@ -13,18 +13,42 @@
 	 * @param { slime.loader.Export<Pick<slime.jrunscript.shell.java.Exports,"Jdk">> } $export
 	 */
 	function($api,$context,$export) {
+		/** @type { slime.jrunscript.shell.java.Exports["Jdk"]["from"]["base"] } */
+		var fromBase = function(base) {
+			if (base === null || typeof(base) == "undefined") {
+				return $api.fp.Result.from.failure({
+					type: "empty-base",
+					missing: (base === null) ? "null" : "undefined"
+				});
+			}
+			if (typeof(base) != "string") {
+				throw new TypeError("Expected string base, got " + typeof(base));
+			}
+			var normalized = base.trim();
+			if (normalized.length == 0) {
+				return $api.fp.Result.from.failure({
+					type: "empty-base",
+					missing: "empty-string"
+				});
+			}
+			return $api.fp.Result.from.success({ base: normalized });
+		};
+
 		$export({
 			Jdk: {
 				from: {
+					base: fromBase,
 					javaHome: function() {
 						var home = $context.home();
 						var javaHome = home.pathname;
 						//	TODO	workaround for JDK 8. Really, we should figure out a better API for determining Java home directory
 						//			under various versions.
 						if (javaHome.basename == "jre") javaHome = javaHome.parent;
-						return {
-							base: javaHome.toString()
-						};
+						var from = fromBase(javaHome.toString());
+						if (from.ok === false) {
+							throw new Error("Could not create Jdk from java.home: " + JSON.stringify(from.error));
+						}
+						return from.value;
 					}
 				},
 				jrunscript: function(jdk) {


### PR DESCRIPTION
## Summary

This change introduces a first-class `Result` type in `$api.fp`, applies it to `jsh.shell.java.Jdk.from.base`, and documents the project error-handling convention for FP APIs.

## Changes

- Add `$api.fp.Result` with helpers:
  - `Result.from.success`
  - `Result.from.failure`
  - `Result.map`
  - `Result.flatMap`
  - `Result.mapError`
- Add Fifty coverage for `Result.map` and `Result.flatMap` in the fp module tests.
- Update `rhino/shell/java`:
  - `Jdk.from.base` now returns `Result`.
  - Runtime contract:
    - non-string values throw `TypeError`.
    - null/undefined/empty-string are represented as `Result` failure (`empty-base`) with `missing` detail.
  - `Jdk.from.javaHome` is routed through `from.base`.
- Add and align contributor guidance:
  - Add "FP error handling conventions" section in `CONTRIBUTING.md`.
  - Add a quick-start agent checklist in `AGENTS.md` and point it to the FP error-handling section.

## Validation

- `./wf tsc --vscode` passed.
- `./fifty test.jsh /slime/loader/$api-Function.fifty.ts` passed.
- `./fifty test.jsh /slime/rhino/shell/java.fifty.ts` passed.