### PR TITLE
Refactor time context to use zone reader

### DIFF
--- a/js/time/context.browser.js
+++ b/js/time/context.browser.js
@@ -74,9 +74,7 @@
 		}, {});
 
 		$export({
-			world: {
-				zones: zones
-			}
+			zones: zones
 		});
 	}
 //@ts-ignore

--- a/js/time/context.java.js
+++ b/js/time/context.java.js
@@ -43,20 +43,18 @@
 		};
 
 		$export({
-			world: {
-				zones: (
-					function() {
-						var TimeZone = Packages.java.util.TimeZone;
-						/** @type { slime.time.World["zones"] } */
-						var rv = {};
-						var jstrings = TimeZone.getAvailableIDs();
-						for (var i=0; i<jstrings.length; i++) {
-							rv[String(jstrings[i])] = Zone(TimeZone.getTimeZone(jstrings[i]));
-						}
-						return rv;
+			zones: (
+				function() {
+					var TimeZone = Packages.java.util.TimeZone;
+					/** @type { slime.time.Context["zones"] } */
+					var rv = {};
+					var jstrings = TimeZone.getAvailableIDs();
+					for (var i=0; i<jstrings.length; i++) {
+						rv[String(jstrings[i])] = Zone(TimeZone.getTimeZone(jstrings[i]));
 					}
-				)()
-			}
+					return rv;
+				}
+			)()
 		})
 	}
 //@ts-ignore

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -29,9 +29,7 @@ namespace slime.time {
 	export interface Datetime extends Date, Time {
 	}
 
-	//	TODO	the below type should probably be deprecated and replaced with two exported functions, while converting the
-	//			world.Zone type to a set of codecs
-
+	//	TODO	could this type be converted to a Codec?
 	/**
 	 * A time zone definition that can be used by the implementation to convert between ECMAScript time values and local times in
 	 * the given time zone.
@@ -59,18 +57,16 @@ namespace slime.time {
 		 */
 		now: slime.$api.fp.impure.Reading<number>
 
-		zones: {
-			[id: string]: world.Zone
-		}
+		zone: slime.$api.fp.impure.Reading<slime.time.Zone>
 	}
 
 	export interface Context {
+		zones?: {
+			[id: string]: world.Zone
+		}
+
 		world?: {
 			now?: World["now"]
-
-			zones?: {
-				[id: string]: world.Zone
-			}
 		}
 	}
 
@@ -1133,6 +1129,12 @@ namespace slime.time {
 	//@ts-ignore
 	)(fifty);
 
