### PR TITLE
Refactor paged GitHub operation typing

### DIFF
--- a/rhino/tools/github/module.fifty.ts
+++ b/rhino/tools/github/module.fifty.ts
@@ -97,6 +97,18 @@ namespace slime.jrunscript.tools.github {
 
 		export interface Paged<I,O> extends Operation<I,O[]> {
 		}
+
+		export type PagedResponseElement<P extends keyof slime.external.github.rest.Endpoints> =
+			slime.external.github.rest.Endpoints[P]["response"]["data"] extends readonly (infer T)[] ? T : never
+
+		export type PagedOperation<P extends keyof slime.external.github.rest.Endpoints> = Paged<
+			slime.external.github.rest.Endpoints[P]["parameters"],
+			PagedResponseElement<P>
+		>
+
+		export type PagedOperations = {
+			"GET /user/repos": PagedOperation<"GET /user/repos">
+		}
 	}
 
 	(
@@ -256,10 +268,7 @@ namespace slime.jrunscript.tools.github {
 			}
 
 			fifty.tests.world.ReposListForAuthenticatedUser = function() {
-				var listUserRepos: rest.Paged<
-					slime.external.github.rest.Endpoints["GET /user/repos"]["parameters"],
-					slime.external.github.rest.Endpoints["GET /user/repos"]["response"]
-				> = {
+				var listUserRepos: rest.PagedOperation<"GET /user/repos"> = {
 					request: subject.request.get("user/repos"),
 					response: subject.response.json.page
 				};


### PR DESCRIPTION
## Summary
- introduce a reusable `PagedOperation<P>` type for GitHub REST paginated operations
- add `PagedResponseElement<P>` to infer element types from endpoint response data arrays
- simplify `GET /user/repos` typed operation usage to remove repeated boilerplate

## Notes
- this change is type-level refactoring only
- existing behavior is unchanged