### PR TITLE
Refactor time context to world namespace

### DIFF
--- a/js/time/context.browser.js
+++ b/js/time/context.browser.js
@@ -74,8 +74,10 @@
 		}, {});
 
 		$export({
-			zones: zones
-		})
+			world: {
+				zones: zones
+			}
+		});
 	}
 //@ts-ignore
 )($api,$export);

--- a/js/time/context.java.js
+++ b/js/time/context.java.js
@@ -43,18 +43,20 @@
 		};
 
 		$export({
-			zones: (
-				function() {
-					var TimeZone = Packages.java.util.TimeZone;
-					/** @type { slime.time.Context["zones"] } */
-					var rv = {};
-					var jstrings = TimeZone.getAvailableIDs();
-					for (var i=0; i<jstrings.length; i++) {
-						rv[String(jstrings[i])] = Zone(TimeZone.getTimeZone(jstrings[i]));
+			world: {
+				zones: (
+					function() {
+						var TimeZone = Packages.java.util.TimeZone;
+						/** @type { slime.time.World["zones"] } */
+						var rv = {};
+						var jstrings = TimeZone.getAvailableIDs();
+						for (var i=0; i<jstrings.length; i++) {
+							rv[String(jstrings[i])] = Zone(TimeZone.getTimeZone(jstrings[i]));
+						}
+						return rv;
 					}
-					return rv;
-				}
-			)()
+				)()
+			}
 		})
 	}
 //@ts-ignore

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -64,7 +64,27 @@ namespace slime.time {
 		}
 	}
 