+	export interface Interface {
+		value: () => slime.external.lib.es5.TimeValue
+		datetime: () => Datetime
+		date: () => Date
+	}
+
 	(
 		function(
 			fifty: slime.fifty.test.Kit
@@ -1151,8 +1153,14 @@ namespace slime.time {
 	)(fifty);
 
 	export interface Exports {
+		/**
+		 * Helpers to make it easier to construct {@link World} implementations.
+		 */
 		world: {
 			Date: {
+				/**
+				 * A `Reading` that uses the global Date function to determine the current time value.
+				 */
 				now: World["now"]
 
 				Zone: {

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -132,13 +132,15 @@ namespace slime.time {
 				const { load } = test;
 
 				fifty.tests.exports.Value.now = function() {
+					var now = {
+						base: 999,
+						read: function(this: { base: number }) {
+							return this.base + 1;
+						}
+					};
 					var context: Context = {
 						world: {
-							now: {
-								read: function() {
-									return 1000;
-								}
-							}
+							now: now
 						}
 					};
 
@@ -150,8 +152,75 @@ namespace slime.time {
 
 					verify(defaulted).Value.now().is.type("number");
 
-					var now = defaulted.Value.now();
-					verify(now).is(now);
+					var nowValue = defaulted.Value.now();
+					verify(nowValue).is(nowValue);
+				};
+
+				fifty.tests.exports.value = function() {
+					var instant = Date.UTC(2026, 0, 2, 3, 4, 5, 6);
+					var configured = test.subject.use({
+						now: {
+							read: function() {
+								return instant;
+							}
+						},
+						zone: {
+							read: function() {
+								return test.subject.Timezone.UTC;
+							}
+						}
+					});
+
+					verify(configured).value().is(instant);
+				};
+
+				fifty.tests.exports.datetime = function() {
+					var instant = Date.UTC(2026, 0, 2, 3, 4, 5, 6);
+					var configured = test.subject.use({
+						now: {
+							read: function() {
+								return instant;
+							}
+						},
+						zone: {
+							read: function() {
+								return test.subject.Timezone.UTC;
+							}
+						}
+					});
+					var datetime = configured.datetime();
+
+					verify(datetime, "datetime()", function(it) {
+						it.year.is(2026);
+						it.month.is(1);
+						it.day.is(2);
+						it.hour.is(3);
+						it.minute.is(4);
+						it.second.is(5.006);
+					});
+				};
+
+				fifty.tests.exports.date = function() {
+					var instant = Date.UTC(2026, 0, 2, 3, 4, 5, 6);
+					var configured = test.subject.use({
+						now: {
+							read: function() {
+								return instant;
+							}
+						},
+						zone: {
+							read: function() {
+								return test.subject.Timezone.UTC;
+							}
+						}
+					});
+					var date = configured.date();
+
+					verify(date, "date()", function(it) {
+						it.year.is(2026);
+						it.month.is(1);
+						it.day.is(2);
+					});
 				};
 			}
 		//@ts-ignore

--- a/js/time/module.fifty.ts
+++ b/js/time/module.fifty.ts
@@ -157,7 +157,7 @@ namespace slime.time {
 				};
 
 				fifty.tests.exports.value = function() {
-					var instant = Date.UTC(2026, 0, 2, 3, 4, 5, 6);
+					var instant = Date.UTC(2026, 0, 2, 3, 4, 5);
 					var configured = test.subject.use({
 						now: {
 							read: function() {
@@ -175,7 +175,7 @@ namespace slime.time {
 				};
 
 				fifty.tests.exports.datetime = function() {
-					var instant = Date.UTC(2026, 0, 2, 3, 4, 5, 6);
+					var instant = Date.UTC(2026, 0, 2, 3, 4, 5);
 					var configured = test.subject.use({
 						now: {
 							read: function() {
@@ -196,12 +196,12 @@ namespace slime.time {
 						it.day.is(2);
 						it.hour.is(3);
 						it.minute.is(4);
-						it.second.is(5.006);
+						it.second.is(5);
 					});
 				};
 
 				fifty.tests.exports.date = function() {
-					var instant = Date.UTC(2026, 0, 2, 3, 4, 5, 6);
+					var instant = Date.UTC(2026, 0, 2, 3, 4, 5);
 					var configured = test.subject.use({
 						now: {
 							read: function() {

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -479,13 +479,6 @@
 			return js.getUTCFullYear() === year && js.getUTCMonth() === month-1 && js.getUTCDate() === day;
 		}
 
-		// /** @type { { now: (world: slime.time.World) => () => number }} */
-		// var Value = {
-		// 	now: function(world) {
-		// 		return world.now.read || Date.now;
-		// 	}
-		// };
-
 		/** @type { slime.time.Exports["use"] } */
 		var use = function(world) {
 			/** @type { slime.time.date.Exports["format"] } */
@@ -1173,7 +1166,9 @@
 
 			return {
 				Value: {
-					now: world.now.read
+					now: function() {
+						return world.now.read();
+					}
 				},
 				Datetime: {
 					date: function(datetime) {

--- a/js/time/module.js
+++ b/js/time/module.js
@@ -479,12 +479,12 @@
 			return js.getUTCFullYear() === year && js.getUTCMonth() === month-1 && js.getUTCDate() === day;
 		}
 
-		/** @type { { now: (world: slime.time.World) => () => number }} */
-		var Value = {
-			now: function(world) {
-				return world.now.read || Date.now;
-			}
-		};
+		// /** @type { { now: (world: slime.time.World) => () => number }} */
+		// var Value = {
+		// 	now: function(world) {
+		// 		return world.now.read || Date.now;
+		// 	}
+		// };
 
 		/** @type { slime.time.Exports["use"] } */
 		var use = function(world) {
@@ -910,7 +910,7 @@
 				}
 
 				this.local = function(zone) {
-					if (!zone) zone = world.zones.local;
+					if (!zone) zone = world.zone.read();
 					var unix = zone.unix({
 						year: day.year.value,
 						month: (day.month.id) ? day.month.id.index : day.month.index,
@@ -1074,7 +1074,7 @@
 				//	Time zone information: http://www.twinsun.com/tz/tz-link.htm
 				/** @type { slime.time.old.When["local"] } */
 				this.local = function(zone) {
-					if (!zone) zone = world.zones.local;
+					if (!zone) zone = world.zone.read();
 					var zoned = zone.local(date.getTime());
 					return new Time({
 						day: new Day(zoned.year,zoned.month,zoned.day),
@@ -1137,7 +1137,7 @@
 					} else if (parsedTime[8] == "Z") {
 						offset = 0;
 					}
-					var utc = world.zones.UTC.unix({
+					var utc = worlds.Date.Zone.UTC.unix({
 						year: Number(parsedTime[1]),
 						month: Number(parsedTime[2]),
 						day: Number(parsedTime[3]),
@@ -1150,7 +1150,7 @@
 				}
 
 				this.encode = function(when) {
-					return when.local(world.zones.UTC).format("yyyy-mm-ddTHR:mi:sc.###Z");
+					return when.local(worlds.Date.Zone.UTC).format("yyyy-mm-ddTHR:mi:sc.###Z");
 				}
 			}
 			When.codec.Date = new function() {
@@ -1163,7 +1163,7 @@
 				}
 			}
 			var today = function() {
-				var datetime = world.zones.local.local(world.now.read());
+				var datetime = world.zone.read().local(world.now.read());
 				return {
 					year: datetime.year,
 					month: datetime.month,
@@ -1172,7 +1172,9 @@
 			};
 
 			return {
-				Value: $api.fp.methods.pin(world)(Value),
+				Value: {
+					now: world.now.read
+				},
 				Datetime: {
 					date: function(datetime) {
 						return {
@@ -1345,7 +1347,9 @@
 						return Date_add(first, -1);
 					}
 				},
-				Timezone: world.zones,
+				//	For now, we automatically include "local" and "UTC" if not present in the context, for compatibility, though
+				//	this API may well change anyway
+				Timezone: $api.Object.compose(worlds.Date.Zone, $context.zones || {}),
 				zone: {
 					Time: {
 						codec: {
@@ -1477,7 +1481,7 @@
 										hour: datetime.hour,
 										minute: datetime.minute,
 										second: datetime.second,
-										offset: Math.round((world.zones.UTC.unix(datetime) - zone.unix(datetime)) / (60 * 1000))
+										offset: Math.round((worlds.Date.Zone.UTC.unix(datetime) - zone.unix(datetime)) / (60 * 1000))
 									}
 								}
 							},
@@ -1491,7 +1495,7 @@
 										hour: datetime.hour,
 										minute: datetime.minute,
 										second: datetime.second,
-										offset: Math.round((world.zones.UTC.unix(datetime) - value) / (60 * 1000))
+										offset: Math.round((worlds.Date.Zone.UTC.unix(datetime) - value) / (60 * 1000))
 									}
 								}
 							}
@@ -1526,7 +1530,7 @@
 							if (time.offset < -1439 || time.offset > 1439) {
 								throw new TypeError(message);
 							}
-							var localAsUtc = world.zones.UTC.unix({
+							var localAsUtc = worlds.Date.Zone.UTC.unix({
 								year: time.year,
 								month: time.month,
 								day: time.day,
@@ -1537,6 +1541,20 @@
 							return localAsUtc - time.offset * 60 * 1000;
 						}
 					}
+				},
+				value: function() {
+					return world.now.read();
+				},
+				datetime: function() {
+					return world.zone.read().local(world.now.read());
+				},
+				date: function() {
+					var datetime = world.zone.read().local(world.now.read());
+					return {
+						year: datetime.year,
+						month: datetime.month,
+						day: datetime.day
+					};
 				},
 				install: install,
 				Day: Object.assign(
@@ -1549,7 +1567,7 @@
 				Time: Object.assign(
 					Time,
 					{
-						Zone: world.zones
+						Zone: $api.Object.compose(worlds.Date.Zone, $context.zones || {})
 					}
 				),
 				Year: Year,
@@ -1571,7 +1589,7 @@
 			exports,
 			use({
 				now: ($context.world && $context.world.now) || { read: function() { return new Date().getTime(); } },
-				zones: $api.Object.compose(worlds.Date.Zone, ($context.world && $context.world.zones) || {})
+				zone: { read: function() { return worlds.Date.Zone.local; } }
 			})
 		);
 


### PR DESCRIPTION
## Summary
Refactors time context wiring to use a zone reader API and adds top-level helper methods for current value, datetime, and date.

## Changes
- Export zones directly from browser/java time context modules instead of nested world.zones.
- Update time module types to model zone as a Reading of Zone and make Context.zones optional at the top level.
- Replace direct world.zones access with world.zone.read() and worlds.Date.Zone.UTC where appropriate.
- Add value(), datetime(), and date() helpers to the time module interface.

## Why
This aligns time-zone resolution with the updated context shape and provides a consistent API for current time/date access.