### PR TITLE
Add fp.build and migrate jrunscript composition call

### DIFF
--- a/contributor/jrunscript.jsh.js
+++ b/contributor/jrunscript.jsh.js
@@ -27,8 +27,7 @@
 				function(p) {
 					var jrunscript = $api.fp.now(
 						jsh.shell.java.Jdk.from.javaHome,
-						//	TODO	below should use $api.fp.build
-						$api.fp.now(
+						$api.fp.build(
 							jsh.shell.java.Jdk.jrunscript,
 							$api.fp.Partial.impure.exception(function(jdk) {
 								return new Error("Could not resolve jrunscript for JDK home: " + jdk.base);

--- a/contributor/jrunscript.jsh.js
+++ b/contributor/jrunscript.jsh.js
@@ -29,7 +29,7 @@
 						jsh.shell.java.Jdk.from.javaHome,
 						$api.fp.build(
 							jsh.shell.java.Jdk.jrunscript,
-							$api.fp.Partial.impure.exception(function(jdk) {
+							$api.fp.Partial.impure.exception(function(/** @type { slime.jrunscript.shell.java.Jdk } */jdk) {
 								return new Error("Could not resolve jrunscript for JDK home: " + jdk.base);
 							})
 						)

--- a/loader/$api-Function.fifty.ts
+++ b/loader/$api-Function.fifty.ts
@@ -1685,6 +1685,33 @@ namespace slime.$api.fp {
 			: Input
 	)
 
+	type NowFunctionFirstDeprecated = {
+		/**
+		 * @deprecated Use {@link Exports.build | `$api.fp.build`} when the first argument to `now` is a function value.
+		 */
+		<
+			F extends slime.external.lib.es5.TypescriptFunction,
+			S1Out
+		>(
+			f: F,
+			s1: (f: F) => S1Out
+		): S1Out
+
+		/**
+		 * @deprecated Use {@link Exports.build | `$api.fp.build`} when the first argument to `now` is a function value.
+		 */
+		<
+			F extends slime.external.lib.es5.TypescriptFunction,
+			S1Out,
+			S1 extends (f: F) => S1Out,
+			SRest extends readonly BuildStep[]
+		>(
+			f: F,
+			s1: S1,
+			...rest: BuildStepChain<S1Out, SRest>
+		): BuildResult<S1Out, SRest>
+	}
+
 	export interface Exports {
 		/**
 		 * Returns the result of transforming a function value through one or more combinators.
@@ -1715,7 +1742,7 @@ namespace slime.$api.fp {
 		 * Returns the result of invoking a function on an argument. `now(p, f)` is syntactic sugar for `f(p)`, and
 		 * `now(p, f, g) is syntactic sugar for `g(f(p))`.
 		 */
-		now: Now_map & {
+		now: NowFunctionFirstDeprecated & Now_map & {
 			/**
 			 * @deprecated Replaced by {@link Exports.now}.
 			 */

--- a/loader/$api-Function.fifty.ts
+++ b/loader/$api-Function.fifty.ts
@@ -1663,7 +1663,54 @@ namespace slime.$api.fp {
 	//@ts-ignore
 	)(fifty);
 
+	type BuildStep = (x: unknown) => unknown
+
+	type BuildStepChain<Input, Steps extends readonly BuildStep[]> = (
+		Steps extends readonly [infer S, ...infer Rest]
+			? S extends (x: Input) => infer Next
+				? Rest extends readonly BuildStep[]
+					? [S, ...BuildStepChain<Next, Rest>]
+					: never
+				: never
+			: []
+	)
+
+	type BuildResult<Input, Steps extends readonly BuildStep[]> = (
+		Steps extends readonly [infer S, ...infer Rest]
+			? S extends (x: Input) => infer Next
+				? Rest extends readonly BuildStep[]
+					? BuildResult<Next, Rest>
+					: never
+				: never
+			: Input
+	)
+
 	export interface Exports {
+		/**
+		 * Returns the result of transforming a function value through one or more combinators.
+		 * `build(f, g)` is syntactic sugar for `g(f)`, and `build(f, g, h)` is syntactic sugar for `h(g(f))`.
+		 */
+		build: {
+			<
+				F extends slime.external.lib.es5.TypescriptFunction,
+				S1Out
+			>(
+				f: F,
+				s1: (f: F) => S1Out
+			): S1Out
+
+			<
+				F extends slime.external.lib.es5.TypescriptFunction,
+				S1Out,
+				S1 extends (f: F) => S1Out,
+				SRest extends readonly BuildStep[]
+			>(
+				f: F,
+				s1: S1,
+				...rest: BuildStepChain<S1Out, SRest>
+			): BuildResult<S1Out, SRest>
+		}
+
 		/**
 		 * Returns the result of invoking a function on an argument. `now(p, f)` is syntactic sugar for `f(p)`, and
 		 * `now(p, f, g) is syntactic sugar for `g(f(p))`.
@@ -1687,6 +1734,21 @@ namespace slime.$api.fp {
 		) {
 			const { verify } = fifty;
 			const { $api } = fifty.global;
+
+			fifty.tests.exports.build = function() {
+				var times2 = function(n: number): number {
+					return n * 2;
+				};
+
+				var logging = function(f: (n: number) => number) {
+					return function(p: number): number {
+						return f(p);
+					};
+				};
+
+				var loggedTimes2 = $api.fp.build(times2, logging);
+				verify(loggedTimes2(3)).is(6);
+			};
 
 			fifty.tests.exports.now = function() {
 				var f = function(i: number): string {

--- a/loader/$api-Function.fifty.ts
+++ b/loader/$api-Function.fifty.ts
@@ -1740,7 +1740,7 @@ namespace slime.$api.fp {
 
 		/**
 		 * Returns the result of invoking a function on an argument. `now(p, f)` is syntactic sugar for `f(p)`, and
-		 * `now(p, f, g) is syntactic sugar for `g(f(p))`.
+		 * `now(p, f, g)` is syntactic sugar for `g(f(p))`.
 		 */
 		now: NowFunctionFirstDeprecated & Now_map & {
 			/**
@@ -1763,6 +1763,8 @@ namespace slime.$api.fp {
 			const { $api } = fifty.global;
 
 			fifty.tests.exports.build = function() {
+				var buildUntyped = $api.fp.build as any;
+
 				var times2 = function(n: number): number {
 					return n * 2;
 				};
@@ -1775,6 +1777,18 @@ namespace slime.$api.fp {
 
 				var loggedTimes2 = $api.fp.build(times2, logging);
 				verify(loggedTimes2(3)).is(6);
+
+				verify(times2).evaluate(function(f) {
+					return buildUntyped(f);
+				}).threw.type(TypeError);
+
+				verify(3).evaluate(function(n) {
+					return buildUntyped(n, logging);
+				}).threw.type(TypeError);
+
+				verify(times2).evaluate(function(f) {
+					return buildUntyped(f, 42);
+				}).threw.type(TypeError);
 			};
 
 			fifty.tests.exports.now = function() {

--- a/loader/$api-Function.js
+++ b/loader/$api-Function.js
@@ -276,6 +276,12 @@
 			return pipe.apply(this, items.slice(1))(items[0]);
 		}
 
+		var build_map = function() {
+			if (arguments.length < 2) throw new TypeError();
+			if (typeof(arguments[0]) != "function") throw new TypeError("First argument must be a function.");
+			return now_map.apply(this, arguments);
+		}
+
 		/** @type { <T>(ordering: slime.$api.fp.Ordering<T>) => slime.$api.fp.CompareFn<T> } */
 		var orderingToJs = function(ordering) {
 			return function(a,b) {
@@ -802,6 +808,7 @@
 				invoke: now_map,
 				map: now_map
 			}),
+			build: build_map,
 			result: now_map,
 			object: {
 				Update: {

--- a/loader/$api-Function.js
+++ b/loader/$api-Function.js
@@ -279,6 +279,11 @@
 		var build_map = function() {
 			if (arguments.length < 2) throw new TypeError();
 			if (typeof(arguments[0]) != "function") throw new TypeError("First argument must be a function.");
+			for (var i=1; i<arguments.length; i++) {
+				if (typeof(arguments[i]) != "function") {
+					throw new TypeError("All arguments after index 0 must be functions; index " + i + " is not.");
+				}
+			}
 			return now_map.apply(this, arguments);
 		}
 


### PR DESCRIPTION
## Summary
- add `$api.fp.build` runtime support in fp core
- add TypeScript declaration/tests for `$api.fp.build`
- migrate the nested function-construction usage in `contributor/jrunscript.jsh.js` from `$api.fp.now(...)` to `$api.fp.build(...)`

## Validation
- project pre-commit checks passed (ESLint, MPL header check, TypeScript)
- branch pushed as `ci-faster`

Creating this PR as a checkpoint before evaluating a soft deprecation for function-first `$api.fp.now` usage.