### PR TITLE
docs: note project board URL source in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,11 @@ Create the issue template in the `local/.github/ISSUE_TEMPLATE` folder, creating
 Issues with a strong focus on improving documentation should receive the `documentation` label, while issues focused on test
 coverage should receive the `project` label.
 
+### Project board URL source
+
+When you need the current SLIME project board URL, use `contributor/README.html` as a repository-local source of truth (for
+example, the "Board" link), rather than assuming wiki content is available.
+
 ## Developer workflow
 
 When refactoring, always run `./wf tsc` after the refactor to make sure type-checking passed. If it does not, something is wrong.


### PR DESCRIPTION
## Summary
Adds guidance to AGENTS.md that the SLIME project board URL should be sourced from contributor/README.html (the "Board" link), instead of assuming wiki content is available.

## Changes
- Add "Project board URL source" subsection under GitHub integration in AGENTS.md.
- Document contributor/README.html as the repository-local source of truth for the board URL.

## Validation
- Commit hooks/checks passed during commit:
  - ESLint
  - MPL license header verification
  - TypeScript check