-	export type Context = Partial<World>;
+	export interface Exports {
+		world: {
+			Date: {
+				now: World["now"]
+				zones: {
+					local: world.Zone
+					UTC: world.Zone
+				}
+			}
+		}
+	}
+
+	export interface Context {
+		world?: {
+			now?: World["now"]
+
+			zones?: {
+				[id: string]: world.Zone
+			}
+		}
+	}
 
 	export namespace test {
 		export const { subject, load } = (function(fifty: slime.fifty.test.Kit) {
@@ -129,9 +149,11 @@ namespace slime.time {
 
 				fifty.tests.exports.Value.now = function() {
 					var context: Context = {
-						now: {
-							read: function() {
-								return 1000;
+						world: {
+							now: {
+								read: function() {
+									return 1000;
+								}
 							}
 						}
 					};
@@ -194,8 +216,10 @@ namespace slime.time {
 
 			fifty.tests.exports.Date.today = function() {
 				var subject = test.load({
-					now: {
-						read: $api.fp.Thunk.value(1643907600000)
+					world: {
+						now: {
+							read: $api.fp.Thunk.value(1643907600000)
+						}
 					}
 				});
 				var today = subject.Date.input.today();
@@ -1143,7 +1167,7 @@ namespace slime.time {
 	//@ts-ignore
 	)(fifty);
 
-	export type Exports = Interface
+	export interface Exports extends Interface {}
 
 	export type Script = slime.runtime.loader.Scoped<Context|void,Exports>
 }

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -9,7 +9,7 @@
 	/**
 	 * @param { slime.$api.Global } $api
 	 * @param { slime.time.Context } $context
-	 * @param { slime.loader.Export<slime.time.Interface> } $export
+	 * @param { slime.loader.Export<slime.time.Exports> } $export
 	 */
 	function($api,$context,$export) {
 		// /** @type { never } */
@@ -31,7 +31,6 @@
 							return new Date(local.year,local.month-1,local.day,local.hour,local.minute,local.second).getTime();
 						}
 					},
-					//	TODO	Should we make this conditional on $context.zones.UTC?
 					UTC: {
 						local: function(unix) {
 							var date = new Date(unix);
@@ -51,8 +50,8 @@
 		};
 
 		var context = {
-			now: $context.world.now || world.Date.now,
-			zones: $api.Object.compose(world.Date.zones, $context.world.zones || {})
+			now: ($context.world && $context.world.now) || world.Date.now,
+			zones: $api.Object.compose(world.Date.zones, ($context.world && $context.world.zones) || {})
 		};
 
 		// /**
@@ -1178,6 +1177,7 @@
 		};
 
 		$export({
+			world: world,
 			Value: $api.fp.methods.pin({ now: context.now, zones: context.zones })(Value),
 			Datetime: {
 				date: function(datetime) {

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -12,55 +12,57 @@
 	 * @param { slime.loader.Export<slime.time.Interface> } $export
 	 */
 	function($api,$context,$export) {
-		/**
-		 * The default World implementation.
-		 *
-		 * @type { Pick<slime.time.World,"now"> & { zones: slime.time.Interface["Timezone"] } }
-		 */
+		// /** @type { never } */
+		// var Date;
+
 		var world = {
-			now: { read: function() { return new Date().getTime(); } },
-			zones: {
-				local: new function() {
-					this.local = function(unix) {
-						var date = new Date(unix);
-						return {
-							year: date.getFullYear(), month: date.getMonth()+1, day: date.getDate(),
-							hour: date.getHours(), minute: date.getMinutes(), second: date.getSeconds() + date.getMilliseconds() / 1000
+			Date: {
+				now: { read: function() { return new Date().getTime(); } },
+				zones: {
+					local: {
+						local: function(unix) {
+							var date = new Date(unix);
+							return {
+								year: date.getFullYear(), month: date.getMonth()+1, day: date.getDate(),
+								hour: date.getHours(), minute: date.getMinutes(), second: date.getSeconds() + date.getMilliseconds() / 1000
+							}
+						},
+						unix: function(local) {
+							return new Date(local.year,local.month-1,local.day,local.hour,local.minute,local.second).getTime();
 						}
-					}
-					this.unix = function(local) {
-						return new Date(local.year,local.month-1,local.day,local.hour,local.minute,local.second).getTime();
-					}
-				},
-				//	TODO	Should we make this conditional on $context.zones.UTC?
-				UTC: new function() {
-					this.local = function(unix) {
-						var date = new Date(unix);
-						return {
-							year: date.getUTCFullYear(), month: date.getUTCMonth()+1, day: date.getUTCDate(),
-							hour: date.getUTCHours(), minute: date.getUTCMinutes(), second: date.getUTCSeconds() + date.getUTCMilliseconds() / 1000
-						};
-					}
-					this.unix = function(local) {
-						var wholeSeconds = Math.floor(local.second);
-						var milliseconds = Math.round((local.second - Math.floor(local.second)) * 1000);
-						return Date.UTC(local.year,local.month-1,local.day,local.hour,local.minute,wholeSeconds,milliseconds);
+					},
+					//	TODO	Should we make this conditional on $context.zones.UTC?
+					UTC: {
+						local: function(unix) {
+							var date = new Date(unix);
+							return {
+								year: date.getUTCFullYear(), month: date.getUTCMonth()+1, day: date.getUTCDate(),
+								hour: date.getUTCHours(), minute: date.getUTCMinutes(), second: date.getUTCSeconds() + date.getUTCMilliseconds() / 1000
+							};
+						},
+						unix: function(local) {
+							var wholeSeconds = Math.floor(local.second);
+							var milliseconds = Math.round((local.second - Math.floor(local.second)) * 1000);
+							return Date.UTC(local.year,local.month-1,local.day,local.hour,local.minute,wholeSeconds,milliseconds);
+						}
 					}
 				}
 			}
 		};
 
-		var zones = $api.Object.compose(world.zones, $context.zones || {});
-
-		/** @type { slime.time.World } */
 		var context = {
-			now: (function(now) {
-				if (typeof(now) == "function") return { read: now };
-				if (now && typeof(now.read) == "function") return now;
-				return world.now;
-			})($context.now),
-			zones: zones
-		}
+			now: $context.world.now || world.Date.now,
+			zones: $api.Object.compose(world.Date.zones, $context.world.zones || {})
+		};
+
+		// /**
+		//  * The default World implementation.
+		//  *
+		//  * @type { slime.time.World }
+		//  */
+		// var world = {
+		// 	zones: {}
+		// };
 
 		var harmonize = function(y,m,d) {
 			if (typeof(y) != "number") throw "y not number: " + y;
@@ -1349,7 +1351,7 @@
 					return Date_add(first, -1);
 				}
 			},
-			Timezone: zones,
+			Timezone: context.zones,
 			zone: {
 				Time: {
 					codec: {

--- a/js/time/old.fifty.ts
+++ b/js/time/old.fifty.ts
@@ -5,7 +5,7 @@
 //	END LICENSE
 
 namespace slime.time {
-	export interface World {
+	export interface Context {
 		/** @deprecated */
 		old?: {
 			/** @deprecated */


### PR DESCRIPTION
## Summary
- move exported zone collections in browser and Java contexts under `world.zones`
- reshape time module context wiring to read from `context.world` and compose default zones from `world.Date.zones`
- align typing updates in `module.fifty.ts` and `old.fifty.ts` with the new context shape

## Validation
- commit hooks passed:
  - ESLint
  - MPL header check
  - TypeScript compile (`tsc`)