### PR TITLE
Use AdapterExports for jsh time world typing

### DIFF
--- a/jrunscript/jsh/_.fifty.ts
+++ b/jrunscript/jsh/_.fifty.ts
@@ -256,7 +256,7 @@ namespace slime.jsh {
 		}
 
 		file: slime.jrunscript.file.Plugin
-		time: slime.time.Interface
+		time: slime.time.AdapterExports
 		ip: slime.jrunscript.ip.Exports
 		db: {
 			jdbc: slime.jsh.db.jdbc.Exports


### PR DESCRIPTION
## Summary

- Update the jsh world typing for `time` in `jrunscript/jsh/_.fifty.ts`.
- Use `slime.time.AdapterExports` instead of `slime.time.Interface`.

## Validation

- Commit hooks passed: ESLint, license headers, and TypeScript compile.
