### PR TITLE
Model Jdk.from.javaHome as a value property

### DIFF
--- a/contributor/jrunscript.jsh.js
+++ b/contributor/jrunscript.jsh.js
@@ -25,9 +25,7 @@
 		jsh.script.cli.main(
 			$api.fp.pipe(
 				function(p) {
-					// TODO: force CoffeeScript for verification?
-
-					var jrunscript = $api.fp.Thunk.now(
+					var jrunscript = $api.fp.now(
 						jsh.shell.java.Jdk.from.javaHome,
 						//	TODO	below should use $api.fp.build
 						$api.fp.now(

--- a/contributor/plugin.jsh.js
+++ b/contributor/plugin.jsh.js
@@ -21,6 +21,8 @@
 		plugin({
 			isReady: function() { return Boolean(jsh.unit) && Boolean(jsh.project); },
 			load: function() {
+				// TODO: force CoffeeScript for verification?
+
 				var code = {
 					/** @type { slime.project.internal.jrunscript_environment.Script } */
 					Environment: $loader.script("jrunscript-environment.js")

--- a/jrunscript/jsh/launcher/test/suite.js
+++ b/jrunscript/jsh/launcher/test/suite.js
@@ -195,7 +195,7 @@
 						//	TODO	considered passing the location of jrunscript directly but it might affect native launcher, which
 						//			currently contains its own logic for locating jrunscript. So for now we pass this (somewhat
 						//			inaccurately-named, since it might not really be JAVA_HOME) value
-						{ JSH_LAUNCHER_JDK_HOME: $context.library.shell.java.Jdk.from.javaHome().base },
+						{ JSH_LAUNCHER_JDK_HOME: $context.library.shell.java.Jdk.from.javaHome.base },
 						$api.Object.compose(
 							(p.bash && p.logging) ? { JSH_LOG_JAVA_PROPERTIES: p.logging } : {},
 							($context.library.shell.environment.JSH_SHELL_LIB) ? { JSH_SHELL_LIB: $context.library.shell.environment.JSH_SHELL_LIB } : {}

--- a/jrunscript/jsh/loader/jsh.fifty.ts
+++ b/jrunscript/jsh/loader/jsh.fifty.ts
@@ -380,7 +380,7 @@ namespace slime.jsh {
 
 				const withJava = function(environment: { [name: string]: string }): { [name: string]: string } {
 					var javaBin = $api.fp.now(
-						jsh.shell.java.Jdk.from.javaHome().base,
+						jsh.shell.java.Jdk.from.javaHome.base,
 						jsh.file.Location.from.os,
 						jsh.file.Location.directory.relativePath("bin"),
 						$api.fp.property("pathname")

--- a/jrunscript/jsh/script/plugin.jsh.fifty.ts
+++ b/jrunscript/jsh/script/plugin.jsh.fifty.ts
@@ -82,7 +82,7 @@ namespace slime.jsh.script {
 
 			const environmentWithJavaInPath: slime.$api.fp.Transform<slime.jrunscript.shell.run.Environment> = function(given) {
 				var PATH = given.PATH.split(":");
-				var home = jsh.shell.java.Jdk.from.javaHome();
+				var home = jsh.shell.java.Jdk.from.javaHome;
 				var insert = jsh.file.Pathname(home.base).directory.getRelativePath("bin").toString();
 				//var insert = jsh.shell.java.home.getRelativePath("bin").toString();
 				jsh.shell.console("Inserting: " + insert);

--- a/jrunscript/jsh/shell/jsh.fifty.ts
+++ b/jrunscript/jsh/shell/jsh.fifty.ts
@@ -448,7 +448,7 @@ namespace slime.jsh.shell {
 			};
 
 			var getJavaHome = function() {
-				var h = jsh.shell.java.Jdk.from.javaHome();
+				var h = jsh.shell.java.Jdk.from.javaHome;
 				return jsh.file.Pathname(h.base).directory;
 			}
 
@@ -567,7 +567,7 @@ namespace slime.jsh.shell {
 						environment: function(was) {
 							var PATH = (function() {
 								var now = jsh.shell.PATH.pathnames;
-								var jdk = jsh.shell.java.Jdk.from.javaHome();
+								var jdk = jsh.shell.java.Jdk.from.javaHome;
 								var bin = jsh.file.Pathname(jdk.base + "/" + "bin");
 								now.unshift(bin);
 								return jsh.file.Searchpath(now);
@@ -605,7 +605,7 @@ namespace slime.jsh.shell {
 						environment: function(was) {
 							//	TODO	maybe we should standardize all this to make it easier to work with native executable
 							//			launcher
-							var jdk = jsh.shell.java.Jdk.from.javaHome();
+							var jdk = jsh.shell.java.Jdk.from.javaHome;
 							var PATH = (function() {
 								var now = jsh.shell.PATH.pathnames;
 								var bin = jsh.file.Pathname(jdk.base + "/" + "bin");
@@ -839,7 +839,7 @@ namespace slime.jsh.shell {
 						var pathnames = jsh.shell.PATH.pathnames;
 						pathnames.unshift(
 							jsh.file.Pathname(
-								jsh.shell.java.Jdk.from.javaHome().base
+								jsh.shell.java.Jdk.from.javaHome.base
 							).directory.getRelativePath("bin")
 						);
 						return jsh.file.Searchpath(pathnames).toString();

--- a/jrunscript/jsh/suite.fifty.ts
+++ b/jrunscript/jsh/suite.fifty.ts
@@ -81,7 +81,7 @@ namespace slime.jsh.test {
 				var shell = fixtures.shells.built(true);
 				if (ISSUE_2039_RESOLVED && shell) {
 					var home = jsh.file.Pathname(shell.home).directory;
-					var jdk = jsh.shell.java.Jdk.from.javaHome();
+					var jdk = jsh.shell.java.Jdk.from.javaHome;
 					var jdkBin = $api.fp.now(jdk.base, jsh.file.Location.from.os, jsh.file.Location.directory.relativePath("bin"));
 
 					var addJavaToPath = function(existing) {
@@ -282,7 +282,7 @@ namespace slime.jsh.test {
 					environment: function(base) {
 						return fifty.global.$api.Object.compose(
 							base,
-							{ JSH_LAUNCHER_JDK_HOME: jsh.shell.java.Jdk.from.javaHome().base },
+							{ JSH_LAUNCHER_JDK_HOME: jsh.shell.java.Jdk.from.javaHome.base },
 							{ JSH_ENGINE: engine || null }
 						);
 					},

--- a/jrunscript/jsh/tools/ncdbg.jsh.js
+++ b/jrunscript/jsh/tools/ncdbg.jsh.js
@@ -145,7 +145,7 @@
 					args.push("--lazy");
 				}
 				var JAVA_HOME = (function() {
-					var h = jsh.shell.java.Jdk.from.javaHome();
+					var h = jsh.shell.java.Jdk.from.javaHome;
 					return jsh.file.Pathname(h.base).directory;
 				})();
 				jsh.shell.run({

--- a/jrunscript/jsh/tools/suite.fifty.ts
+++ b/jrunscript/jsh/tools/suite.fifty.ts
@@ -21,7 +21,7 @@ namespace slime.jsh.tools.test {
 				var tmp = jsh.shell.TMPDIR.createTemporary({ directory: true });
 
 				var environmentWithJdk = function(now) {
-					var jdk = jsh.shell.java.Jdk.from.javaHome();
+					var jdk = jsh.shell.java.Jdk.from.javaHome;
 
 					var jdkBin = $api.fp.now(jdk, $api.fp.property("base"), jsh.file.Location.from.os, jsh.file.Location.directory.relativePath("bin"));
 

--- a/rhino/http/servlet/suite.fifty.ts
+++ b/rhino/http/servlet/suite.fifty.ts
@@ -20,7 +20,7 @@ namespace slime.servlet {
 			//	TODO	standardize; remove duplicate with this exact name in another file
 			const environmentWithJavaInPath: slime.$api.fp.Transform<slime.jrunscript.shell.run.Environment> = function(given) {
 				var PATH = given.PATH.split(":");
-				var home = jsh.shell.java.Jdk.from.javaHome();
+				var home = jsh.shell.java.Jdk.from.javaHome;
 				var insert = jsh.file.Pathname(home.base).directory.getRelativePath("bin").toString();
 				//var insert = jsh.shell.java.home.getRelativePath("bin").toString();
 				jsh.shell.console("Inserting: " + insert);

--- a/rhino/shell/java.fifty.ts
+++ b/rhino/shell/java.fifty.ts
@@ -48,9 +48,9 @@ namespace slime.jrunscript.shell.java {
 				base: (base: string) => slime.$api.fp.Result<JdkFromBaseError,Jdk>
 
 				/**
-				 * Returns a Jdk object based on the value of the `java.home` property.
+				 * The Jdk value corresponding to the JDK referenced by the `java.home` property.
 				 */
-				javaHome: () => Jdk
+				javaHome: Jdk
 			}
 
 			jrunscript: (jdk: Jdk) => slime.$api.fp.Maybe<string>
@@ -65,7 +65,7 @@ namespace slime.jrunscript.shell.java {
 			const { subject } = test;
 
 			fifty.tests.manual.Jdk = function() {
-				var jdk = subject.Jdk.from.javaHome();
+				var jdk = subject.Jdk.from.javaHome;
 				jsh.shell.console(jdk.base);
 			}
 		}

--- a/rhino/shell/java.js
+++ b/rhino/shell/java.js
@@ -36,21 +36,29 @@
 
 		$export({
 			Jdk: {
-				from: {
-					base: fromBase,
-					javaHome: function() {
-						var home = $context.home();
-						var javaHome = home.pathname;
-						//	TODO	workaround for JDK 8. Really, we should figure out a better API for determining Java home directory
-						//			under various versions.
-						if (javaHome.basename == "jre") javaHome = javaHome.parent;
-						var from = fromBase(javaHome.toString());
-						if (from.ok === false) {
-							throw new Error("Could not create Jdk from java.home: " + JSON.stringify(from.error));
+				from: $api.fp.now(
+					{
+						base: fromBase
+					},
+					$api.Object.defineProperty({
+						name: "javaHome",
+						descriptor: {
+							enumerable: true,
+							get: function() {
+								var home = $context.home();
+								var javaHome = home.pathname;
+								//	TODO	workaround for JDK 8. Really, we should figure out a better API for determining Java home directory
+								//			under various versions.
+								if (javaHome.basename == "jre") javaHome = javaHome.parent;
+								var from = fromBase(javaHome.toString());
+								if (from.ok === false) {
+									throw new Error("Could not create Jdk from java.home: " + JSON.stringify(from.error));
+								}
+								return from.value;
+							}
 						}
-						return from.value;
-					}
-				},
+					})
+				),
 				jrunscript: function(jdk) {
 					return $context.getJrunscriptPathFromJdk(jdk.base);
 				}

--- a/rhino/shell/module.js
+++ b/rhino/shell/module.js
@@ -533,7 +533,7 @@
 					//			That's one of the reasons the VM arguments are split out; they need to be prefixed with `-J` in
 					//			`jrunscript` but not for the `java` launcher.
 
-					var jdk = (j.jdk) ? j.jdk : $exports.java.Jdk.from.javaHome();
+					var jdk = (j.jdk) ? j.jdk : $exports.java.Jdk.from.javaHome;
 					var jdkBase = $context.api.file.Location.from.os(jdk.base);
 					var _jdkBase = $context.api.file.Location.java.File.simple(jdkBase);
 					var jdkInstall = $context.api.bootstrap.java.Install(_jdkBase);

--- a/rhino/tools/maven/mvnw.jsh.fifty.ts
+++ b/rhino/tools/maven/mvnw.jsh.fifty.ts
@@ -77,7 +77,7 @@ namespace slime.jrunscript.tools.maven.script.mvnw {
 							rv.push("install");
 						}),
 						environment: function(was) {
-							return $api.Object.compose(was, { JAVA_HOME: jsh.shell.java.Jdk.from.javaHome().base });
+							return $api.Object.compose(was, { JAVA_HOME: jsh.shell.java.Jdk.from.javaHome.base });
 						},
 						directory: project,
 						stdio: {

--- a/rhino/tools/maven/mvnw.jsh.js
+++ b/rhino/tools/maven/mvnw.jsh.js
@@ -62,7 +62,7 @@
 						)
 					);
 
-					var jdk = jsh.shell.java.Jdk.from.javaHome();
+					var jdk = jsh.shell.java.Jdk.from.javaHome;
 
 					if (p.options.archetype) {
 						jsh.shell.console("Generating project from archetype ...");

--- a/tools/wf/plugin-standard.jsh.fifty.ts
+++ b/tools/wf/plugin-standard.jsh.fifty.ts
@@ -232,7 +232,7 @@ namespace slime.jsh.wf.standard {
 									environment: $api.Object.compose(
 										jsh.shell.environment,
 										{
-											JSH_LAUNCHER_JDK_HOME: jsh.shell.java.Jdk.from.javaHome().base
+											JSH_LAUNCHER_JDK_HOME: jsh.shell.java.Jdk.from.javaHome.base
 										}
 									)
 								});
@@ -375,7 +375,7 @@ namespace slime.jsh.wf.standard {
 							environment: Object.assign({},
 								jsh.shell.environment,
 								{
-									JSH_LAUNCHER_JDK_HOME: jsh.shell.java.Jdk.from.javaHome().base,
+									JSH_LAUNCHER_JDK_HOME: jsh.shell.java.Jdk.from.javaHome.base,
 									PROJECT: repository.directory.toString()
 								},
 								environment


### PR DESCRIPTION
## Summary

Model `Jdk.from.javaHome` as a value property instead of a thunk-style function, and update callers accordingly.

## Changes

- Change Java shell API shape:
  - `Jdk.from.javaHome` is now a `Jdk` value property (getter-backed) rather than `() => Jdk`.
- Implement property definition in `rhino/shell/java.js` using `$api.Object.defineProperty` over the `from` object.
- Update type documentation in `rhino/shell/java.fifty.ts` to match value semantics.
- Update call sites across jsh/rhino/tools/tests from `Jdk.from.javaHome()` to `Jdk.from.javaHome`.
- Keep existing `from.base` validation behavior and error semantics unchanged.

## Validation

- `./wf tsc --vscode` passed during commit checks.
- Repository commit checks (ESLint + MPL header + TypeScript) passed.